### PR TITLE
Erasure: a real delete, a surviving proof, and no memory of a ban (ADR-0021)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -244,8 +244,10 @@ Suggestion, which is a suggestion made _to us_)
 **Pause**:
 A Person stepping out without leaving: every Publication becomes invisible and unaddressable, they
 leave matching and suggestions, and Offers already sent to them are frozen rather than declined. It
-touches no Consent, so it is never a Revocation and never an erasure — someone who pauses expects to
-come back. Distinct from a **Suspension**, which is what the platform does _to_ a Person for cause;
+touches no Consent, so it is never a Revocation and never an **Erasure** — someone who pauses expects
+to come back, and a Pause is what they are offered, once and with equal weight, at the moment they
+ask to be deleted. Distinct from a **Suspension**, which is what the platform does _to_ a Person for
+cause;
 the difference shows in the Offers, which a Pause freezes and a Suspension voids.
 _Spanish (UI)_: pausa
 _Avoid_: Deactivate, Suspend, Ban, Disable, Delete, Hide
@@ -266,6 +268,10 @@ reason, and the sender may revise and send again.
 
 Contact Details are exchanged only when an Offer is accepted, and the platform knows nothing of what
 happens afterwards.
+
+An Offer outlives either side's **Erasure**: it is both people's record, and one person leaving does
+not take the other's copy with them. The side that erased simply stops being anybody — shown as a
+deleted account, with the terms left exactly as they were agreed.
 _Spanish (UI)_: propuesta
 _Avoid_: Application, Postulación, Oferta (means the job posting in Colombian usage), Match,
 Placement, Colocación, Remisión
@@ -316,9 +322,10 @@ _Avoid_: Mute, Hide, Ignore, Ban (that is ours to do, not theirs)
 **Suspension**:
 What the platform does to a Person for cause: the account becomes unusable, every Publication is
 suppressed, and Offers they sent are voided rather than frozen. Indefinite and reversible by an
-operator, never timed. The Person and the evidence are **retained**, not deleted — the record of why
-must outlive the account, and a Person deleted outright simply registers again tomorrow. The opposite
-of a **Pause** in every respect, including who chose it.
+operator, never timed. The Person and the evidence are retained for as long as the account
+exists — but a Suspension **does not survive an Erasure**: someone who asks to be deleted is
+deleted, and nothing is kept to recognise them by if they come back. The opposite of a **Pause** in
+every respect, including who chose it.
 _Spanish (UI)_: suspensión
 _Avoid_: Ban, Deactivation, Pause, Delete, Removal
 
@@ -407,6 +414,23 @@ the right to take us to the regulator. Withdrawing a Consent and asking to be er
 of Complaint rather than things beside it.
 _Spanish (UI)_: reclamo
 _Avoid_: Report (that is a safety term), Claim, Dispute, Grievance
+
+**Erasure**:
+A Person asking to be deleted, and being deleted. Not a hiding and not a marking — the account, the
+Publications, the Photo and everything else about them stop existing, and the platform keeps no way
+of recognising them if they return, not even after a Suspension. What survives is only the proof that
+they once authorised us and that we honoured this request, kept because the law requires the proof
+and bounded by the same published schedule as everything else.
+
+It takes effect at once. There is no waiting period to change your mind, because a waiting period
+would mean still holding what someone asked us to destroy — so the alternative, a **Pause**, is
+offered instead at the moment of the decision, and only then.
+
+Two things it cannot reach: what another Person already wrote down after a Contact Exchange, and the
+shared record of an Offer, which is that other Person's too.
+_Spanish (UI)_: supresión, eliminar mi cuenta
+_Avoid_: Deletion request, Right to be forgotten, Deactivation, Removal, Anonymisation (we delete
+rather than blank out), Pause, Suspension
 
 **Complaint Legend**:
 A mark saying that a Person's data is the subject of a live Complaint, together with the reason they

--- a/docs/adr/0007-consent-as-versioned-per-purpose-evidence.md
+++ b/docs/adr/0007-consent-as-versioned-per-purpose-evidence.md
@@ -316,7 +316,7 @@ whose charter widens accordingly. Only the `/my-data` surface, export, erasure a
 schedule remain, all with #27.
 
 One thing above is now load-bearing elsewhere: **the instantly-closed `data_requests` row** this ADR
