### PR TITLE
Local development environment with docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Copy to `.env` at the repo root and adjust if needed:
+#
+#     cp .env.example .env
+#
+# One file, at the root, is the single source for local configuration. Docker Compose loads it
+# automatically, and `packages/db/drizzle.config.ts` reads it by absolute path from the repo root,
+# so the connection string is written once and cannot drift between the container and the client.
+#
+# `.env` is gitignored. Nothing here is a real secret — these are throwaway local credentials for a
+# container bound to localhost. Staging and production get their values from Fly secrets (ADR-0005),
+# never from a file in the repo.
+
+# Host port for the local Postgres container. Change this alone if something already owns 5432 —
+# DATABASE_URL interpolates it below, so there is exactly one place to edit.
+#
+# Writing the port twice would be worse than untidy. Setting POSTGRES_PORT=5433 while DATABASE_URL
+# still said 5432 would point `db:migrate` at whatever *other* Postgres already owns 5432 — the one
+# you moved out of the way — and apply this project's migrations to it.
+POSTGRES_PORT=5432
+
+# Local development database, served by `docker compose` (see docker-compose.yml).
+# Compose interpolates ${POSTGRES_PORT} natively; `@repo/db` does it with dotenv-expand.
+DATABASE_URL=postgres://encuentra:encuentra@localhost:${POSTGRES_PORT}/encuentra

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,48 @@ with `pnpm --filter web <script>`.
 
 There is no test runner configured in this repo yet.
 
+### Database
+
+From a clean clone, two steps stand up a working database (Docker must be running):
+
+```sh
+cp .env.example .env   # one file, at the root, is the single source for local config
+pnpm bootstrap         # pnpm install && pnpm db:up && pnpm db:migrate
+```
+
+Named `bootstrap`, not `setup`: **`pnpm setup` is a built-in pnpm command** that creates `PNPM_HOME`
+and edits your shell rc file. pnpm resolves built-ins before package scripts, so a script called
+`setup` is silently unreachable — you would get a modified `~/.zshrc` and no database.
+
+Then:
+
+```sh
+pnpm db:up          # start Postgres, blocking until its healthcheck passes
+pnpm db:down        # stop it, keeping the data
+pnpm db:reset       # destroy the volume and rebuild from migrations — the from-zero path
+pnpm db:generate    # drizzle-kit generate (add --custom for a hand-written migration)
+pnpm db:migrate     # apply pending migrations
+pnpm db:studio      # drizzle-kit studio
+pnpm db:psql        # psql shell in the container
+```
+
+The local container is **`postgres:18.6-trixie`**, pinned to the exact patch PlanetScale runs
+(ADR-0004), UTF-8 / `en_US.UTF-8` / UTC. Debian rather than Alpine because musl has no real locale
+support, which would make Spanish text sort differently locally than in production.
+
+`DATABASE_URL` lives in the **repo-root `.env`** only. Docker Compose reads it natively;
+`@repo/db` reads it by walking up to the workspace root, so there is never a second copy to drift.
+In production the walk finds nothing and the value comes from the environment (Fly secrets,
+ADR-0005).
+
+**Extensions are created by migration `0000_enable_extensions.sql`, not by a container init
+script** — an init script runs only on a brand-new volume and has no counterpart on PlanetScale.
+
+**PlanetScale does not restore extensions from a backup, and `pnpm db:migrate` will not fix that**:
+a restore also brings back `drizzle.__drizzle_migrations`, which already lists migration `0000` as
+applied, so the runner reports nothing to do while `pg_trgm` and `unaccent` are missing. Post-restore
+recovery means running those `CREATE EXTENSION` statements explicitly — a runbook step #15 owns.
+
 ## Architecture
 
 pnpm workspace + Turborepo monorepo (`apps/*`, `packages/*`), currently the `create-turbo` scaffold
@@ -31,6 +73,9 @@ with the `docs` app removed — the README still describes it, so ignore that pa
   Its `exports` map is `"./*": "./src/*.tsx"`, so `packages/ui/src/button.tsx` imports as
   `@repo/ui/button`. Adding a component file is all that's needed to make it importable; there is no
   index barrel and no build step. `turbo gen react-component` scaffolds one.
+- `packages/db` (`@repo/db`) — tier 0 of the ADR-0006 module DAG: every table, the pool singleton,
+  the `Db`/`Tx` types, `drizzle.config.ts` and the migrations. drizzle-kit is the sole owner of
+  migrations. `src/schema/index.ts` is deliberately empty — no table has been designed yet.
 - `packages/eslint-config` (`@repo/eslint-config`) — flat ESLint configs exported as `./base`,
   `./next-js`, `./react-internal`. Each workspace's `eslint.config.*` just re-exports one of these.
 - `packages/typescript-config` (`@repo/typescript-config`) — `base.json` plus `nextjs.json` /
@@ -45,8 +90,16 @@ packages run first.
 
 - `eslint-plugin-only-warn` downgrades every rule to a warning, but scripts run with
   `--max-warnings 0`, so warnings still fail the task.