-writes on self-service revocation is the pattern ADR-0019 reuses for an export.
+writes on self-service revocation is the pattern ADR-0020 reuses for an export.
 
 Two points from the research remain open and are for counsel, not for engineering: the **physical
 address and telephone** D.1377 art. 13(1) requires us to publish (a persona-natural-vs-S.A.S.

--- a/docs/adr/0013-safety-between-individuals.md
+++ b/docs/adr/0013-safety-between-individuals.md
@@ -160,6 +160,18 @@ an Offer pending against an account that will never answer strands the recipient
 > account will never answer either way, and the sender is stranded identically. The counterparty sees
 > a neutral _no longer available_ and is never told a moderation action occurred.
 
+> **Amended by #27 — a suspension does not survive an erasure request.** This ADR treats the
+> suspension record as permanent, on the reasoning that _"a Person deleted outright simply registers
+> again tomorrow"_. That reasoning is sound and is **not a lawful ground to refuse**:
+> `2.2.2.25.2.6` and C-748 resolutivo Cuarto leave exactly one — a _deber legal o contractual de
+> permanecer_ — and we sign no contracts and move no money. So a suspended Person who files an art.
+> 15 _supresión_ reclamo **is erased completely**, and the platform keeps **no record that the
+> suspension ever happened**. #27 weighed a minimal blocklist as the replacement and **declined to
+> build one**: keyed on an email a returning fraudster simply changes, it is worth nothing against
+> anyone trying, while a retained coded fraud reason about a person who asked to be forgotten is
+> plausibly _dato sensible_ under art. 5's open list. **v1 has no ban memory**, which is the same gap
+> ADR-0008 named and which the map schedules against ADR-0009.
+
 **Contact Details already released by a Contact Exchange are gone, and this ADR says so rather than
 implying a reach the platform does not have.** Suspension stops future exchanges; it cannot retrieve
 a phone number someone already wrote down. This is the direct, unavoidable cost of moving no money
@@ -323,10 +335,11 @@ Until that ticket resolves, build to the recommended positions and do not treat 
 > (`docs/research/moderation-record.md`) did the reading; ADR-0020 and #27 made the calls.
 >
 > 1. **Erasure versus ban** — **#27**. Colombian law carries exactly one refusal ground
->    (`2.2.2.25.2.6`'s _deber legal o contractual de permanecer_), so erasure **narrows rather than
->    refuses**. _"The Person and the evidence are retained, not deleted"_ survives an ordinary
->    suspension but **not an art. 15 _supresión_ reclamo**; #27 owns that amendment and the blocklist
->    that replaces it.
+>    (`2.2.2.25.2.6`'s _deber legal o contractual de permanecer_) and we can never invoke it, so
+>    **erasure always succeeds**. _"The Person and the evidence are retained, not deleted"_ survives
+>    an ordinary suspension but **not an art. 15 _supresión_ reclamo** — see the amendment at
+>    _Suspension, and what it cannot reach_. #27 also **declined the blocklist** the research
+>    recommended as the replacement: **we comply and lose the ban, with nothing kept.**
 > 2. **Art. 8(a) against the report record** — **ADR-0020**, in the two amendments above. The
 >    recommended position was half wrong: the identity stays withheld, the words do not.
 >

--- a/docs/adr/0021-erasure-a-real-delete-and-no-memory-of-a-ban.md
+++ b/docs/adr/0021-erasure-a-real-delete-and-no-memory-of-a-ban.md
@@ -1,0 +1,328 @@
+# Erasure: a real delete, a surviving proof, and no memory of a ban
+
+ADR-0008 chose hard delete repo-wide and then deliberately stopped, handing this ticket the one table
+it could not decide for: `persons` itself. ADR-0020 built the case file and the clock and left the
+same gap — an erasure request _is_ a `data_requests` row, so the proof of compliance cannot die with
+the subject it is about. `docs/research/moderation-record.md` supplied the law and one defect it
+could not fix.
+
+This ADR closes all three. Erasure **deletes**, the proof **survives on a key of its own**, and the
+platform keeps **no memory of a ban** — that last one reversing the research's own recommendation,
+on grounds the research did not have.
+
+## Erasure deletes the row
+
+**A _supresión_ under art. 15 hard-deletes the `persons` row.** Redaction in place was live until now:
+ADR-0008 kept both options open precisely because it could not choose between them, and redaction is
+genuinely cheaper — every foreign key stays valid, `RESTRICT` never fires, and none of the three
+problems below exists.
+
+It loses on a failure mode neither ADR had named. **Redaction is a denylist; deletion is not.**
+Redacting in place means maintaining, forever, an enumeration of which columns on `persons` identify
+someone. A column added in 2028 by someone who has not read this ADR is silently missed and nothing
+fails. ADR-0017's reflective invariant guards the mirror-image hazard — a new _table_ referencing
+`persons` — but it cannot guard a new _column_ on a row we deliberately keep, and no cheap test can:
+"is this column identifying" is a judgement, not a schema property. A `DELETE` is complete by
+construction and needs no list.
+
+Beyond that it is simply what the statute says. `2.2.2.25.2.8` requires _supresión_ once the
+_finalidad_ is met, and a redacted row is the tombstone ADR-0008 banned repo-wide, wearing better
+manners.
+
+## The proof outlives the subject, on a key of its own
+
+`consents` and `data_requests` must survive the delete. ADR-0008 anticipated the shape —
+_"a nullable FK or a different anchor"_ — and ADR-0020 declined to pick, so that both tables would
+get one mechanism rather than two.
+
+**Both: `person_id` becomes nullable and is set to `NULL` at erasure, and both tables carry a
+non-null `subject_key` written at insert.**
+
+```
+subject_key = HMAC-SHA256(secret, lowercase(trim(email)))
+```
+
+The email, because ADR-0009 makes `users.email` the identity anchor. **This is the answer to the
+defect `docs/research/moderation-record.md` carried forward**: that research argued for a keyed HMAC
+over a bare digest because _"a plain SHA of a cédula is brute-forceable"_, reasoning from an
+identifier this platform never collects — ADR-0010 refused document uploads and signup is name, date
+of birth and a credential. The argument for keying survives the correction intact; only the input
+changes.
+
+A `public_id`-only anchor was the alternative and is cheaper on privacy: it proves the _shape_ of
+compliance — a consent existed, an erasure happened, on these dates — while keeping nothing that
+could re-identify anyone. It was rejected because it cannot do the one thing ADR-0007 built this
+evidence for. `docs/research/ley-1581-obligations.md` §3 states the standard as being able to
+_"render back to a specific candidate, on demand, the exact consent artefact they were shown"_. A
+Titular who disputes gives us their email; we hash it; we find their consents and the
+`document_version` they were shown. An unlinkable record answers the regulator and fails the person.
+
+**The key can never be rotated.** Re-hashing needs plaintext we no longer hold. One long-lived
+secret in Fly secrets (ADR-0005), and losing it makes every surviving proof unverifiable — which
+puts it in the same class as the extensions problem #17 found: a backup that restores the database
+and not the secret restores nothing that matters. Named here, owned by the backup and disaster
+recovery work.
+
+**One limitation, stated rather than discovered later.** The key is the email _at the moment the row
+was written_. A Person who changes their email and then erases leaves older `consents` rows keyed to
+the older address, so a later lookup needs the old email too. The erasure's own `data_requests`
+row — the one that proves we complied — is always keyed to the current address, because erasure is
+the moment we last know it. Any future email-change feature inherits this as a constraint.
+
+## What the counterparty of an Offer keeps
+
+An Offer is two people's data. B accepted work from A; A erases; B asked for nothing and is a Titular
+too.
+
+ADR-0015 makes this tractable: the Offer **copies** its terms rather than pointing at them, so
+`publication_id` is provenance and nothing more. **Sever the person-side links — `sender_person_id`
+and `publication_id` both become nullable — and the Offer stands alone.** A null on one side _is_ the
+_cuenta eliminada_ placeholder: derived, never stored, following the precedent ADR-0015 set when it
+derived `frozen` from `persons.status` rather than storing a copy that drifts.
+
+**The Offer is kept whole.** Stripping the erased side's free text was the alternative and it
+reintroduces exactly the denylist that decided the first section — an enumeration of "which columns
+hold the erased side's words," silently incomplete the next time a column is added. The accepted
+cost, named rather than implied: **if A erases in month 1, B holds A's words until the Offer's own
+12-month term expires.** That is a real residue and the retention term is what bounds it.
+
+The same rule runs through `reports`, in one direction only. A Report is both people's data, so:
+the **reported** Person's erasure deletes it along with everything else about them, while the
+**reporter**'s erasure severs the reporter link and leaves the Report standing — because it is the
+reported Person's data and ADR-0020 gives them a standing right to see it.
+
+## There is no memory of a ban, and that is the decision
+
+`docs/research/moderation-record.md` recommends keeping a keyed HMAC, a timestamp and a coded reason
+in a blocklist so a banned fraudster is recognised on return. **We build nothing.** The ticket left
+this open explicitly, and the research's own recommendation rests on a premise this repo does not
+have.
+
+1. It catches only a fraudster who **reuses their email**. Against one who does not, it is worth
+   exactly zero — and re-registration is where the effort of a returning fraudster goes.
+2. ADR-0009 made signup free, instant and unlimited with no phone OTP, so re-registration already
+   costs nothing. A blocklist does not raise that cost; it occasionally notices.
+3. **It retains a coded fraud reason about a person who asked to be forgotten.** The research itself
+   flags (§"What could not be verified", item 4) that art. 5's list is open — _"tales como"_ — and
+   its test is data _"cuyo uso indebido puede generar su discriminación"_, which a fraud label in a
+   labour-matching context plainly can. If it is _sensible_, art. 6 wants explicit consent we will
+   never have. This is the reason that decides it.
+4. We would have to **publish a retention term no source supports.** The research is unambiguous that
+   no number exists in the regime and that Ley 1266's 4/8-year _caducidad_ must not be cited
+   (art. 2(e) excludes it textually). Publishing a term we invented, for the record hardest to
+   justify, is the worst place to spend that credibility.
+5. ADR-0013 refused accumulation-driven auto-suppression on brigading grounds. A permanent ban record
+   is the same shape and strictly worse, because the account is gone and there is nobody left to
+   appeal.
+
+**So v1 has no ban memory.** That is a real cost and it is not new: ADR-0008 already named it —
+_"hard-delete a fraudster and they re-register tomorrow, because nothing survived to recognise
+them"_ — and the map's fog schedules the ADR-0009 collision for the day reputation accrues, at which
+point re-registration stops being cheap for reasons that actually work. This ADR confirms the gap
+rather than patching it with a control that does not close it.
+
+## Narrowing is not refusing
+
+`docs/research/moderation-record.md` settles that Colombian law carries **exactly one** ground for
+refusing erasure — `2.2.2.25.2.6`'s _deber legal o contractual de permanecer_, written into art. 8(e)
+by C-748 resolutivo Cuarto. The ticket had guessed the list would also include an open request or
+investigation in flight; it does not, and the three-limb list the research was sent to check is
+Mexico's LFPDPPP art. 26.
+
+We sign no contracts and move no money, so **the set is empty in practice and self-service erasure
+always succeeds.**
+
+| Outcome                                          | `outcome`  |
+| ------------------------------------------------ | ---------- |
+| Everything deleted                               | `answered` |
+| Everything deleted, a minimum retained and named | `answered` |
+| The Titular is told they cannot be erased        | `refused`  |
+
+The middle row is the trap, and it is why this section exists: keeping less **is not** saying no.
+Recording a narrowed erasure as `refused` would put a false statement in the one record the SIC
+reads. With no blocklist the middle row now has no product path at all, but the distinction is
+recorded because it is the natural mistake for whoever revisits this.
+
+**`data_requests` gains a nullable `refusal_ground`**, `text({ enum })` + `check()` per ADR-0008,
+with one value: `legal_or_contractual_duty`. A `CHECK` makes it non-null exactly when
+`outcome = 'refused'`. No product surface can produce it; an operator can, and
+`2.2.2.25.2.6` requires the refusal to be specific and documented if the impossible case ever
+arrives.
+
+## The retention schedule is declared where the table is
+
+`2.2.2.25.2.8` requires us to **publish** a retention schedule, to **honour** it, and — as a duty in
+its own right — to **document** the procedures. The hazard is the one every published schedule has:
+the document and the code drift, and nobody notices until a regulator reads both.
+
+ADR-0017 already forces every table to declare an **erasure classification where the table is
+defined**, in `@repo/db`'s `src/columns.ts` helpers, and enumerates them reflectively. **The
+retention term joins that same declaration** — one declaration carrying both facts, not two that can
+disagree — and **the published table in the _política_ is generated from it**. The document and the
+code cannot drift because there is only one of them.
+
+This follows ADR-0020's holidays-are-a-constant reasoning: reference-data machinery in service of an
+array is not worth a table, a migration and a seed.
+
+| Data                                                        | Erasure       | Term                                                   |
+| ----------------------------------------------------------- | ------------- | ------------------------------------------------------ |
+| `persons`, contact details                                  | with Person   | account lifetime                                       |
+| `publications`, `capability_profiles`, `needs`, skill links | with Person   | account lifetime                                       |
+| Photo row and object                                        | with Person   | account lifetime; rejected bytes at once (ADR-0010)    |
+| `users`, `sessions`, `accounts`                             | with Person   | account lifetime (cascade)                             |
+| `verifications`                                             | with Person   | expiry (**no foreign key** — see below)                |
+| `blocks`                                                    | with Person   | while both accounts live                               |
+| `offer_send_attempts`                                       | with Person   | 12 months                                              |
+| `offers`                                                    | links severed | 12 months from terminal state                          |
+| `reports` — dismissed                                       | see above     | 12 months from dismissal                               |
+| `reports` — actioned                                        | see above     | while the Suspension is live, + 24 months              |
+| `consents`                                                  | evidence      | 5 years from account closure                           |
+| `data_requests`                                             | evidence      | 5 years from `resolved_at`                             |
+| `skills`, `municipalities`, `denominations`, documents      | impersonal    | none — reference data and the texts evidence points at |
+
+**The five-year figure is our own proportionality judgement and is flagged as provisional.** The
+research is explicit that no number exists in the regime and that whatever we pick is defensible only
+if documented in advance. The reasoning: the exposure the consent evidence exists to survive is the
+SIC's sanctioning power, which I believe **CPACA (Ley 1437 de 2011) art. 52** caps at three years
+from the act — so five covers the window with margin while anything longer starts failing
+_razonable y necesario_. **That article was not read**, and a follow-up issue carries the
+verification, exactly as ADR-0020 filed #41 for the holiday list. The shape of this decision does not
+change with the number; the number is one constant in one file.
+
+**The purge jobs are specified here and scheduled by #15**, the same split ADR-0020 used for its
+deadline alarm. Each is a delete over one table against its declared term, and each pings
+Healthchecks.io so that a job which stops running alarms too.
+
+## The erasure sequence
+
+**Erasure is immediate. There is no grace period.** A scheduled-delete row is data we were told to
+delete and are still holding — the soft-delete instinct ADR-0008 banned, wearing a clock.
+
+The mis-tap risk is real and this audience is the one #30 and #35 exist to protect, so the answer is
+the reversible door we already built: **the confirmation offers Pause at equal visual weight**
+(ADR-0011 — _"stepping out without leaving"_). Equal weight is not decoration. It follows ADR-0015's
+rule for the Offer decline escape, and it is what keeps offering an alternative from becoming
+obstruction of a right `2.2.2.25.4.2` requires to be _de fácil acceso_. It is offered once, and never
+again after the Person has chosen.
+
+**One transaction.** ADR-0007 established that Better Auth's server API runs its **own** transaction
+and cannot enlist in ours, and accepted an orphan window at signup as the price. Erasure cannot take
+that deal: a half-erased Person against a 15-business-day statutory clock is a breach, not an
+inconvenience. So the Better Auth rows are deleted through a `@repo/auth` module function taking
+`Db | Tx`, not through Better Auth's API — ADR-0006's _only the owning module writes to its own
+tables_ is satisfied, and the transaction boundary stays where ADR-0006 put it.
+
+Leaf-first, per ADR-0008's explicit-ordering rule; `sessions` and `accounts` need no line of their
+own because `docs/research/better-auth-audit.md` §3.3 confirms both are `ON DELETE CASCADE` to
+`users.id`. The object-store step is ADR-0010's and runs **after** commit, with its reconciliation
+sweep as the net.
+
+> **`verifications` has no foreign key, and ADR-0017's invariant cannot see it.** The audit (§3.3)
+> records it as a shared bucket keyed by `identifier` — which for our flows _is the email_. So it
+> holds personal data, is unreachable by cascade, and **the reflective erasure test will never
+> enumerate it, because that test finds tables by their foreign key to `persons`.** It is deleted
+> explicitly by `identifier`, and it gets its own named assertion in the erasure invariant rather
+> than trusting enumeration. This is the first known hole in that guard and it is unlikely to be the
+> last: any future table holding an email rather than a `person_id` has the same shape.
+
+## The `/my-data` surface
+
+This ADR specifies the information architecture and hands the visual design to #12 and #35, which
+own that vocabulary. The ticket's own `## Skills` named `/prototype` for the surface and **this is a
+deliberate departure from it**: prototyping earns its place when _how should it look or behave_ is
+the key question, and ADR-0020 had already fixed the hard part — `/my-data` shows every category,
+always, instantly, safety records included, because the latency asymmetry would otherwise be the
+disclosure.
+
+| Section                             | Shows                                                                                  | Writes a `data_requests` row |
+| ----------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------- |
+| Mi cuenta                           | name, date of birth, email, Contact Details, municipality, account status              | no                           |
+| Lo que publico                      | Publications, Skills, Self-description, Photo and its review state                     | no                           |
+| Mis autorizaciones                  | every Consent, current state **and full history**, each linked to the Disclosure shown | on revoking, closed at once  |
+| Quién recibió mis datos de contacto | derived from `offers.accepted_at`                                                      | no                           |
+| Mis propuestas                      | Offers sent and received, and their states                                             | no                           |
+| Seguridad                           | Reports about me at reason-code / date / action grain; my Blocks; my own answer        | on requesting the substance  |
+| Mis solicitudes                     | my Data Requests, their state and deadline; the Complaint Legend if live               | no                           |
+| Correct · revoke · pause · delete   | the operations                                                                         | on revoking and on erasure   |
+
+Viewing writes nothing (ADR-0020). _Quién recibió mis datos de contacto_ is the art. 8(c) answer —
+_"a quién se le ha suministrado"_ — and it exists only because ADR-0015 collapsed the
+contact-exchange log into `offers.accepted_at`. **That collapse is now load-bearing for a statutory
+right**, which it was not when ADR-0015 made it.
+
+## Export is deferred; the duty is not
+
+**Self-service export leaves v1** and is filed as its own ticket. The art. 12 _parágrafo_ duty to
+hand the Titular _copia_ of the proof of the art. 12 disclosure is **not** deferred with it: it is
+discharged by ADR-0020's operator path, where a request arrives at the published contact address and
+an operator produces the artefact inside the 10-día-hábil clock. What is deferred is the
+self-service button, not the right, and the _política_ must describe the channel that actually
+exists.
+
+One constraint the eventual export inherits, recorded now while the reasoning is fresh: it must carry
+the **rendered text of every Disclosure version accepted**, not merely the fact of acceptance. Art.
+12 _parágrafo_ entitles the Titular to a copy of the proof, and ADR-0007 already stores those texts
+per version, so the artefact is an assembly rather than a re-render.
+
+## The _manual interno_ has a home
+
+ADR-0020 left art. 17(k)'s written internal manual explicitly homeless — _"#27 owns the retention
+schedule, #15 owns the runbook, neither owns this"_. **This ADR specifies its contents; a task ticket
+carries the writing**, because writing a legal document into `docs/legal/` is doing, and this map
+plans. `2.2.2.25.2.8` makes documenting the _tratamiento, conservación y supresión_ procedures a duty
+in its own right, and this ADR decides those procedures — so its largest chapter is already written
+above.
+
+It must cover: ADR-0020's manual identity path and its redaction wording, ADR-0020's deadline alarm
+procedure, the erasure sequence and the narrowing above, and the retention schedule with its purge
+jobs.
+
+## What this does not decide
+
+- **Export contents, format and delivery** — its own ticket, post-v1.
+- **The CPACA art. 52 anchor** behind the five-year evidence term — a follow-up issue.
+- **Backup and disaster recovery**, which now inherits a second irreplaceable secret alongside #17's
+  extensions problem: the HMAC key, unrotatable and worthless to restore a database without.
+- **An email-change feature**, which inherits the subject-key limitation above.
+
+## Consequences
+
+- **ADR-0008 is completed, and amended in one place.** Its erasure question is answered — hard
+  delete — and the constraint it predicted lands: **`consents.person_id` becomes nullable**, joined
+  by `data_requests.person_id`, with `subject_key` as the anchor that survives. Its `RESTRICT`
+  default and explicit leaf-first ordering are untouched and are what make the sequence auditable.
+- **ADR-0015 is amended.** `offers.sender_person_id` and `offers.publication_id` become **nullable**,
+  severed on erasure, with the _cuenta eliminada_ placeholder derived from the null. Its five
+  terminal states are untouched.
+- **ADR-0017 is amended twice.** The lifecycle declaration it requires now carries **both** the
+  erasure classification and the retention term, in one declaration; and its reflective erasure
+  invariant is recorded as **unable to reach `verifications`**, which needs a named assertion of its
+  own. Per ADR-0017's rule that an ADR requiring a test names the file: the erasure invariant is
+  extended at `packages/db/src/erasure.invariant.test.ts`, and a new
+  `packages/db/src/lifecycle.invariant.test.ts` asserts that every table declares both facts.
+- **ADR-0020 is completed.** It inherits the anchor it deferred, for `data_requests` and `consents`
+  alike; gains `refusal_ground`; and its homeless _manual interno_ has an owner.
+- **ADR-0013 is amended** — see below.
+- **ADR-0007's stale cross-reference is corrected**: the instantly-closed `data_requests` row is the
+  pattern **ADR-0020** reuses for an export, not ADR-0019, which is the formatter.
+- **`CONTEXT.md`** gains **Erasure**; **Suspension**, **Pause** and **Offer** are amended.
+- **The ticket's profile-view audit log is recorded as retired, not decided here.** ADR-0011 declined
+  it (the log is cited to arts. 4(g)/17(d), not 8(c), and a signed-in Person reading a published
+  profile is an _authorised_ access) and ADR-0013 declined the abuse-investigation version. The
+  constraint the ticket asked to state against #22 was likewise already discharged by ADR-0011's
+  public tier.
+- **#15 inherits** the purge jobs and their Healthchecks.io pings, alongside ADR-0020's deadline
+  alarm, and one more secret that must exist in every environment.
+
+> **Amends ADR-0013 and `CONTEXT.md`'s Suspension entry.** _"The Person and the evidence are
+> **retained**, not deleted"_ is too strong. It holds for an ordinary suspension, which is the common
+> case and which this ADR does not touch. It does **not** hold against an art. 15 _supresión_
+> reclamo: a suspended Person who asks to be erased **is erased**, completely, and the platform keeps
+> **no record that the suspension ever happened**. ADR-0013's justification for retention —
+> _"a Person deleted outright simply registers again tomorrow"_ — is true and is not a lawful reason
+> to refuse, per `2.2.2.25.2.6` and C-748 resolutivo Cuarto.
+>
+> ADR-0013's _deliberately does not decide_ item 1 is now decided, and the rest of that ADR is
+> confirmed: Reports rooted on a Person, suspension as a retained `persons.status`, and no automatic
+> state transition — the last now doing constitutional work through C-748 §2.6.5.2.6's bar on
+> adverse effects grounded _únicamente_ in a database record.


### PR DESCRIPTION
Resolves #27. Part of #1.

ADR-0008 chose hard delete repo-wide and then stopped at the one table it could not decide for —
`persons`. ADR-0020 built the case file and left the same gap: an erasure request *is* a
`data_requests` row, so the proof of compliance cannot die with its subject.
`docs/research/moderation-record.md` (#31) supplied the law and one defect it could not fix. This
closes all three.

## The load-bearing decisions

**Erasure deletes the row.** Redaction in place was genuinely cheaper — every FK stays valid,
`RESTRICT` never fires, none of the problems below exist — and it loses on a failure mode neither ADR
had named. **Redaction is a denylist; deletion is not.** It means maintaining forever an enumeration
of which columns identify someone, and a column added in 2028 by someone who has not read the ADR is
silently missed. ADR-0017's reflective invariant guards a new *table*; nothing can guard a new
*column* on a row we deliberately keep, because "is this identifying" is a judgement, not a schema
property.

**The proof survives on a keyed HMAC of the email.** `consents.person_id` and
`data_requests.person_id` become nullable; `subject_key` is what outlives the subject. This is also
**the answer to the defect #31 carried forward** — that research argued for keying over a bare digest
because *"a plain SHA of a cédula is brute-forceable"*, reasoning from an identifier this platform
never collects. The argument survives; the input changes to `users.email` per ADR-0009. A
`public_id`-only anchor is cheaper on privacy and was rejected: it answers the regulator and fails the
person, which is the opposite of what ADR-0007 built the evidence for.

**There is no memory of a ban.** #31 recommended a blocklist; this declines to build one. It catches
only a fraudster who reuses their email, ADR-0009 already made re-registration free and unlimited, and
the reason that decides it is that a retained coded fraud reason about a person who asked to be
forgotten is plausibly *dato sensible* under art. 5's open list — which art. 6 then wants explicit
consent for that we will never have. Plus we would have to publish a term no source supports. **v1 has
no ban memory**, which is the gap ADR-0008 already named and the map already schedules against
ADR-0009; it is confirmed rather than patched with a control that does not close it.

**Narrowing is not refusing.** Colombian law has exactly one refusal ground and we can never invoke
it, so self-service erasure always succeeds. The trap recorded for whoever revisits: keeping less is
not saying no, and recording a narrowed erasure as `refused` would put a false statement in the one
record the SIC reads.

**The retention schedule is declared where the table is.** It joins ADR-0017's per-table erasure
classification — one declaration carrying both facts — and the published table in the *política* is
**generated** from it, so the document and the code cannot drift.

## The find

**`verifications` has no foreign key.** The #3 audit records it as a shared bucket keyed by
`identifier`, which for our flows *is the email*. So it holds personal data, is unreachable by cascade,
and **ADR-0017's reflective erasure invariant will never enumerate it** — that test finds tables by
their FK to `persons`. First known hole in the guard, and unlikely to be the last: any future table
holding an email rather than a `person_id` has the same shape. It gets a named assertion of its own.

## Also

- Erasure is **immediate**, with Pause offered at equal visual weight on the confirmation — a
  scheduled-delete row is the soft-delete instinct ADR-0008 banned, wearing a clock.
- **One transaction**, deleting Better Auth rows through a `@repo/auth` module function rather than its
  API. ADR-0007 accepted an orphan window at signup; erasure cannot take that deal against a statutory
  clock.
- An **Offer outlives either side's erasure** — links severed, terms kept, *cuenta eliminada* derived
  from the null. Stripping the erased side's words was rejected as the same denylist that decided the
  first section. Cost named: B holds A's words until the 12-month term expires.
- **The 5-year evidence term is flagged as provisional** — its CPACA art. 52 anchor was not read. #44
  carries the verification, exactly as ADR-0020 filed #41 for the holiday list.

## Amendments

| Doc | Change |
| --- | --- |
| ADR-0008 | completed; `consents.person_id` nullable as it predicted |
| ADR-0013 | Suspension does not survive an erasure; blocklist declined |
| ADR-0015 | `offers.sender_person_id` / `publication_id` nullable |
| ADR-0017 | lifecycle declaration carries both facts; `verifications` unreachable |
| ADR-0020 | inherits the anchor it deferred; gains `refusal_ground` |
| ADR-0007 | stale cross-reference `ADR-0019` → `ADR-0020` (a parallel-session artefact) |
| `CONTEXT.md` | gains **Erasure**; **Suspension**, **Pause**, **Offer** amended |

## Scope

Export **left this ticket** for #42 (post-v1) — the art. 12 *parágrafo* duty is discharged meanwhile by
ADR-0020's operator path, so the right is not deferred, only the button. The art. 17(k) *manual
interno*, homeless since ADR-0020, is specified here and written in #43.

**Departure from the ticket, argued as one:** #27's `## Skills` named `/prototype` for the surface.
This specifies the information architecture instead and hands pixels to #12 and #35 — prototyping
earns its place when *how should it look* is the key question, and ADR-0020 had already fixed the hard
part. Also recorded: the **profile-view audit log** #27 assigned here was already declined twice, by
ADR-0011 and ADR-0013, so it is retired rather than re-decided.