-- TS is strict with `noUncheckedIndexedAccess` and `module`/`moduleResolution: NodeNext`; relative
-  imports in non-Next packages need explicit extensions where NodeNext requires them.
+- TS is strict with `noUncheckedIndexedAccess`. `@repo/typescript-config/base.json` sets
+  `module`/`moduleResolution: NodeNext`, which requires explicit `.js` extensions on relative
+  imports.
+- **JIT packages override that to `moduleResolution: Bundler` and drop the extensions** — see
+  `packages/db/tsconfig.json`. ADR-0006 makes every domain package raw TypeScript resolved by a
+  bundler (Turbopack for `apps/web`, esbuild for drizzle-kit's config loader), and **Turbopack does
+  not rewrite `.js` to `.ts`**: a NodeNext-style `import "./client.js"` type-checks and then fails
+  `next build` with `Can't resolve ./client.js`. Bundler resolution is also what `apps/web` already
+  uses via `nextjs.json`, so this makes a package agree with its only consumer. Apply it to each new
+  domain package.
 - Components in `packages/ui` that use hooks or handlers need the `"use client"` directive (see
   `packages/ui/src/button.tsx`) since `apps/web` renders on the server by default.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -229,6 +229,18 @@ none is permanently first and none is permanently unreachable. The rotation is w
 results fair rather than a quiet sentence of invisibility on whoever sorts last.
 _Avoid_: Bucket, Tier (that is the location tier, which is only one part of a Band), Page
 
+**Suggestion**:
+Work the platform puts in front of a Person without their having asked — a Search whose query is one of
+their own Publications rather than something they typed. A Capability Profile is suggested Needs; each
+Need is suggested Capability Profiles; a Person with no Publication is suggested nothing, because there
+is no query to derive. It is the same machinery as a Search and never a second one, so every Suggestion
+carries the same one-line explanation of why it is there, shown unprompted. Suggestions are **not
+reciprocal**: the two directions run over different corpora, so appearing in someone's Suggestions says
+nothing about their appearing in yours.
+_Spanish (UI)_: coincidencias
+_Avoid_: Match (see Contact Exchange), Recommendation, Feed, Alert, Sugerencia (that is a Skill
+Suggestion, which is a suggestion made *to us*)
+
 **Pause**:
 A Person stepping out without leaving: every Publication becomes invisible and unaddressable, they
 leave matching and suggestions, and Offers already sent to them are frozen rather than declined. It
@@ -324,8 +336,12 @@ _Avoid_: Breach on its own (ambiguous), Report, Violation
 One specific thing Encuentra may do with a Person's data, which that Person accepts or refuses on
 its own. Colombian law requires each to be separately selectable, so the set of Purposes is fixed
 vocabulary rather than a policy document: hold an account and profile; publish; disclose contact
-details; send transactional messages; send suggestions; send news; keep the platform safe; show a
-Photo.
+details; send transactional messages; send news; keep the platform safe; show a Photo.
+
+There is deliberately no Purpose for *sending* Suggestions, because nothing sends them: Suggestions are
+a surface a Person visits, not a message they receive. A Purpose is only ever asked for something the
+platform actually does — consenting to a *finalidad* nobody pursues would make the Disclosure describe
+a fiction.
 
 Three of them — hold an account, send transactional messages, keep the platform safe — are
 *constitutive*: refusing one means there is no account, because nothing lawful remains to do.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,6 @@
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
     "eslint": "^9.39.1",
-    "typescript": "5.9.2"
+    "typescript": "6.0.3"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+name: encuentra
+
+services:
+  postgres:
+    # Pinned to the exact patch PlanetScale runs (ADR-0004). PlanetScale offers only Postgres 17
+    # and 18 and has **no in-place major-version upgrade** — moving majors means creating a new
+    # database and migrating into it. Starting on 18 is therefore the cheap moment to choose.
+    #
+    # Debian, not Alpine, deliberately: Alpine's musl has no real locale support, so `en_US.UTF-8`
+    # collation is unavailable and text sorts differently there than on any glibc host. The ~80 MB
+    # saving is not worth Spanish text ordering that differs between a laptop and production.
+    image: postgres:18.6-trixie
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: encuentra
+      POSTGRES_PASSWORD: encuentra
+      POSTGRES_DB: encuentra
+      # Explicit rather than inherited: the image's own LANG default could change under us, and
+      # collation drift is silent — it surfaces as an ORDER BY that disagrees with production.
+      POSTGRES_INITDB_ARGS: --encoding=UTF8 --locale=en_US.UTF-8
+      # ADR-0008: "the database session timezone is UTC and is never relied upon". Every
+      # America/Bogota computation is explicit in application code.
+      TZ: UTC
+      PGTZ: UTC
+    ports:
+      # Bound to loopback explicitly. A bare "5432:5432" publishes on 0.0.0.0, which would put a
+      # Postgres whose credentials are `encuentra`/`encuentra` on whatever network the laptop is
+      # joined to. Nothing outside this machine has any business reaching a dev database.
+      #
+      # Overridable so a Postgres already listening on 5432 does not have to be stopped.
+      # Keep in step with DATABASE_URL in .env — see .env.example.
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      # Postgres 18 moved PGDATA to /var/lib/postgresql/18/docker and the image declares its
+      # volume at /var/lib/postgresql. Mounting the pre-18 /var/lib/postgresql/data path here
+      # would appear to work and silently persist nothing.
+      - postgres-data:/var/lib/postgresql
+    healthcheck:
+      # What `docker compose up --wait` blocks on, which is what makes `pnpm db:up` a usable
+      # step in a scripted setup rather than a race against Postgres finishing initdb.
+      #
+      # `-h 127.0.0.1` is load-bearing, not decoration. Without it `pg_isready` probes the Unix
+      # socket, and the entrypoint runs its *temporary* init server with `listen_addresses=''`
+      # (docker-entrypoint.sh line 297) — serving the socket but not TCP. A probe landing in that
+      # window reports healthy, `--wait` returns, and `db:migrate` connects over TCP from the host
+      # and gets ECONNREFUSED. Probing TCP is what the temp server cannot answer.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U encuentra -d encuentra"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
+volumes:
+  postgres-data:

--- a/docs/adr/0016-suggestions-as-a-search-you-did-not-type.md
+++ b/docs/adr/0016-suggestions-as-a-search-you-did-not-type.md
@@ -1,0 +1,282 @@
+# Suggestions are a search you did not type
+
+ADR-0014 decided what a search *is* — who may run one, what it accepts, what comes back and in what
+order. This ADR decides the other half of #20: the surface where **the platform** chooses, with nobody
+typing a query.
+
+**Most of #20's body is already answered, and is recorded here only so that nobody re-opens it.** It
+asked whether the algorithm should be deterministic rules, scored ranking or embeddings, and whether the
+technical layer should be full-text Spanish, `pg_trgm` or an external service. ADR-0012 made a Skill the
+only matching key; ADR-0014 settled the ranking as `(location tier, Skill Overlap)` bands with a daily
+seeded shuffle, and settled that no text index appears in the search path at all. What remained was
+narrower and harder: what a suggestion runs on when nobody has stated a query, what the surface shows
+when the corpus is empty, and whether the platform pushes.
+
+One more thing arrives already decided. ADR-0007's revocation table says refusing `suggestions` means
+*"sends stop. Nothing else."* The in-app surface is therefore **not gated on that Purpose** — it rides
+`account`. That is inheritance, not a decision made here.
+
+## A suggestion is a search whose query is your own Publication
+
+**There is no second engine.** A suggestion is ADR-0014's search with the query *derived* from the
+viewer's own Publication — its Skills, its Municipality, its remote flag — instead of typed into a box.
+Same `OR` over Skill ids, same Skill Overlap, same `(tier, overlap)` bands, same daily seeded shuffle,
+same btree, same absence rules.
+
+A bespoke scorer and embeddings were the alternatives. Both fail #20's own requirement that the answer to
+*"why was I shown this?"* be a sentence, and ADR-0012 made the vocabulary flat precisely so that pull and
+push run on one key — a second engine would duplicate that key and then have to be kept agreeing with it.
+
+The framing matters more than the mechanism: **a Need is a standing search, and a Capability Profile is
+the standing search that runs against it.** Everything below follows from taking that literally.
+
+## The completeness bias, and where it actually lives
+
+In a search the query is at most 5 hand-picked Skills, so Skill Overlap lands in [1, 5] and claiming
+twenty Skills buys very little. A *derived* query is a stored set of up to twenty, and ranking by absolute
+overlap against it systematically favours whoever claimed the most — the failure #20 named, and the
+sentence ADR-0012 already called intolerable.
+
+**The first fix considered was capping the derived query at five Skills, rotated daily.** It is rejected,
+and the reason is worth recording because it looks like the obvious answer. It does not remove the bias —
+a padded twenty-Skill Need still intersects today's five more often than a focused one does — and it pays
+for that non-fix with a real cost: a Need matching eight of your Skills becomes **invisible** on any day
+whose five miss it. In a cold corpus that is the best match in the product, hidden. It is also silent
+machinery on the one surface whose entire defence is that it can be explained.
+
+Splitting the two directions shows where the bias really sits:
+
+| Surface | Query | Overlap bounded by | Verdict |
+| --- | --- | --- | --- |
+| A Need's suggestions (Profiles) | the Need's Skills | the **Need's** size | Structurally identical to search |
+| A Profile's suggestions (Needs) | the Profile's Skills | **20** | Rewards Needs that ask for everything |
+
+So the asymmetry is not in the query. It is in a cap that was never argued for. **ADR-0012 set twenty per
+*Publication* and justified it only for the person grain** — *"the receptionist who also cooks, drives,
+sells and minds children is honestly at fifteen"*. It made no argument at all about a Need, and a single
+piece of paid work requiring twenty distinct capabilities is not one job.
+
+> **A Need carries at most five Skills.** This amends ADR-0012.
+
+Five, taking ADR-0014's own reason verbatim: it capped a search query at five because *"past that the
+overlap score stops discriminating and the query returns everyone."* A Need is a standing search, so it
+takes the same number for the same reason. With that, overlap lands in [1, 5] on both surfaces, absolute
+count works unmodified, and nothing is sampled behind anyone's back.
+
+ADR-0012 warned that its cap is **asymmetric** — raising it is one line, lowering it means telling
+published people to delete Skills. That warning is why this change has to happen now: there are no
+published Needs, so lowering is free exactly once.
+
+## Per Publication, and the person who has none
+
+A Person holds at most one Capability Profile and any number of Needs. The query is a Publication, so the
+suggestions are **per Publication**: your Profile suggests Needs, and *each* Need separately suggests
+Profiles. A Person with a Profile and three Needs is looking at four derived lists, because those are four
+genuinely different questions.
+
+**They are never merged into one feed.** Merging needs a rule for how four lists share one column, and any
+such rule is a second ranking system with no justification behind it. Home shows **one list at a time**,
+chosen by a selector over your Publications — which also means the cost of the surface does not grow with
+how many Needs you happen to have published. At launch almost everyone holds exactly one Publication, so
+the selector is invisible in the common case.
+
+**A Person with no Publication gets no suggestions**, because there is no query to derive. They get the
+Wall and the one action that changes their situation. Suggestions are what publishing buys, which is the
+right incentive to build.
+
+## Cold start is a supply problem, and it is asymmetric
+
+#20 called the empty engine *"the single biggest early risk to the product"*. Half of that framing is
+wrong in a way that changes where the launch effort goes.
+
+At launch the scarce side is **Needs**. Workers are the supply, so the **hirer's** surface — a Need
+suggesting Capability Profiles — works from the first day. The empty surface is the **worker's**, and no
+ranking change fixes an empty corpus.
+
+So the engine does not pretend. Widening is already exhausted: ADR-0014 made location a *band* rather than
+a filter, so the only thing left to relax is the Skill requirement, and relaxing it means showing someone
+work they cannot do. Padding with the Wall's sample is worse — an unexplainable row on the surface whose
+defence is explainability.
+
+**What ships is ADR-0014's empty state, unchanged**: other Skills in the same Skill Group, *publish a Need
+so people come to you*, and a Skill Suggestion when the term could not be found at all. It is written
+there for search and extends here without modification.
+
+The consequence to act on is not a matching decision at all: the first Needs are worth more than any
+ranking work, and that is product ops, past this map's destination.
+
+## Rotation is the whole of fairness, and the real fix is elsewhere
+
+#20 asked what counters ranking that disadvantages people with the least digital literacy. Under
+`(tier, overlap)` bands, a Profile holding one of a Need's five Skills sits permanently below one holding
+four, and the daily shuffle reaches only *within* a band.
+
+**That is accepted, and no counterweight is added.** Overlap is the only signal, and unlike a photograph
+or a completeness score it is **honestly actionable**: *you match fewer of the things this person asked
+for* is true, and it is fixable by the person it describes.
+
+- **An exposure counter that lifts under-surfaced Persons is rejected.** It is new behavioural personal
+  data serving no consented *finalidad* — the reasoning ADR-0014 used to refuse `last_active_at`, arriving
+  here from a second direction.
+- **A recency lift for new Publications is rejected** for the same reason plus a worse one: it would punish
+  the person who published once and cannot afford the data to come back, which is the population the
+  fairness clause exists to protect.
+
+**The counter to the digital-literacy problem lives in the picker, not in the ranking.** Someone who
+selects two Skills because the picker defeated them is a picker bug, and a thumb on the ranking hides that
+bug rather than fixing it. #30 owns it, and ADR-0012's minimum-of-one is the floor beneath it.
+
+## Twenty is a display default; two hundred is the safety bound
+
+The surface shows **20**, extends by an explicit action, and hard-stops at **200 per source Publication** —
+ADR-0014's cap. The ADR states plainly which of those two numbers is load-bearing, because they look alike
+and are not.
+
+**Twenty is presentation.** It is not a cost control: producing a ranked top-20 requires ranking the entire
+candidate set anyway, so the per-row shuffle hash runs over every match regardless of what is displayed. A
+`LIMIT` buys a top-N heapsort rather than a full sort — memory, not work. And it is not a fairness control
+either; if anything, letting people go deeper is what gets the tail seen.
+
+**Two hundred is the bound that matters, and it is inherited rather than invented.** Suggestions must not
+be a wider door than search. `/search/people` stops at 200, and an indefinitely scrolling suggestion list
+would let anyone publish a deliberately broad Need and scroll their suggestions instead of searching,
+which makes the search cap decorative. Parity between the two surfaces is the control; ADR-0011's
+enumeration argument is the reason behind it.
+
+As in ADR-0014, the cap is only fair because the rotation makes it a different 200 tomorrow. The two remain
+load-bearing on each other.
+
+**Rendering is left open.** Twenty rows extending to at most 200 does not need virtualisation, and how a
+bounded list paints is #12's decision, not an architectural one this map owes an implementer.
+
+## The explanation is always on the card
+
+ADR-0014's sentence — *"3 of your 4 skills, in your municipality"* — is inherited, with one addition: it
+must name the **source Publication**, because a Person looking at four derived lists needs to know which
+question produced this answer. *"Pide 3 de las 5 habilidades de tu perfil · Risaralda"*.
+
+**It is shown unprompted on every card, never behind a disclosure control.** An explanation you have to ask
+for is an explanation for nobody, and this is the one surface where the platform rather than the Person
+chose what to show — which is precisely when it owes the sentence without being asked.
+
+## No push in v1
+
+The map's given was that push is opt-in and promotional under Ley 2300 from day one. **v1 sends nothing.**
+
+#5's research is unambiguous about what a suggestions digest would be: art. 5 extends Ley 2300 to
+*mensajes publicitarios* over email and app messaging, and a *"nuevos empleos para ti"* send is squarely
+that, inheriting sending windows in `America/Bogotá`, a *festivo* calendar, one-contact-per-day and
+not-across-channels-in-a-week caps, and a one-click unsubscribe. ADR-0015 separately declined a
+notification system on the ground that every v1 notification is 1:1 with an Offer row; a digest is the
+first thing that is not.
+
+**And at launch there is nothing to send** — the section above says the worker-facing corpus is the empty
+one, and a digest of nothing is the worst possible first impression of a channel someone opted into.
+
+**The cost of this decision is real and is not hidden:** pull-only means a worker learns that matching work
+appeared only by coming back to look, and this audience rations mobile data. That is the strongest argument
+against, it is not answered here, and it is what the successor ticket exists for.
+
+**`suggestions` is therefore dropped from the v1 Purpose set** — four unticked boxes at `/signup`, not
+five. Consenting to a *finalidad* nobody pursues means a Disclosure describing a fiction, and #14 already
+flagged that the single signup form is a lot of screen before anyone has seen the product. ADR-0008 dropped
+`pgEnum` so that a Purpose can appear later without an `ALTER TYPE`; it needs none. The honest cost is that
+v1.1 needs a new Disclosure version and a re-consent prompt for everyone who signed up before it.
+
+## Live queries, and no cache
+
+Suggestions run as **live Postgres queries on ADR-0014's existing indexes**. No materialised view, no
+background job, no per-Person suggestion table.
+
+**Redis is refused, and cost is the weakest of three reasons.**
+
+1. **Staleness has a safety direction here.** A cached list can surface a Person who has since Paused, been
+   Suspended, or Blocked the viewer. ADR-0011, ADR-0013 and ADR-0014 all treat absence as a safety
+   property — ADR-0014 goes as far as making absence indistinguishable from *"nobody holds that skill"*
+   because the negative space is itself a disclosure. A cache that lags on a Block is a safety bug.
+2. **It is a second copy of personal data outside the constraint system.** A key holding *"these people are
+   suggested to Person X"* is the N+1 erasure adapter ADR-0008 forbids and ADR-0014 rejected an external
+   search index over. ADR-0013 already refused Redis once, for safety counters, because a Redis counter is
+   a second source of truth that drifts and cannot be audited — the same objection with a larger blast
+   radius.
+3. **It is a new processor**, needing a *contrato de transmisión* in #21's register, against #18's
+   $4.46–$7.46 remainder — which that audit listed as an implied cost and never actually priced.
+
+**What caching is fine is stated so nobody reads this as an anti-caching rule.** ADR-0014's static Skill
+and Municipality JSON stays, indefinitely cacheable, and it is the caching that actually matters for
+someone on a bad connection. Route-level caching of non-personalised surfaces — the Wall, the authored
+`/skills/<slug>` pages — is fine for the same reason: nothing is keyed to a Person.
+
+**The escape hatch is named rather than left to be discovered.** If measurement later says the shuffle
+hurts, ADR-0005's single long-lived Fly machine makes an in-process LRU available with no new vendor, no
+new processor and no register entry — which is exactly what ADR-0009 chose for the rate limiter. That is
+the thing to reach for before reaching for Redis.
+
+The known cost is recorded: unlike search, this surface runs on **every signed-in home page view**, and the
+seeded shuffle is a per-row hash no index can serve. It is the first place a scale target will bite.
+
+## Where it lives, and what it is called
+
+**`@repo/matching`**, whose charter ADR-0014 already widened to *search and suggestions*. Same package,
+same flat key, same reads of `blocks` direct from `@repo/db`.
+
+**The signed-in home *is* the suggestions surface.** For someone who lost their income, the first thing
+after signing in should be work that matches them, not a dashboard they must navigate out of. A separate
+`/suggestions` route would make the product's central mechanic something you have to find. `/search/work`
+and `/search/people` remain the deep surfaces you go to deliberately.
+
+**The Wall shares the seeded-shuffle helper and nothing else.** `CONTEXT.md` says a Wall *"is still never a
+search result: it answers no query"*, and the moment it borrows band-and-rank it becomes the public ranked
+index ADR-0011 built two Walls to avoid being.
+
+**In code the term is `Suggestion`.** In Spanish the surface is ***coincidencias***, **not** *sugerencias*
+— `CONTEXT.md` already spends that word on **Skill Suggestion**, which is a suggestion made *to us* and has
+the better claim on it. One Spanish word naming two unrelated things is exactly the collision ADR-0001's
+naming rule exists to prevent.
+
+**Suggestions are not reciprocal.** A Profile's suggestions are Needs and a Need's are Profiles — two
+different corpora — so A appearing in B's list implies nothing about B appearing in A's. Stated out loud so
+that nobody builds a mutual-match concept, which `CONTEXT.md` bars by name on **Contact Exchange** anyway.
+
+## Who is absent, and what disappears once you have acted
+
+Absence is ADR-0014's, unchanged: only active Publications of active Persons, so Paused and Suspended
+Persons and draft, unpublished and suppressed Publications are gone, a Block hides both parties in both
+directions, and absence is never signposted. Your own Publications never appear in your own lists.
+
+One case is new here, because a suggestion is an invitation to act where a search result is not:
+
+**A suggestion you are forbidden to act on is hidden.** Pairs closed by ADR-0015's per-pair rule — the
+90-day close after a second decline — and by a Block disappear. Offering someone work they will be refused
+from sending is noise dressed as an opportunity.
+
+**A Publication you have a *pending* Offer against keeps appearing, with its status.** Removing it would
+make home disagree with *Propuestas enviadas*, which reads off the same `offers` row.
+
+**Nothing is hidden merely because you looked at it.** That would need the profile-view log ADR-0011 and
+ADR-0014 both refused.
+
+## Consequences
+
+- **ADR-0012 amended.** The twenty-Skill cap is per Capability Profile; a **Need carries at most five**.
+  Lowering it is free only because no Need has been published — this is the one moment the asymmetry that
+  ADR named allows it.
+- **ADR-0007 amended.** `suggestions` leaves the v1 Purpose set: **four** unticked boxes at `/signup`, not
+  five. Its revocation-table row goes with it. The mechanism is untouched — ADR-0008's `text({ enum })`
+  needs no migration to add it back.
+- **ADR-0014 extended, not amended.** Its query shape, bands, shuffle, 200-cap, indexes, absence rules and
+  empty state are all inherited verbatim; suggestions add a derived query and a display default in front of
+  them.
+- **`CONTEXT.md`** gains **Suggestion**; **Purpose** loses *send suggestions* from its enumeration.
+- **#12 inherits** the rendering decision this ADR deliberately leaves open, the always-visible explanation
+  line as a copy obligation, and the Publication selector for a Person holding more than one Publication.
+- **#30 inherits** a sharper reason to exist: this ADR refuses to correct ranking fairness and names the
+  picker as the place the correction belongs.
+- **#15 inherits** nothing new. There is no scheduler, no *festivo* calendar and no digest to drain, because
+  v1 pushes nothing.
+- **#16 inherits** a required test that suggestions never surface a Paused, Suspended or Blocked
+  counterparty — the property a cache would have broken, now guaranteed only by the queries being live.
+- **The cold-start half of #20 leaves this map.** The matching-surface question is answered; supplying the
+  first Needs is product ops, past the destination.
+- **A successor ticket owns push**: reinstating the `suggestions` Purpose and designing the digest under
+  Ley 2300, with the pull-only cost above as its opening argument.

--- a/docs/research/moderation-record.md
+++ b/docs/research/moderation-record.md
@@ -1,0 +1,301 @@
+# Ley 1581 against the moderation record: erasure versus ban, and art. 8(a)
+
+Research for [#31](https://github.com/m0t0r/workforpereira/issues/31). Part of the
+[Encuentra architecture map (#1)](https://github.com/m0t0r/workforpereira/issues/1). Surfaced by
+[#13](https://github.com/m0t0r/workforpereira/issues/13); consumed by
+[#26](https://github.com/m0t0r/workforpereira/issues/26),
+[#27](https://github.com/m0t0r/workforpereira/issues/27) and ADR-0013.
+
+> **Not legal advice**, and deliberately **not** a counsel-grade brief. This is a reading scoped to two
+> build decisions — what `persons` and the moderation tables may retain, and what a `/mis-datos`
+> *consulta* response contains. Where a question has no clean answer in the primary text it says so
+> and names the safer default, rather than reading further.
+
+**Method.** Primary sources only, in Spanish: Ley 1581 de 2012, Decreto 1074 de 2015 título 2.2.2.25
+(compiling Decreto 1377 de 2013), and C-748 de 2011 where it construes those articles.
+`funcionpublica.gov.co` failed TLS and `secretariasenado.gov.co` refused connections throughout, so
+texts were read from the MinTIC and CRC *normogramas* — `.gov.co` compilations reproducing the
+consolidated text with its *Jurisprudencia Vigencia* apparatus — cross-checked against a second
+mirror for every provision quoted. SIC guidance did not surface cheaply and was not read.
+
+**Nothing is inherited from [#5](https://github.com/m0t0r/workforpereira/issues/5).** Its §4 reading —
+that the only lawful refusal of erasure is a legal or contractual duty to remain — was re-verified and
+is **confirmed**, as is its compiled-number mapping (D.1377 art. 9 = `2.2.2.25.2.6`, art. 11 =
+`2.2.2.25.2.8`, art. 22 = `2.2.2.25.4.3`).
+
+**Being free and charitable is not an argument and is not used as one.** Art. 2 reaches databases held
+by entities *"de naturaleza pública o privada"* with no commerciality filter, and the *ámbito
+exclusivamente personal o doméstico* exception is expressly lost once data is *"suministrado a
+terceros"*. It matters here only as a reason to prefer the simpler of two lawful options.
+
+---
+
+## The answer, in six lines
+
+1. **There is exactly one ground for refusing erasure** — *"cuando el Titular tenga un deber legal o
+   contractual de permanecer en la base de datos"* (`2.2.2.25.2.6`). C-748 writes the same single
+   carve-out into art. 8(e), so it is constitutional-grade and correspondingly narrow. The three-limb
+   list #31 hypothesised (judicial obstruction, *intereses jurídicamente tutelados*, public interest)
+   is **Mexico's LFPDPPP art. 26, not Colombian law** — discard it.
+2. **No Colombian source reaches the ban scenario at all**, so the answer is neither of #31's clean
+   outcomes. The position is **narrow the erasure, do not refuse it**: hard-delete the `persons` row,
+   keep a **keyed hash + timestamp + coded reason** in a separate blocklist, for a **bounded and
+   published** term. Ley 1266's 4/8-year *caducidad* does not apply and must not be cited.
+3. **Art. 8(a) reaches a Report written about the titular by another titular. Settled.** Art. 3(c)
+   defines personal data by association, not authorship.
+4. **The reporter's identity is withholdable** — on art. 13's closed list plus arts. 4(f)/(h) and
+   18(j), **not** on the *seguridad* duties ADR-0013 and #31 both reached for.
+5. **Withholding the reporter's *words* wholesale is ADR-0013's weakest position** and narrows to
+   withholding identifying detail while disclosing the substance.
+6. **Rectifying an allegation is unresolved**, but art. 15.2's *reclamo en trámite* legend is the
+   statute's own answer to contested-not-yet-false data, and it is not optional.
+
+---
+
+## 1. Erasure versus ban
+
+### 1.1 One refusal ground, and it is the only one
+
+**Decreto 1074 art. `2.2.2.25.2.6`** (= D.1377 art. 9):
+
+> Los Titulares podrán en todo momento solicitar al responsable o encargado la supresión de sus datos
+> personales y/o revocar la autorización […] mediante la presentación de un reclamo, de acuerdo con lo
+> establecido en el artículo 15 de la Ley 1581 de 2012.
+>
+> La solicitud de supresión de la información y la revocatoria de la autorización **no procederán
+> cuando el Titular tenga un deber legal o contractual de permanecer en la base de datos**.
+
+**C-748 de 2011, resolutivo Cuarto**, striking *"sólo"* from art. 8(e):
+
+> […] el literal e) debe entenderse en el sentido que el Titular **también podrá revocar la
+> autorización y solicitar la supresión del dato, cuando no exista un deber legal o contractual que le
+> imponga el deber de permanecer en la referida base de datos**.
+
+Three doors #31 asked about are closed by this. **The three-limb list does not exist** — verified
+absent from the Colombian text on two independent official mirrors; there is no criminal-investigation
+ground and no public-interest ground. **Art. 9 is not a retention exception**: it is the consent
+requirement, and it runs the other way — it is why the `safety` Purpose exists at all. **Art. 17(d) is
+not one either**: *"conservar la información bajo las condiciones de seguridad necesarias"* governs
+*how* held data is secured, not whether it may be held. And **there is no defence-of-a-right ground
+and no *interés legítimo***; arts. 4(c) and 9 make consent the axis and art. 10's exceptions are a
+closed list about public, health, judicial and statistical cases. ADR-0007 already relies on this, and
+it cuts against us here exactly as it cut for us there.
+
+### 1.2 The *finalidad* argument, and its limit
+
+**Art. `2.2.2.25.2.8`** (= D.1377 art. 11):
+
+> […] sólo podrán recolectar, almacenar, usar o circular los datos personales **durante el tiempo que
+> sea razonable y necesario, de acuerdo con las finalidades que justificaron el tratamiento** […] Una
+> vez cumplida la o las finalidades […] deberán proceder a la supresión […] No obstante, los datos
+> personales **deberán ser conservados cuando así se requiera para el cumplimiento de una obligación
+> legal o contractual**.
+>
+> Los responsables y encargados **deberán documentar los procedimientos para el Tratamiento,
+> conservación y supresión** de los datos personales […]
+
+This is the operative text for #27. It sets **no number** — a proportionality standard tied to the
+declared *finalidad*, self-assessed and reviewable by the SIC — and its second paragraph makes
+**documenting** the retention and deletion procedure a standalone duty, independent of whether the
+retention is lawful. Art. 17(k)'s manual interno is where that lives.
+
+The argument it supports is that the `safety` Purpose ADR-0007 made required *is* a declared
+*finalidad*, so while a suspension is live that *finalidad* is not *cumplida* and the erasure duty in
+sentence two has not triggered. That is real. **It also proves too much if leaned on** — the same
+reasoning would justify keeping the whole evidence file forever, which *"razonable y necesario"*
+plainly forbids. It supports a minimum, not a maximum.
+
+### 1.3 Where this lands — unresolved, and stated as such
+
+**No Colombian primary source addresses the ban scenario.** Not Ley 1581, not título 2.2.2.25, not
+C-748. The *deber contractual* limb is undefined: nothing says whether a duty the responsable wrote
+into its **own adhesion contract** counts, or whether it must be independent of the responsable's
+unilateral drafting. A Terms clause reading *"if we suspend you, you agree to remain in our database"*
+is exactly what the SIC could characterise as evading art. 8(e) and the *principio de libertad*, and no
+concepto or decision was found either way. So there **is** a ground, it **is** constitutional-grade,
+and a *finalidad* argument sits behind it — but it is untested on these facts and cannot carry a full
+evidence file.
+
+### 1.4 The minimum record, and for how long
+
+Nothing prescribes a permitted minimum; what the sources prescribe is the shape of the constraint —
+`2.2.2.25.2.8` (*razonable y necesario*), art. 4(f) (restricted access, never publicly visible), art.
+4(g) (security), `2.2.2.25.4.3` (*"precisos y suficientes […] de tal manera que satisfagan los
+propósitos del tratamiento"*). Applied, that yields the record specified in **Consequences** below: a
+**keyed HMAC** of the identifying key, a suspension timestamp, a coded reason, and nothing else, in a
+table separate from `persons`.
+
+Two details carry weight. The hash must be **keyed, not a bare digest** — a plain SHA of a cédula is
+trivially brute-forceable and would remain personal data under art. 3(c), *"determinada o
+**determinable**"*. (The keyed version is still personal data; the key is what stops it being an open
+ledger.) And the blocklist does **not** reopen ADR-0008's `deleted_at` rule: it is a deliberately
+designed evidentiary table in exactly that ADR's sense, and it can point at an article.
+
+**On duration the sources support no number.** **Ley 1266's *caducidad* does not apply**: its art. 13
+(as substituted by Ley 2157 de 2021) gives the 4- and 8-year figures for *dato negativo financiero*,
+but Ley 1581 art. 2(e) expressly excludes Ley 1266 databases from its scope, and C-748 relies on that
+split when refusing to import a Ley 1266 rule into Ley 1581. What the habeas-data line behind those
+figures does say at the level of principle is that negative data is **temporal** — which argues
+*against* an indefinite blocklist rather than for importing a safe harbour. **Indefinite retention is
+the hardest position to defend under *razonable y necesario***.
+
+---
+
+## 2. Art. 8(a) against the report record
+
+### 2.1 Does art. 8(a) reach a Report written by another titular? **Yes — settled**
+
+Art. 3(c) defines a *dato personal* as *"cualquier información vinculada o que pueda asociarse a una o
+varias personas naturales determinadas o determinables"* — by **association, not authorship**, so one
+field can be two people's data at once. Art. 14 obliges us to supply *"**toda la información contenida
+en el registro individual o que esté vinculada con la identificación del Titular**"*, and C-748 §2.16.3
+restates that as *"toda la información contenida en la base de datos"*. No art. 2 exclusion reaches a
+moderation database. The reason code, date and action taken are unambiguously the reported Person's
+data; so is the free text, to the extent it is about them.
+
+### 2.2 May the reporter's identity be withheld? **Yes — but not on ADR-0013's basis**
+
+The reporter's identity is **not the reported Person's data at all** — it is the reporter's own, and
+art. 14 compels disclosure only of information *"vinculada con la identificación del **Titular**"*.
+Handing it over is a *suministro* of a third party's data, and **art. 13 is a closed list**: to *"los
+Titulares, sus causahabientes o sus representantes legales"*, to public entities or by court order, or
+to *"los terceros autorizados por el Titular o por la ley"*. As to the reporter's identity, the
+reported Person is none of these. **Art. 4(f)** (*"sólo podrá hacerse por personas autorizadas por el
+Titular y/o por las personas previstas en la presente ley"*), **art. 4(h)** *confidencialidad*, and
+**art. 18(j)** (*"permitir el acceso a la información únicamente a las personas que pueden tener acceso
+a ella"*) all point the same way.
+
+**ADR-0013 and #31 both reached for arts. 4(g)/17(d) *seguridad*. That is the weakest candidate** — it
+governs adulteration and unauthorised access to the store, not an exception to a titular's own access
+right. Lead with art. 13 + 4(f)/(h). Arts. 5–6 (*datos sensibles*) are situational reinforcement only:
+a `harassment` report can touch *vida sexual*, and where it does art. 6 adds a second independent
+reason to restrict. Do not build the general rule on it.
+
+### 2.3 Is a redacted answer lawful? **Unresolved — and the text leans against a thin redaction**
+
+**No redaction regime, no balancing clause and no rights-of-others carve-out exists anywhere** in Ley
+1581 or título 2.2.2.25 — a negative finding from reading the título through. What exists pulls toward
+completeness: **art. 14** (*"toda la información"*), **art. 11** (*"deberá corresponder **en un todo** a
+aquella que repose en la base de datos"*), and **C-748 §2.16.3** importing the *derecho de petición*
+standard — *"(i) la respuesta debe ser **de fondo**, es decir, no puede evadirse el objeto de la
+petición, (ii) que de forma **completa y clara** se respondan a los interrogantes"*. C-748 acknowledges
+the principles are *mandatos de optimización* needing case-by-case *ponderación* where rights collide,
+but **never performs that ponderación for a two-titular record, and no article supplies the rule.**
+
+**Safer default, narrower than ADR-0013's.** Answer *completely* on everything that is the reported
+Person's own data — reason code, date, action taken, that Reports exist and how many — **and the
+substance of the allegation**, with only the reporter's identifying threads removed. Then **state in
+the response that third-party identifying data was withheld, and cite arts. 13 and 4(f)/(h)**. A
+disclosed redaction is far more defensible than a silent one: the failure C-748 names is *"evadirse el
+objeto de la petición"*, and an answer saying what it withheld and why does not evade. **Withholding
+the words wholesale is the position most exposed under arts. 11 and 14.**
+
+### 2.4 Can the titular rectify a Report? **Unresolved on the text; three things bite**
+
+**C-748 does not distinguish allegations from facts** — the distinction is absent from the sentencia.
+What it says (§2.6.5.2.4) is that data *"deben obedecer a situaciones reales, actualizadas y
+**comprobables**"*. ADR-0013's framing survives that on its face: the *comprobable* proposition is
+"reporter R submitted code C at time T", and the truth of the allegation is not the datum. **But no
+source says so, and nothing forecloses the opposite reading.** What does bite:
+
+1. **Art. 15.2's legend is mandatory and self-executing.** On a complete *reclamo* we **must** write
+   `reclamo en trámite` plus its motive into the database within **2 días hábiles** and keep it until
+   decided (art. 17(l) says the same toward any Encargado). This is the statute's own mechanism for
+   contested-but-not-yet-false data. #5 §4 already flagged it as a persistent flag on affected
+   records; **Reports are affected records.**
+2. ***Integridad* makes the remedy *adición*, not *supresión*.** Art. 4(d) prohibits *"el Tratamiento
+   de datos parciales, incompletos, fraccionados o que induzcan a error"*, and C-748 fn. 212 records a
+   tutela granted where an administrator held negative data without recording the subject's answering
+   submission. A Report row carrying an accusation with **no field for the reported Person's response**
+   is *parcial* in that sense.
+3. **C-748 §2.6.5.2.6**: *"queda prohibido generar efectos jurídicos adversos frente a los Titulares,
+   con base, **únicamente** en la información contenida en una base de datos."* ADR-0013's refusal of
+   every automatic state transition is not only good product design — it is what keeps
+   `suspend_person` on the right side of this sentence, and should be cited as such.
+
+---
+
+## What could not be verified
+
+1. **Whether a self-drafted Terms clause qualifies as a *deber contractual* under `2.2.2.25.2.6`.** No
+   primary source either way. **The load-bearing uncertainty in §1**, and the first thing for a lawyer.
+2. **Any permitted retention term.** No number exists in the regime; whatever #27 picks is our own
+   proportionality judgement, defensible only if documented in advance.
+3. **SIC guidance on supresión, retention or answering *consultas*** — out of scope by this ticket's
+   own terms. #5 §12 item 17 already records that the *responsabilidad demostrada* guía is an
+   image-only scan.
+4. **Whether a fraud/suspension flag is a *dato sensible*.** Art. 5's list is open (*"tales como"*) and
+   its test is data *"cuyo uso indebido puede generar su discriminación"*, which a fraud label in a
+   labour-matching context plainly can. Unresolved by any source — and a further argument for the
+   blocklist being a hash rather than a readable flag.
+5. **C-748 was read from the MinTIC/CRC normogram annex**, which reproduces the sentencia in full, not
+   from corteconstitucional.gov.co. Confirm before quoting externally. **T-729/2002, C-1011/2008,
+   SU-082/1995, SU-089/1995 and T-1085/2001** were not read and appear only as C-748 characterises
+   them — §2.4 point 2 is an analogy from that footnote, not a holding.
+
+---
+
+## Consequences
+
+**Question 1 — what `persons` and the moderation tables must retain.**
+
+- **A suspended Person who has not asked for erasure changes nothing.** Suspension-as-`persons.status`
+  stands as ADR-0013 designed it for that case, which is the common one.
+- **An art. 15 *supresión* reclamo from a suspended Person must be honoured, narrowed.** #27's erasure
+  implementation gets **one enumerated exception branch, not a refusal path**: hard-delete the
+  `persons` row and its dependents, and write a blocklist row holding a **keyed HMAC of the normalised
+  email (and *documento* if held), a suspension timestamp, and a coded reason — nothing else**, in a
+  separate table read only by the registration check.
+- **#27 must set and publish a bounded term with automatic purge**, justified against the `safety`
+  *finalidad*. Not 4 years, not 8 — Ley 1266 does not apply. The term and the deletion procedure go in
+  the Política and the manual interno **before** launch; `2.2.2.25.2.8` makes documenting them a duty
+  in its own right.
+- **The narrowing must be stated in the response**: resolve within 15 días hábiles, name the ground
+  invoked (*deber contractual de permanecer*, `2.2.2.25.2.6`), and confirm everything else was erased.
+
+**Question 2 — what the `/mis-datos` *consulta* response contains.**
+
+- **#26's answer shape for a reported Person**: reason code, date, action taken, the fact and count of
+  Reports, **and the substance of the free text with identifying threads removed** — not the text
+  withheld wholesale.
+- **Never disclosed**: the reporter's identity or any detail that fingerprints them. Basis: art. 13's
+  closed list, arts. 4(f) and 4(h), art. 18(j). **Not** arts. 4(g)/17(d).
+- **The response must name its own redaction** and cite that basis. A silent partial answer is the
+  failure mode C-748 describes.
+- **#26 also inherits the art. 15.2 legend on `reports`** — a `reclamo en trámite` marker plus motive,
+  set within 2 días hábiles, cleared only on decision. A flag on the record, not a ticket status.
+- **`reports` gains a field for the reported Person's response.** Rectification of the allegation is
+  refused — the row records that something was *said* — but *adición* is what art. 4(d) points at, and
+  a row with no place for the answer is the *parcialidad* the article prohibits.
+
+**ADR-0013 — confirmed in part, amended rather than rewritten.**
+
+- **Confirmed**: Reports rooted on a Person; Suspension as a retained `persons.status`; withholding the
+  reporter's identity; no automatic state transition — the last now doing constitutional work.
+- **Must change**: *"The Person and the evidence are **retained**, not deleted"*, in ADR-0013 and in
+  `CONTEXT.md`'s **Suspension** entry, is **too strong**. It survives an ordinary suspension and does
+  not survive an art. 15 *supresión* reclamo. Both should say a suspension survives erasure only as a
+  minimal blocklist record, for a bounded term.
+- **Must change**: *"withhold the reporter's identity **and their words**"* narrows to *withhold the
+  identity and identifying detail; disclose the substance*.
+- **Replace** *What this ADR deliberately does not decide* with §1.3, §2.3 and §2.4 — including that
+  both questions remain unresolved at the level of authority, with the safer default named.
+
+---
+
+## Sources
+
+- Ley 1581 de 2012 — MinTIC *normograma* consolidated text, carrying the C-748/2011 *Jurisprudencia
+  Vigencia* annex: <https://normograma.mintic.gov.co/mintic/compilacion/docs/ley_1581_2012.htm>; CRC
+  mirror: <https://normograma.crcom.gov.co/crc/compilacion/docs/ley_1581_2012.htm>
+- Decreto 1074 de 2015 título 2.2.2.25 — arts. `2.2.2.25.2.6`, `2.2.2.25.2.8`, `2.2.2.25.4.1`–`4.4`
+- Decreto 1377 de 2013 arts. 9 y 11, standalone confirmation of the compiled text:
+  <https://normograma.mintic.gov.co/mintic/compilacion/docs/decreto_1377_2013.htm> and
+  <https://www.medellin.gov.co/normograma/docs/astrea/docs/decreto_1377_2013.htm>
+- Corte Constitucional, Sentencia C-748 de 2011 — ratio on art. 8(e), resolutivo Cuarto, §§2.6.4,
+  2.6.5.2.4, 2.6.5.2.6, 2.16.3 and fn. 212
+- Ley 1266 de 2008 art. 13 as substituted by Ley 2157 de 2021 art. 3, read only to establish that it
+  does **not** apply: <https://normograma.mintic.gov.co/mintic/compilacion/docs/ley_1266_2008.htm>
+- **Negative finding, verified by reading the título through**: no article of Ley 1581 or of Decreto
+  1074 título 2.2.2.25 prescribes the content of a *consulta* response beyond arts. 11 and 14, and none
+  contains a redaction or third-party-rights exception.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,20 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo run check-types"
+    "check-types": "turbo run check-types",
+    "bootstrap": "pnpm install && pnpm db:up && pnpm db:migrate",
+    "db:up": "docker compose up -d --wait",
+    "db:down": "docker compose down",
+    "db:reset": "docker compose down -v && pnpm db:up && pnpm db:migrate",
+    "db:generate": "pnpm --filter @repo/db generate",
+    "db:migrate": "pnpm --filter @repo/db migrate",
+    "db:studio": "pnpm --filter @repo/db studio",
+    "db:psql": "docker compose exec postgres psql -U encuentra -d encuentra"
   },
   "devDependencies": {
     "prettier": "^3.7.4",
     "turbo": "^2.10.9",
-    "typescript": "5.9.2"
+    "typescript": "6.0.3"
   },
   "packageManager": "pnpm@9.0.0",
   "engines": {

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "drizzle-kit";
+
+import { databaseUrl } from "./src/env";
+
+// ADR-0004 and ADR-0006: drizzle-kit is the sole owner of migrations, rooted in `packages/db`.
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/schema/index.ts",
+  out: "./migrations",
+  // ADR-0008: set once, here. TypeScript reads `personId`, Postgres reads `person_id`, and the
+  // name is written exactly once — spelling both at every column is a second place to drift.
+  casing: "snake_case",
+  dbCredentials: { url: databaseUrl() },
+  strict: true,
+  verbose: true,
+});

--- a/packages/db/eslint.config.js
+++ b/packages/db/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from "@repo/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/db/migrations/0000_enable_extensions.sql
+++ b/packages/db/migrations/0000_enable_extensions.sql
@@ -1,0 +1,23 @@
+-- Extensions are created by a migration rather than by a container init script, so that local
+-- Docker, staging and production get them through the one mechanism drizzle-kit already owns
+-- (ADR-0004). An init script under /docker-entrypoint-initdb.d would run only on a brand-new
+-- volume, leaving every existing developer database behind the moment this list changes, and it
+-- would have no counterpart on PlanetScale at all.
+--
+-- A PlanetScale-specific hazard from docs/research/postgres-host.md sits nearby but is NOT solved
+-- here: **extensions are not restored from a backup** and must be reinstalled. Re-running
+-- migrations does *not* do it — a restore brings back drizzle.__drizzle_migrations too, which
+-- already records this file as applied, so `drizzle-kit migrate` reports nothing to do and every
+-- query needing pg_trgm or unaccent then fails at runtime. Post-restore recovery has to run these
+-- statements explicitly. #15 owns writing that into a runbook.
+--
+-- Both are native extensions on PlanetScale Postgres — plain CREATE EXTENSION, no dashboard step.
+
+-- Trigram matching. ADR-0014 puts none of trigram, full-text or external search in the *search*
+-- path — search is a btree on publication_skills — but the typeahead over the seeded skill,
+-- denomination and municipality lists still wants it.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Diacritic stripping, for the precomputed `search_text` ADR-0014 writes at seed time so that
+-- `atencion` matches `atención`. Never called in a query.
+CREATE EXTENSION IF NOT EXISTS unaccent;

--- a/packages/db/migrations/meta/0000_snapshot.json
+++ b/packages/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,18 @@
+{
+  "id": "31d146e7-36a9-40d1-afa9-7adab946891d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1786909481151,
+      "tag": "0000_enable_extensions",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@repo/db",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema/index.ts"
+  },
+  "scripts": {
+    "generate": "drizzle-kit generate",
+    "migrate": "drizzle-kit migrate",
+    "studio": "drizzle-kit studio",
+    "lint": "eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^17.4.2",
+    "dotenv-expand": "^1000.0.0",
+    "drizzle-orm": "^0.45.2",
+    "pg": "^8.23.0"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "@types/pg": "^8.21.0",
+    "drizzle-kit": "^0.31.10",
+    "eslint": "^9.39.1",
+    "typescript": "6.0.3"
+  }
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,49 @@
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+import { databaseUrl } from "./env";
+import * as schema from "./schema/index";
+
+/**
+ * ADR-0006: one pool, constructed once. Next.js builds a fresh module graph on every HMR reload in
+ * development, so without the global cache a long dev session leaks a pool per edit until Postgres
+ * refuses connections.
+ */
+const globalForDb = globalThis as typeof globalThis & {
+  dbPool?: Pool;
+  dbInstance?: NodePgDatabase<typeof schema>;
+};
+
+/**
+ * The singleton handle, built on first use.
+ *
+ * **Lazily, deliberately.** `databaseUrl()` throws when `DATABASE_URL` is unset, so building the
+ * pool at module scope would make merely *importing* this package require a connection string.
+ * `next build` in CI (#15) has no root `.env`, and it loads every route's module graph to
+ * prerender — so one route importing `@repo/db` would fail the whole build, including routes that
+ * never touch the database. Deferring to first call keeps the single instance while letting a
+ * build that never queries succeed.
+ *
+ * ADR-0006: **modules never call this** — every module function takes a `Db | Tx` as its first
+ * argument, so a caller's transaction is the handle the module writes on. Only `apps/web` use
+ * cases reach for it, at the point where a transaction boundary is opened.
+ */
+export function getDb(): Db {
+  if (!globalForDb.dbInstance) {
+    globalForDb.dbPool ??= new Pool({ connectionString: databaseUrl() });
+    globalForDb.dbInstance = drizzle(globalForDb.dbPool, {
+      schema,
+      // Set here *as well as* in drizzle.config.ts. The config value governs what drizzle-kit
+      // emits in migrations; this one governs the column names the runtime puts in queries. Two
+      // different consumers, and a mismatch is silent until a query names a column that does not
+      // exist.
+      casing: "snake_case",
+    });
+  }
+  return globalForDb.dbInstance;
+}
+
+export type Db = NodePgDatabase<typeof schema>;
+
+/** The handle `db.transaction(...)` yields — a *different object* from the singleton (ADR-0006). */
+export type Tx = Parameters<Parameters<Db["transaction"]>[0]>[0];

--- a/packages/db/src/env.ts
+++ b/packages/db/src/env.ts
@@ -1,0 +1,59 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { config } from "dotenv";
+import { expand } from "dotenv-expand";
+
+/**
+ * Walks up from `process.cwd()` looking for the workspace root — the directory holding
+ * `pnpm-workspace.yaml` — and returns the path to its `.env`, or `undefined` if there is no
+ * workspace above us.
+ *
+ * Walking beats a path relative to this file. drizzle-kit bundles `drizzle.config.ts` to CJS with
+ * esbuild before evaluating it, and `import.meta.dirname` is `undefined` in that bundle, so
+ * anything anchored to this module's own location breaks under the CLI. `cwd` differs between the
+ * two callers — `packages/db` for drizzle-kit, `apps/web` for the running app — but the workspace
+ * root is above both.
+ */
+function findWorkspaceEnv(): string | undefined {
+  let dir = process.cwd();
+
+  for (;;) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml"))) {
+      return resolve(dir, ".env");
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/**
+ * Reads `DATABASE_URL`, loading the repo-root `.env` first if there is one.
+ *
+ * One `.env`, at the root, is the single source for local configuration — Docker Compose reads it
+ * natively and this reads it explicitly, so the connection string is written once and cannot drift
+ * between the container and its clients.
+ *
+ * In production there is no `.env` and no workspace root: the lookup misses, nothing is loaded,
+ * and the value comes from the process environment (Fly secrets, ADR-0005). `dotenv` never
+ * overrides an existing variable, so an explicit `DATABASE_URL=… pnpm db:migrate` against another
+ * environment also wins over the file.
+ */
+export function databaseUrl(): string {
+  const path = findWorkspaceEnv();
+  if (path) {
+    // `expand` resolves `${POSTGRES_PORT}` inside DATABASE_URL. Plain dotenv does not interpolate,
+    // where Compose does — so without this the same `.env` would mean two different things to the
+    // container and to its clients.
+    expand(config({ path, quiet: true }));
+  }
+
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "DATABASE_URL is not set. Copy .env.example to .env at the repo root, or export it.",
+    );
+  }
+  return url;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,1 @@
+export { getDb, type Db, type Tx } from "./client";

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Every table in the system, grouped by owning module (ADR-0006).
+ *
+ * The schema is *central* rather than per-module because Drizzle's relations API defeats the
+ * split in both generations — see ADR-0006, "Why the schema is central". Ownership stays legible
+ * through one file per owner (`./auth.ts`, `./catalog.ts`, `./people.ts`, …), re-exported here.
+ *
+ * Empty by design: no table has been designed yet. The tables land with the implementation
+ * tickets that follow this map, under the conventions ADR-0008 fixes (plural tables, singular
+ * columns, `timestamptz` everywhere, hard deletes, `RESTRICT` by default).
+ */
+
+export {};

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    // Overrides base.json's NodeNext. `@repo/db` is a JIT package (ADR-0006) — it ships raw
+    // TypeScript and is resolved by a *bundler*, never by Node: Turbopack for `apps/web`,
+    // esbuild for drizzle-kit's config loader. NodeNext demands `.js` on every relative import,
+    // and Turbopack does not rewrite `.js` to `.ts`, so `import "./client.js"` type-checks here
+    // and then fails at `next build` with "Can't resolve ./client.js".
+    //
+    // Bundler resolution is also what the consumer already uses — `apps/web` extends
+    // `@repo/typescript-config/nextjs.json`, which sets it — so this makes the package agree with
+    // how its only consumer reads it. This applies to every JIT domain package ADR-0006 defines,
+    // not just this one.
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "noEmit": true
+  },
+  "include": ["src", "drizzle.config.ts"],
+  "exclude": ["node_modules", "migrations"]
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-turbo": "^2.7.1",
     "globals": "^16.5.0",
-    "typescript": "^5.9.2",
-    "typescript-eslint": "^8.50.0"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.67.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,7 @@
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
     "eslint": "^9.39.1",
-    "typescript": "5.9.2"
+    "typescript": "6.0.3"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,45 +15,8 @@ importers:
         specifier: ^2.10.9
         version: 2.10.10
       typescript:
-        specifier: 5.9.2
-        version: 5.9.2
-
-  apps/docs:
-    dependencies:
-      '@repo/ui':
-        specifier: workspace:*
-        version: link:../../packages/ui
-      next:
-        specifier: 16.3.0
-        version: 16.3.0(@types/node@22.15.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react:
-        specifier: ^19.2.0
-        version: 19.2.0
-      react-dom:
-        specifier: ^19.2.0
-        version: 19.2.0(react@19.2.0)
-    devDependencies:
-      '@repo/eslint-config':
-        specifier: workspace:*
-        version: link:../../packages/eslint-config
-      '@repo/typescript-config':
-        specifier: workspace:*
-        version: link:../../packages/typescript-config
-      '@types/node':
-        specifier: ^22.15.3
-        version: 22.15.3
-      '@types/react':
-        specifier: 19.2.2
-        version: 19.2.2
-      '@types/react-dom':
-        specifier: 19.2.2
-        version: 19.2.2(@types/react@19.2.2)
-      eslint:
-        specifier: ^9.39.1
-        version: 9.39.1
-      typescript:
-        specifier: 5.9.2
-        version: 5.9.2
+        specifier: 6.0.3
+        version: 6.0.3
 
   apps/web:
     dependencies:
@@ -89,8 +52,45 @@ importers:
         specifier: ^9.39.1
         version: 9.39.1
       typescript:
-        specifier: 5.9.2
-        version: 5.9.2
+        specifier: 6.0.3
+        version: 6.0.3
+
+  packages/db:
+    dependencies:
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      dotenv-expand:
+        specifier: ^1000.0.0
+        version: 1000.0.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.21.0)(pg@8.23.0)
+      pg:
+        specifier: ^8.23.0
+        version: 8.23.0
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
+      '@types/pg':
+        specifier: ^8.21.0
+        version: 8.21.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/eslint-config:
     devDependencies:
@@ -122,11 +122,11 @@ importers:
         specifier: ^16.5.0
         version: 16.5.0
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
+        specifier: ^6.0.3
+        version: 6.0.3
       typescript-eslint:
-        specifier: ^8.50.0
-        version: 8.50.0(eslint@9.39.1)(typescript@5.9.2)
+        specifier: ^8.67.0
+        version: 8.67.0(eslint@9.39.1)(typescript@6.0.3)
 
   packages/typescript-config: {}
 
@@ -158,13 +158,468 @@ importers:
         specifier: ^9.39.1
         version: 9.39.1
       typescript:
-        specifier: 5.9.2
-        version: 5.9.2
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -480,6 +935,9 @@ packages:
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
 
+  '@types/pg@8.21.0':
+    resolution: {integrity: sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==}
+
   '@types/react-dom@19.2.2':
     resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
     peerDependencies:
@@ -488,63 +946,63 @@ packages:
   '@types/react@19.2.2':
     resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
 
-  '@typescript-eslint/eslint-plugin@8.50.0':
-    resolution: {integrity: sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==}
+  '@typescript-eslint/eslint-plugin@8.67.0':
+    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.50.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.67.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.50.0':
-    resolution: {integrity: sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==}
+  '@typescript-eslint/parser@8.67.0':
+    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.50.0':
-    resolution: {integrity: sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==}
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.50.0':
-    resolution: {integrity: sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==}
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.50.0':
-    resolution: {integrity: sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.50.0':
-    resolution: {integrity: sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==}
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.50.0':
-    resolution: {integrity: sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.50.0':
-    resolution: {integrity: sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==}
+  '@typescript-eslint/type-utils@8.67.0':
+    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.50.0':
-    resolution: {integrity: sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==}
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.50.0':
-    resolution: {integrity: sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==}
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   acorn-jsx@5.3.2:
@@ -605,6 +1063,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.8:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
@@ -612,12 +1074,16 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -702,9 +1168,113 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv-expand@1000.0.0:
+    resolution: {integrity: sha512-3T4TtUjXm5iGKFEirqKjcDJ0EheFJbv9peb5xytC+HNu3l5Ygnu4dYE8yeqkppHMsh1If9C/A//EJu7IPtNu+A==}
+    engines: {node: '>=16'}
+
   dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -742,12 +1312,28 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
   eslint-config-prettier@10.1.1:
     resolution: {integrity: sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==}
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
 
@@ -785,9 +1371,14 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
     peerDependencies:
       jiti: '*'
     peerDependenciesMeta:
@@ -862,6 +1453,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -883,6 +1479,9 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.2:
+    resolution: {integrity: sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1113,12 +1712,12 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1133,6 +1732,7 @@ packages:
   next@16.3.0:
     resolution: {integrity: sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==}
     engines: {node: '>=20.9.0'}
+    hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.51.1
@@ -1209,6 +1809,40 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1227,6 +1861,22 @@ packages:
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1270,6 +1920,9 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
 
@@ -1297,10 +1950,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1354,6 +2003,17 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1411,14 +2071,19 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   turbo@2.10.10:
     resolution: {integrity: sha512-/90KTW+USzvYOPmafRZHVKLBsHXQ5810Ao/HdtJYAqguIhZ+XruS6eIUjqJUDtrSxaZYynNFht68qckGKAOWTA==}
@@ -1444,16 +2109,17 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.50.0:
-    resolution: {integrity: sha512-Q1/6yNUmCpH94fbgMUMg2/BSAr/6U7GBk61kZTv1/asghQOWOjTlp9K8mixS5NcJmm2creY+UFfGeW/+OcA64A==}
+  typescript-eslint@8.67.0:
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -1489,15 +2155,253 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.2
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1)':
@@ -1744,6 +2648,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.21.0':
+    dependencies:
+      '@types/node': 22.15.3
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+
   '@types/react-dom@19.2.2(@types/react@19.2.2)':
     dependencies:
       '@types/react': 19.2.2
@@ -1752,96 +2662,96 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1)(typescript@5.9.2))(eslint@9.39.1)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@9.39.1)(typescript@6.0.3))(eslint@9.39.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.50.0(eslint@9.39.1)(typescript@5.9.2)
-      '@typescript-eslint/scope-manager': 8.50.0
-      '@typescript-eslint/type-utils': 8.50.0(eslint@9.39.1)(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.50.0(eslint@9.39.1)(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.50.0
+      '@typescript-eslint/parser': 8.67.0(eslint@9.39.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/type-utils': 8.67.0(eslint@9.39.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
       eslint: 9.39.1
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.50.0(eslint@9.39.1)(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.67.0(eslint@9.39.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.50.0
-      '@typescript-eslint/types': 8.50.0
-      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.50.0
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3
       eslint: 9.39.1
-      typescript: 5.9.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.50.0(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.67.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.50.0
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
       debug: 4.4.3
-      typescript: 5.9.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.50.0':
+  '@typescript-eslint/scope-manager@8.67.0':
     dependencies:
-      '@typescript-eslint/types': 8.50.0
-      '@typescript-eslint/visitor-keys': 8.50.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
 
-  '@typescript-eslint/tsconfig-utils@8.50.0(typescript@5.9.2)':
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.2
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.50.0(eslint@9.39.1)(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.67.0(eslint@9.39.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.50.0
-      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.50.0(eslint@9.39.1)(typescript@5.9.2)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.1)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.1
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.50.0': {}
+  '@typescript-eslint/types@8.67.0': {}
 
-  '@typescript-eslint/typescript-estree@8.50.0(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.50.0(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.50.0
-      '@typescript-eslint/visitor-keys': 8.50.0
+      '@typescript-eslint/project-service': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3
-      minimatch: 9.0.5
-      semver: 7.7.3
+      minimatch: 10.2.6
+      semver: 7.8.5
       tinyglobby: 0.2.15
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.50.0(eslint@9.39.1)(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.67.0(eslint@9.39.1)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
-      '@typescript-eslint/scope-manager': 8.50.0
-      '@typescript-eslint/types': 8.50.0
-      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
       eslint: 9.39.1
-      typescript: 5.9.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.50.0':
+  '@typescript-eslint/visitor-keys@8.67.0':
     dependencies:
-      '@typescript-eslint/types': 8.50.0
-      eslint-visitor-keys: 4.2.1
+      '@typescript-eslint/types': 8.67.0
+      eslint-visitor-keys: 5.0.1
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -1927,6 +2837,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.8: {}
 
   brace-expansion@1.1.12:
@@ -1934,13 +2846,15 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@5.0.9:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-from@1.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -2029,7 +2943,23 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv-expand@1000.0.0: {}
+
   dotenv@16.0.3: {}
+
+  dotenv@17.4.2: {}
+
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.23.12
+
+  drizzle-orm@0.45.2(@types/pg@8.21.0)(pg@8.23.0):
+    optionalDependencies:
+      '@types/pg': 8.21.0
+      pg: 8.23.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2138,6 +3068,89 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
   escape-string-regexp@4.0.0: {}
 
   eslint-config-prettier@10.1.1(eslint@9.39.1):
@@ -2186,6 +3199,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.1:
     dependencies:
@@ -2290,6 +3305,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -2326,6 +3344,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
+
+  get-tsconfig@4.14.2:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -2552,13 +3574,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
 
   ms@2.1.3: {}
 
@@ -2660,6 +3682,41 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -2673,6 +3730,16 @@ snapshots:
       nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -2719,6 +3786,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@2.0.0-next.5:
     dependencies:
       is-core-module: 2.16.1
@@ -2754,10 +3823,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.3: {}
-
-  semver@7.8.5:
-    optional: true
+  semver@7.8.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -2851,6 +3917,15 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  split2@4.2.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -2922,11 +3997,17 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@2.1.0(typescript@5.9.2):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.2
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.10.10:
     optionalDependencies:
@@ -2974,18 +4055,18 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.50.0(eslint@9.39.1)(typescript@5.9.2):
+  typescript-eslint@8.67.0(eslint@9.39.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1)(typescript@5.9.2))(eslint@9.39.1)(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.50.0(eslint@9.39.1)(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.50.0(eslint@9.39.1)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@9.39.1)(typescript@6.0.3))(eslint@9.39.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@9.39.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.1)(typescript@6.0.3)
       eslint: 9.39.1
-      typescript: 5.9.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.2: {}
+  typescript@6.0.3: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -3046,5 +4127,7 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
   "ui": "tui",
+  "globalEnv": ["DATABASE_URL", "NODE_ENV"],
+  // The root `.env` is where DATABASE_URL actually comes from locally — `@repo/db` reads the file
+  // rather than inheriting the variable, so Turbo would otherwise hash it as unset and replay a
+  // cached build produced against a different database. Package-level `inputs: [".env*"]` cannot
+  // see it: those globs are package-relative and this file is above every package.
+  "globalDependencies": [".env"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Resolves #17.

Stands up the local database and creates `@repo/db` — tier 0 of the ADR-0006 module DAG.

## What runs

```sh
cp .env.example .env
pnpm bootstrap      # install + db:up + db:migrate
```

Named `bootstrap`, not `setup`: **`pnpm setup` is a built-in pnpm command** that creates `PNPM_HOME`
and edits your shell rc file, and pnpm resolves built-ins before package scripts — so a script called
`setup` is silently unreachable.

`pnpm db:up` blocks on the container healthcheck, so it is usable in a script rather than a race
against `initdb`. `pnpm db:reset` destroys the volume and rebuilds from migrations — verified from
an empty volume.

## Decisions worth reviewing

**Postgres 18.6, pinned exactly.** PlanetScale offers only 17 and 18 and has **no in-place
major-version upgrade** — changing majors means creating a new database and migrating into it. We
have no data yet, so this is the cheap moment to land on 18. Note the version had no host to be read
off: nothing is provisioned on PlanetScale, so 18 is *chosen* here and the host must be created to
match.

**Debian, not Alpine.** musl has no real locale support, so `en_US.UTF-8` collation is unavailable
and text sorts differently there than on any glibc host. Not worth ~80 MB when the product sorts
Spanish.

**Extensions come from a migration, not an init script.** `/docker-entrypoint-initdb.d` runs only on
a brand-new volume — every existing developer database would silently miss a later addition — and it
has no counterpart on PlanetScale.

**It does *not* solve the restore case, and an earlier version of this PR wrongly claimed it did.**
PlanetScale does not restore extensions from a backup; re-running migrations will not fix that,
because a restore also brings back `drizzle.__drizzle_migrations`, which already records `0000` as
applied. The runner reports nothing to do while `pg_trgm`/`unaccent` are missing. Post-restore
recovery is an explicit `CREATE EXTENSION` — a runbook step #15 inherits.

**One `.env`, at the repo root.** Compose reads it natively; `@repo/db` finds it by walking up to the
workspace root. `POSTGRES_PORT` is interpolated into `DATABASE_URL` (`dotenv-expand`) so one port has
one source — otherwise setting `POSTGRES_PORT=5433` while the URL still said 5432 would point
`db:migrate` at whatever *other* Postgres you were working around.

Anchoring to the config file's own location does not work: drizzle-kit bundles `drizzle.config.ts`
to CJS with esbuild, where `import.meta.dirname` is `undefined`. In production the walk misses and
the value comes from Fly secrets (ADR-0005).

**Postgres is published on loopback only.** A bare `"5432:5432"` binds `0.0.0.0`, putting a database
whose credentials are `encuentra`/`encuentra` on whatever network the laptop joins.

**The singleton is built on first use.** `databaseUrl()` throws when unset, so a module-scope pool
would make *importing* `@repo/db` require a connection string — and `next build` in CI (#15, no root
`.env`) loads every route's module graph, so one route importing it would fail the whole build.
Hence `getDb()` rather than an exported `db`.

## The one that generalises beyond this PR

**JIT packages need `moduleResolution: Bundler`, not `base.json`'s NodeNext.** NodeNext demands
`.js` on every relative import, and **Turbopack does not rewrite `.js` to `.ts`** — so
`import "./client.js"` type-checks and then fails `next build` with `Can't resolve ./client.js`.
This applies to all ten domain packages in ADR-0006; `CLAUDE.md` records it.

## Toolchain

**TypeScript 5.9.2 → 6.0.3**, with `typescript-eslint` 8.50.0 → 8.67.0 (a minor). **ESLint stays on
9.39.1.**

TS 7 was attempted and is not reachable: it type-checks clean, but `typescript-estree` crashes on it
(`Cannot read properties of undefined (reading 'Cjs')`), and **every published `typescript-eslint`,
including the canary, peers `typescript <6.1.0`** — there is no v9. That ceiling is what makes 6.0.3
the highest usable version. Revisit with #15 once typed linting supports 7.

## Verified

- `postgres:18.6-trixie` reports PostgreSQL 18.6, UTF8 / `en_US.UTF-8`, `TimeZone` UTC, and
  `data_directory` `/var/lib/postgresql/18/docker` — Postgres 18 moved `PGDATA`, and the pre-18
  `/var/lib/postgresql/data` mount would have persisted nothing while appearing to work.
- `pg_trgm 1.6` and `unaccent 1.1` — the exact versions PlanetScale documents.
- `drizzle-kit migrate` applies `0000` and is idempotent on re-run.
- Five cold `down -v` → `db:up` → `db:migrate` cycles, all green.
- Port interpolation checked by moving `POSTGRES_PORT` to 5433 and watching both the published port
  and the client follow.
- A temporary probe page reached the database through the singleton during `next build`
  (`{"db":"encuentra","tz":"UTC","u":"atencion"}`). Not in this diff — it existed to prove resolution
  and the runtime path, and it is what caught the `moduleResolution` problem.
- `turbo run lint check-types build --force` — 7/7, no cache.

## Scope note

`src/schema/index.ts` is deliberately **empty** — no table has been designed yet, and this map is
plan-only. The pool singleton and `Db`/`Tx` types are included because ADR-0006 specifies them
exactly and they make the `.env` story reachable from `apps/web`; everything else waits for the
implementation tickets.

## Findings for later tickets

- **#16 (testing):** PGlite embeds **PostgreSQL 17.4**, a major behind dev and production — and
  ADR-0008 makes a PGlite test the *required* guard on erasure completeness.
- **#15 (environments/CI):** no in-place major upgrade on PlanetScale; extensions must be recreated
  explicitly after a restore; the local exact-patch pin needs deliberate bumping as PlanetScale
  patches minors; TS 7 pending typed-lint support.
- **Implementation tickets:** Next 16 runs with Cache Components enabled, so an uncached database
  read in a prerendered route fails the build — reads need `"use cache"`, `<Suspense>`, or
  `export const instant = false`.
- **ADR-0008 correction:** it says `casing: 'snake_case'` is set "once in the Drizzle config". It is
  set **twice** — `drizzle.config.ts` governs drizzle-kit's emitted SQL, `drizzle()` governs runtime
  column names. A mismatch is silent.
- **drizzle-orm v1 is still RC** (`latest` is 0.45.2). ADR-0006 reasons about both relations
  generations without picking; this installs stable 0.45.2.