### PR TITLE
Environments, CI/CD, and migration discipline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,10 +9,17 @@ node_modules
 .git
 .github
 
-# Local configuration only. Staging and production read their values from Fly secrets (ADR-0021),
+# Local configuration only. Staging and production read their values from Fly secrets (ADR-0022),
 # and the build itself needs no DATABASE_URL at all.
+#
+# The `**/` forms are load-bearing rather than belt-and-braces: these patterns match relative to the
+# context root with no implicit recursion, which is why `node_modules` above needed its own `**/`
+# twin. Without them a developer's `apps/web/.env.local` is copied into the build, and `next build`
+# inlines every `NEXT_PUBLIC_*` it finds there into the client bundle that ships in the image.
 .env
 .env.*
+**/.env
+**/.env.*
 
 # Prose and prototypes. The design prototype under apps/landing is a reference to port from, not
 # something the app imports.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Keep the build context to source plus manifests. Anything installed, generated or vendored is
+# rebuilt inside the image, and shipping it in the context only slows the upload and busts layers.
+node_modules
+**/node_modules
+.next
+**/.next
+.turbo
+**/.turbo
+.git
+.github
+
+# Local configuration only. Staging and production read their values from Fly secrets (ADR-0021),
+# and the build itself needs no DATABASE_URL at all.
+.env
+.env.*
+
+# Prose and prototypes. The design prototype under apps/landing is a reference to port from, not
+# something the app imports.
+docs
+apps/landing
+*.md
+LICENSE
+
+# Agent scratch.
+.agents
+.claude
+.research-25
+skills-lock.json

--- a/.github/scripts/with-migration-timeouts.mjs
+++ b/.github/scripts/with-migration-timeouts.mjs
@@ -1,0 +1,41 @@
+/**
+ * Adds ADR-0024's migration timeouts to a Postgres URL, and prints the result.
+ *
+ * `drizzle-kit migrate` builds its pool from `connectionString` alone — `packages/db/
+ * drizzle.config.ts` passes `dbCredentials: { url }`, and drizzle-kit's `pg` path ignores every
+ * other field on that object — so there is no configuration file these can live in. They ride on
+ * the URL, where `pg-connection-string` turns `?options=` into the `options` startup parameter.
+ *
+ * `lock_timeout` is the one that matters. Without it a migration that queues behind a long-running
+ * query does not merely wait: every query arriving afterwards queues *behind the migration*,
+ * because Postgres orders lock requests. That is how a routine index build becomes a full stall.
+ * With it, the migration fails instead — and a failed migration applies nothing at all, because
+ * drizzle-kit wraps the whole batch in one transaction.
+ *
+ * Both numbers are deliberate guesses against an application with no traffic, recorded as such in
+ * ADR-0024's accepted risks. Anything that legitimately needs longer is an out-of-band operation
+ * under that ADR, never a migration.
+ *
+ * Writes only to stdout, so the caller captures it into an environment variable rather than a log.
+ */
+const LOCK_TIMEOUT = "5s";
+const STATEMENT_TIMEOUT = "120s";
+
+const input = process.argv[2];
+
+if (!input) {
+  console.error("usage: with-migration-timeouts.mjs <postgres-url>");
+  process.exit(1);
+}
+
+const url = new URL(input);
+
+// Appended to whatever the connection string already carries, rather than assigned: a URL that
+// already sets `options` is a deliberate act by whoever wrote the secret, and silently discarding
+// it would be worse than the timeouts being absent.
+const existing = url.searchParams.get("options");
+const timeouts = `-c lock_timeout=${LOCK_TIMEOUT} -c statement_timeout=${STATEMENT_TIMEOUT}`;
+
+url.searchParams.set("options", existing ? `${existing} ${timeouts}` : timeouts);
+
+process.stdout.write(url.toString());

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  TURBO_TELEMETRY_DISABLED: "1"
+  # `turbo --affected` compares against `main`/`master`, never the repository's configured default
+  # branch. The trunk here is `dev`, so without this every pull request diffs a stale `main`, skips
+  # nearly every package, and passes for the wrong reason.
+  TURBO_SCM_BASE: origin/dev
+
+jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `--affected` walks history to find the merge base.
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Turborepo's own cache, kept on GitHub rather than Vercel Remote Cache: CI runners are always
+      # cold so caching pays, and this map has priced vendor count carefully everywhere else
+      # (ADR-0022).
+      - uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
+      - name: Format
+        run: pnpm format:check
+
+      # ADR-0017's gate, verbatim. `test` and `db:check` are registered in `turbo.json` and defined
+      # by no package yet, so turbo no-ops them — the command is correct today and needs no edit
+      # when the testing lane lands. It fails if they are *unregistered*, which is why they are.
+      #
+      # `--affected` on pull requests, everything on merge — so a gap in affected-detection surfaces
+      # one merge later instead of in production.
+      - name: Lint, types, tests, migration checks
+        env:
+          AFFECTED: ${{ github.event_name == 'pull_request' && '--affected' || '' }}
+        run: pnpm exec turbo run lint check-types test db:check $AFFECTED
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    # Self-arming. ADR-0017 specifies a coverage comment on every pull request, and the testing lane
+    # it describes is not built. This job starts running the moment the first vitest config exists,
+    # with no edit here.
+    if: github.event_name == 'pull_request' && hashFiles('**/vitest.config.ts') != ''
+    permissions:
+      contents: read
+      # Note: a pull request from a fork receives a read-only token on a public repository, so the
+      # comment step will not post. With no external contributors that is a known edge rather than
+      # a broken pipeline; the fix, when it is needed, is a `workflow_run` job.
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # A root task, run once across all packages, so coverage arrives as one summary rather than
+      # the N that `turbo run test` produces per package (ADR-0017).
+      - name: Coverage
+        run: pnpm exec turbo run coverage
+
+      # Reads the `json-summary` artifact and posts a sticky comment. No external coverage service:
+      # ADR-0017 declines one explicitly, and never gates on the number.
+      - uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,18 +56,27 @@ jobs:
       #
       # `--affected` on pull requests, everything on merge — so a gap in affected-detection surfaces
       # one merge later instead of in production.
+      # Written as two steps rather than one with an interpolated flag: an empty variable either
+      # word-splits (a shellcheck warning) or passes an empty argument to turbo (an error), and
+      # neither is worth the one saved line.
+      - name: Lint, types, tests, migration checks (changed packages)
+        if: github.event_name == 'pull_request'
+        run: pnpm exec turbo run lint check-types test db:check --affected
+
       - name: Lint, types, tests, migration checks
-        env:
-          AFFECTED: ${{ github.event_name == 'pull_request' && '--affected' || '' }}
-        run: pnpm exec turbo run lint check-types test db:check $AFFECTED
+        if: github.event_name != 'pull_request'
+        run: pnpm exec turbo run lint check-types test db:check
 
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    # Self-arming. ADR-0017 specifies a coverage comment on every pull request, and the testing lane
-    # it describes is not built. This job starts running the moment the first vitest config exists,
-    # with no edit here.
-    if: github.event_name == 'pull_request' && hashFiles('**/vitest.config.ts') != ''
+    # Self-arming: every step below is gated on a vitest config existing, so this job is a checkout
+    # and nothing else until #16's testing lane lands, and needs no edit when it does.
+    #
+    # The guard is a step rather than a job-level `if`. `hashFiles()` reads the workspace, which does
+    # not exist before checkout, so GitHub refuses the whole workflow file — zero jobs, and a run
+    # named after the file path.
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       # Note: a pull request from a fork receives a read-only token on a public repository, so the
@@ -76,18 +85,35 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+
+      - id: detect
+        run: |
+          if [ -n "$(find . -name vitest.config.ts -not -path './node_modules/*' -print -quit)" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No vitest config yet — coverage is a no-op until ADR-0017's lane lands." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - uses: pnpm/action-setup@v4
+        if: steps.detect.outputs.present == 'true'
+
       - uses: actions/setup-node@v4
+        if: steps.detect.outputs.present == 'true'
         with:
           node-version-file: .nvmrc
           cache: pnpm
+
       - run: pnpm install --frozen-lockfile
+        if: steps.detect.outputs.present == 'true'
 
       # A root task, run once across all packages, so coverage arrives as one summary rather than
       # the N that `turbo run test` produces per package (ADR-0017).
       - name: Coverage
+        if: steps.detect.outputs.present == 'true'
         run: pnpm exec turbo run coverage
 
       # Reads the `json-summary` artifact and posts a sticky comment. No external coverage service:
       # ADR-0017 declines one explicitly, and never gates on the number.
       - uses: davelosert/vitest-coverage-report-action@v2
+        if: steps.detect.outputs.present == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,14 @@ permissions:
 env:
   TURBO_TELEMETRY_DISABLED: "1"
   # `turbo --affected` compares against `main`/`master`, never the repository's configured default
-  # branch. The trunk here is `dev`, so without this every pull request diffs a stale `main`, skips
-  # nearly every package, and passes for the wrong reason.
-  TURBO_SCM_BASE: origin/dev
+  # branch. The trunk here is `dev`, so a hardcoded default would make every pull request diff a
+  # stale `main`, skip nearly every package, and pass for the wrong reason.
+  #
+  # Derived from the event rather than fixed, because the base is not always `dev`. On the
+  # `dev` → `main` promotion pull request — the one that ships to production — a fixed `origin/dev`
+  # would diff `dev` against itself, find zero affected packages, and report success having run no
+  # lint, no type-check and no `db:check` at all.
+  TURBO_SCM_BASE: origin/${{ github.base_ref || 'dev' }}
 
 jobs:
   gate:
@@ -29,7 +34,7 @@ jobs:
           # `--affected` walks history to find the merge base.
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:
@@ -95,7 +100,7 @@ jobs:
             echo "No vitest config yet — coverage is a no-op until ADR-0017's lane lands." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         if: steps.detect.outputs.present == 'true'
 
       - uses: actions/setup-node@v4
@@ -115,5 +120,5 @@ jobs:
 
       # Reads the `json-summary` artifact and posts a sticky comment. No external coverage service:
       # ADR-0017 declines one explicitly, and never gates on the number.
-      - uses: davelosert/vitest-coverage-report-action@v2
+      - uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2
         if: steps.detect.outputs.present == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 # ─────────────────────────────────────────────────────────────────────────────────────────────────
 # DISARMED. The `push` triggers are commented out and this workflow has never run.
 #
-# Nothing it needs exists yet: no Fly app, no PlanetScale database, none of the three secrets.
+# Nothing it needs exists yet: no Fly app, no PlanetScale database, none of the secrets.
 # `docs/runbook.md` carries the provisioning checklist that creates them.
 #
 # TO ARM: uncomment the `push:` block. That is the whole change — step 9 of the checklist.
@@ -21,10 +21,14 @@ on:
   #   branches: [dev, main]
 
 concurrency:
-  # One deploy at a time per ref. Cancelling in flight is wrong here: a cancelled job could stop
-  # between the migration and the deploy, which is the one window ADR-0024's ordering exists to keep
-  # short.
-  group: deploy-${{ github.ref }}
+  # Keyed on the target environment, not on `github.ref`. Two runs deploying the same environment
+  # from different refs would otherwise land in different groups and run `drizzle-kit migrate`
+  # concurrently — and drizzle-kit takes no advisory lock, so both would read `__drizzle_migrations`,
+  # both would decide the same migrations are pending, and the loser would fail part-way.
+  #
+  # Cancelling in flight is wrong here: a cancelled job could stop between the migration and the
+  # deploy, which is the one window ADR-0024's ordering exists to keep short.
+  group: deploy-${{ inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
   cancel-in-progress: false
 
 permissions:
@@ -45,16 +49,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Log in to the Fly registry
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_PRODUCTION_TOKEN }}
         run: flyctl auth docker
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -65,6 +69,10 @@ jobs:
   # Manual, deliberately (ADR-0022). Staging is a rehearsal surface, and a rehearsal nobody chose to
   # run is noise — every merge to `dev` deploying it would make the environment something that
   # happens to you rather than something you use.
+  #
+  # This job is dispatchable from any branch on purpose: rehearsing an unmerged branch is the point.
+  # That is only safe because its token reaches `encuentra-staging` alone, and because the database
+  # it migrates holds no real person (ADR-0022's seeding rule).
   staging:
     name: Staging
     if: github.event_name == 'workflow_dispatch' && inputs.environment == 'staging'
@@ -72,13 +80,23 @@ jobs:
     environment: staging
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
+
+      - name: Resolve the image digest
+        id: image
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_STAGING_TOKEN }}
+        run: |
+          flyctl auth docker
+          digest=$(docker buildx imagetools inspect "registry.fly.io/encuentra:$GITHUB_SHA" \
+            --format '{{.Manifest.Digest}}')
+          echo "ref=registry.fly.io/encuentra@$digest" >> "$GITHUB_OUTPUT"
 
       # Migrate, then deploy — always, in that order (ADR-0024). Old code against a new additive
       # schema is safe by construction; new code against an old schema is not.
@@ -87,48 +105,73 @@ jobs:
       # leaves the database untouched and the deploy simply does not happen.
       - name: Migrate
         env:
-          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
-        run: pnpm db:migrate
+          BASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: |
+          DATABASE_URL="$(node .github/scripts/with-migration-timeouts.mjs "$BASE_URL")" \
+            pnpm db:migrate
 
       - name: Deploy
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl deploy --config fly.staging.toml --image registry.fly.io/encuentra:${{ github.sha }}
+          FLY_API_TOKEN: ${{ secrets.FLY_STAGING_TOKEN }}
+        run: flyctl deploy --config fly.staging.toml --image ${{ steps.image.outputs.ref }}
 
   # Automatic on merge to `main` (ADR-0022). **The fast-forward merge is the human act** — nothing
   # advances `main` by accident — so a separate approval click would be ceremony in front of a
   # decision already taken.
   #
-  # `environment: production` stays for secret scoping and the deployment record. Attaching a
-  # required reviewer to it would re-introduce the pause this shape deliberately removed.
+  # The `workflow_dispatch` arm is restricted to `main` as well. Without that check, anyone with
+  # write access could select a feature branch in the Actions UI, choose `production`, and run
+  # `drizzle-kit migrate` against the live database using DDL that was never reviewed and never
+  # merged — a path that reaches production without `main` being involved at all, which is precisely
+  # what the "the merge is the gate" argument depends on not existing.
   production:
     name: Production
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-      || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
+      github.ref == 'refs/heads/main'
+      && (github.event_name == 'push' || inputs.environment == 'production')
     runs-on: ubuntu-latest
     environment: production
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
+
+      # **Before the migration, not after.** This resolves the tag the `build` job pushed when this
+      # same commit merged to `dev`, and fails if it is absent — which means the commit reached
+      # `main` without ever having been built. Verifying that after Migrate would leave production
+      # carrying a new schema with the old image still serving, a state no runbook procedure covers.
+      #
+      # Resolving to a digest also makes ADR-0022's promotion property enforced rather than asserted:
+      # the deploy names immutable bytes instead of a tag a re-run could have moved.
+      - name: Resolve the image digest
+        id: image
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_PRODUCTION_TOKEN }}
+        run: |
+          flyctl auth docker
+          digest=$(docker buildx imagetools inspect "registry.fly.io/encuentra:$GITHUB_SHA" \
+            --format '{{.Manifest.Digest}}')
+          echo "ref=registry.fly.io/encuentra@$digest" >> "$GITHUB_OUTPUT"
 
       # Connects as the `migrator` role, which holds DDL rights and cannot read a profile. The app's
       # own credential, held in Fly secrets, cannot drop a table (ADR-0022).
+      #
+      # The timeouts are ADR-0024's control, and they have to ride on the URL: drizzle-kit builds its
+      # pool from `connectionString` alone and ignores every other `dbCredentials` field, so there is
+      # no config-file place to put them.
       - name: Migrate
         env:
-          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
-        run: pnpm db:migrate
+          BASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          DATABASE_URL="$(node .github/scripts/with-migration-timeouts.mjs "$BASE_URL")" \
+            pnpm db:migrate
 
-      # No build step: this tag was pushed by the `build` job when the same commit merged to `dev`.
-      # A missing tag fails here loudly, which is the correct outcome — it means the commit reached
-      # `main` without ever having been built.
       - name: Deploy
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl deploy --image registry.fly.io/encuentra:${{ github.sha }}
+          FLY_API_TOKEN: ${{ secrets.FLY_PRODUCTION_TOKEN }}
+        run: flyctl deploy --image ${{ steps.image.outputs.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,134 @@
+name: Deploy
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+# DISARMED. The `push` triggers are commented out and this workflow has never run.
+#
+# Nothing it needs exists yet: no Fly app, no PlanetScale database, none of the three secrets.
+# `docs/runbook.md` carries the provisioning checklist that creates them.
+#
+# TO ARM: uncomment the `push:` block. That is the whole change — step 9 of the checklist.
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to deploy (the image must already exist for this commit)
+        type: choice
+        options: [staging, production]
+        default: staging
+  # push:
+  #   branches: [dev, main]
+
+concurrency:
+  # One deploy at a time per ref. Cancelling in flight is wrong here: a cancelled job could stop
+  # between the migration and the deploy, which is the one window ADR-0024's ordering exists to keep
+  # short.
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Builds on merge to `dev` and deploys nothing.
+  #
+  # This job is what keeps ADR-0022's promotion property alive now that staging is deployed by hand.
+  # The image is tagged with the commit SHA, and because `main` only ever fast-forwards to a commit
+  # that already exists on `dev`, that tag is still there when production deploys — so **production
+  # deploys an image it did not build**, and staging, whenever someone chooses to deploy it, deploys
+  # that same one.
+  build:
+    name: Build image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Log in to the Fly registry
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl auth docker
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: registry.fly.io/encuentra:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Manual, deliberately (ADR-0022). Staging is a rehearsal surface, and a rehearsal nobody chose to
+  # run is noise — every merge to `dev` deploying it would make the environment something that
+  # happens to you rather than something you use.
+  staging:
+    name: Staging
+    if: github.event_name == 'workflow_dispatch' && inputs.environment == 'staging'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      # Migrate, then deploy — always, in that order (ADR-0024). Old code against a new additive
+      # schema is safe by construction; new code against an old schema is not.
+      #
+      # `drizzle-kit migrate` applies every pending migration in one transaction, so a failure here
+      # leaves the database untouched and the deploy simply does not happen.
+      - name: Migrate
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: pnpm db:migrate
+
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --config fly.staging.toml --image registry.fly.io/encuentra:${{ github.sha }}
+
+  # Automatic on merge to `main` (ADR-0022). **The fast-forward merge is the human act** — nothing
+  # advances `main` by accident — so a separate approval click would be ceremony in front of a
+  # decision already taken.
+  #
+  # `environment: production` stays for secret scoping and the deployment record. Attaching a
+  # required reviewer to it would re-introduce the pause this shape deliberately removed.
+  production:
+    name: Production
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      # Connects as the `migrator` role, which holds DDL rights and cannot read a profile. The app's
+      # own credential, held in Fly secrets, cannot drop a table (ADR-0022).
+      - name: Migrate
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: pnpm db:migrate
+
+      # No build step: this tag was pushed by the `build` job when the same commit merged to `dev`.
+      # A missing tag fails here loudly, which is the correct outcome — it means the commit reached
+      # `main` without ever having been built.
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --image registry.fly.io/encuentra:${{ github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,14 @@ script** — an init script runs only on a brand-new volume and has no counterpa
 **PlanetScale does not restore extensions from a backup, and `pnpm db:migrate` will not fix that**:
 a restore also brings back `drizzle.__drizzle_migrations`, which already lists migration `0000` as
 applied, so the runner reports nothing to do while `pg_trgm` and `unaccent` are missing. Post-restore
-recovery means running those `CREATE EXTENSION` statements explicitly — a runbook step #15 owns.
+recovery means running those `CREATE EXTENSION` statements explicitly — **`docs/runbook.md` procedure
+2**.
+
+**`drizzle-kit migrate` applies every pending migration inside one transaction** (ADR-0024). A failed
+run leaves the database untouched, `drizzle.__drizzle_migrations` included, so there is nothing to
+unpick — read the error and fix forward. Two things follow: **`CREATE INDEX CONCURRENTLY` can never
+appear in a migration** (Postgres refuses it inside a transaction block), and **a backfill over ~10,000
+rows is a batched script, not a migration**. Both are out-of-band operations, and v1 has neither.
 
 **Migrations are append-only, and destructive changes take two releases** (ADR-0017; `pnpm db:check`
 enforces all three, though it is not built yet):
@@ -81,7 +88,36 @@ enforces all three, though it is not built yet):
   and `RENAME` are destructive. A migration containing one needs a marker naming the earlier migration
   that made it safe — `-- destructive: completes 0014_add_nullable_x` — and that migration must
   **already be on `dev`**. Under ADR-0005's rolling deploy, old and new code share one schema, so the
-  expand and the contract are two releases and may not share a pull request.
+  expand and the contract are two releases and may not share a pull request. **Two is the floor: a
+  removal that carries data needs three** — expand, then backfill-and-switch, then contract — and only
+  ADR-0024 says so, because the gate cannot see it.
+
+### Deploying
+
+Decided in **ADR-0022** and **ADR-0024**, and **nothing is provisioned**: no Fly app, no PlanetScale
+database, no secrets. `.github/workflows/deploy.yml` ships disarmed and names the one edit that arms
+it; `docs/runbook.md` carries the checklist that must run first.
+
+`dev` is the trunk. **Merging to it builds the image and deploys nothing**; **staging is deployed by
+hand** (`workflow_dispatch`); production deploys **automatically** on a **fast-forward merge of `dev`
+into `main`**, with no approval prompt — **the merge is the gate**. The fast-forward is load-bearing:
+it keeps the `dev`-built image addressable, so **production deploys an image it did not build**. A
+squash or a merge commit breaks that, which is why the merge strategy is not a preference.
+
+**Migrate first, then deploy**, always, on the CI runner as a `migrator` role distinct from the app's.
+Rolling back means redeploying a previous image digest and then `git revert` on `main` in the same
+session; **the schema never rolls back**, because `drizzle-kit` has no `down` and expand/contract makes
+one unnecessary. A restore is data-loss recovery, never a rollback.
+
+**`docs/runbook.md`** holds the executable procedures — migration failure, missing extensions after a
+restore, code rollback, machine OOM, health-check-passes-but-site-down, data loss and the 24-hour RPO,
+reindex after a major-version move, spend check — plus the provisioning checklist.
+
+`turbo.json` registers `test`, `db:check` and ADR-0017's `transit` node. **No package defines the first
+two yet, and that is fine**: turbo errors on an unregistered task and no-ops a registered one nothing
+implements, so the real gate command runs green today and needs no edit when the testing lane lands.
+CI also needs `TURBO_SCM_BASE=origin/dev` — `--affected` compares against `main`/`master`, never the
+configured default branch.
 
 ### Testing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@
 
 # Debian slim, not Alpine. `docker-compose.yml` already rejected musl for Postgres on locale
 # grounds; for Node the reason differs but points the same way — Next.js ships native SWC binaries
-# built against glibc, and the musl variants are the less-travelled path. The image is deployed to
-# Fly and never built there (ADR-0022), so build-stage size costs nothing at runtime.
-FROM node:24-slim AS base
+# built against glibc, and the musl variants are the less-travelled path.
+#
+# Pinned by digest as well as version, matching how `docker-compose.yml` pins Postgres to an exact
+# patch. A floating `node:24-slim` would make "one artifact, promoted" false at the layer that
+# carries the whole runtime OS: the same commit would build a different image tomorrow, and no
+# record would say which base a given release shipped — which is the question a CVE forces.
+FROM node:24.19.0-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Non-interactive pnpm. Without it, `pnpm install` stops on the "modules directories will be removed
@@ -33,8 +37,20 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm exec turbo run build --filter=web
 
 # ---- runner -------------------------------------------------------------------------------------
-FROM base AS runner
+# **From the base image, not from `base`.** Extending `base` would replay `corepack enable` and ship
+# pnpm's shims in the runtime image, which is the opposite of what the traced standalone output is
+# for: an RCE in the Next server would find a working package manager and a network fetch path
+# waiting for it. The package managers Node's own image bundles are removed for the same reason —
+# `server.js` needs the runtime, never the installer.
+FROM node:24.19.0-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS runner
 WORKDIR /app
+
+# yarn is removed alongside npm because Node's Debian image installs it separately, under /opt with
+# symlinks in /usr/local/bin — so removing the npm tree alone leaves a working package manager
+# behind and makes the claim above false.
+RUN rm -rf /usr/local/lib/node_modules/npm /opt/yarn-v* \
+  /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+  /usr/local/bin/yarn /usr/local/bin/yarnpkg
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -46,9 +62,9 @@ ENV HOSTNAME=0.0.0.0
 RUN groupadd --system --gid 1001 nodejs \
   && useradd --system --uid 1001 --gid nodejs nextjs
 
-# `output: "standalone"` emits a server carrying only the modules the build traced, so no install
-# runs here and no package manager is present in the final image. In a workspace it preserves the
-# repo layout, which is why the entrypoint is nested under `apps/web`.
+# `output: "standalone"` emits a server carrying only the modules the build traced, so nothing is
+# installed here. In a workspace it preserves the repo layout, which is why the entrypoint is nested
+# under `apps/web`.
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/public ./apps/web/public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+
+# Debian slim, not Alpine. `docker-compose.yml` already rejected musl for Postgres on locale
+# grounds; for Node the reason differs but points the same way — Next.js ships native SWC binaries
+# built against glibc, and the musl variants are the less-travelled path. The image is deployed to
+# Fly and never built there (ADR-0022), so build-stage size costs nothing at runtime.
+FROM node:24-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+# Non-interactive pnpm. Without it, `pnpm install` stops on the "modules directories will be removed
+# and reinstalled" confirmation, which auto-answers in a non-TTY and then exits having installed
+# nothing — leaving `turbo` missing a layer later, with no error.
+ENV CI=true
+# pnpm's store defaults to ~/.local/share/pnpm/store, not $PNPM_HOME. Naming it explicitly is what
+# lets the BuildKit cache mount below actually hit it.
+ENV npm_config_store_dir="/pnpm/store"
+RUN corepack enable
+
+# ---- builder ------------------------------------------------------------------------------------
+# One stage, and a cache mount rather than a separate fetch stage. The pnpm-recommended
+# `pnpm fetch` + `--offline` split needs the store to survive between two stages, which a BuildKit
+# cache mount does not reliably do; the mount alone keeps the expensive part — the downloads —
+# warm across builds, which is the benefit that was actually wanted.
+FROM base AS builder
+WORKDIR /repo
+
+COPY . .
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+# No DATABASE_URL, deliberately. `packages/db/src/client.ts` builds its pool lazily precisely so a
+# build that never queries succeeds without one — which is what keeps a database credential out of
+# the image build entirely.
+RUN pnpm exec turbo run build --filter=web
+
+# ---- runner -------------------------------------------------------------------------------------
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+# Bind all interfaces: Fly routes to the machine's private address, and Next's default of localhost
+# would answer only itself.
+ENV HOSTNAME=0.0.0.0
+
+RUN groupadd --system --gid 1001 nodejs \
+  && useradd --system --uid 1001 --gid nodejs nextjs
+
+# `output: "standalone"` emits a server carrying only the modules the build traced, so no install
+# runs here and no package manager is present in the final image. In a workspace it preserves the
+# repo layout, which is why the entrypoint is nested under `apps/web`.
+COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/public ./apps/web/public
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,12 @@
+/**
+ * Readiness probe for Fly's health check (ADR-0022).
+ *
+ * **It does not touch the database, deliberately.** `docs/research/observability.md` records that
+ * Fly health checks gate routing and notify nobody, so a database-dependent probe would turn a
+ * transient connection blip into a machine that stops receiving traffic — silently, and under
+ * autostop, into a restart loop. UptimeRobot is the monitor; this endpoint answers only "is the
+ * process up and serving".
+ */
+export function GET(): Response {
+  return Response.json({ status: "ok" });
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  // ADR-0022: the app ships as a container to Fly. Standalone traces the module graph and emits a
+  // server carrying only what it reaches, so the runtime image needs no install and no package
+  // manager. Without this the Dockerfile has nothing to copy.
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
+++ b/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
@@ -128,6 +128,19 @@ point `planetscale-postgres-safety-review` raises against the default role, and 
 time: rotating the application credential does not break CI, and revoking CI's does not take the
 site down.
 
+**Every deploy credential is an _environment_ secret, never a repository secret.** A repository
+secret is readable by every job in every workflow on every branch, which would make the
+`environment:` key on each job scope precisely nothing — the manually-dispatchable `staging` job
+could name `PRODUCTION_DATABASE_URL`, and so could any workflow file added on any branch. The
+scoping is the control; the `environment:` key only expresses it.
+
+**Fly gets two app-scoped deploy tokens rather than one org token**, for the same reason and with
+one honest exception. An org token deploys anything in the organisation, so the `staging` job —
+dispatchable from any branch by design — would hold a credential that can destroy production.
+Splitting them means it cannot. The exception is the `build` job: Fly's registry is namespaced per
+app, so pushing `registry.fly.io/encuentra:…` requires the production app's token, and no
+arrangement of tokens avoids that while the image is built once and promoted.
+
 ## Staging is public, and one earlier decision is what makes that safe
 
 Staging serves the same public Wall as production, on a `*.fly.dev` hostname, with `noindex` and a
@@ -205,7 +218,21 @@ the §6.3 processor register.
 ## Accepted risks
 
 - **A production database credential lives in GitHub Actions secrets**, mitigated by the `migrator`
-  role and not eliminated. A compromised Actions token is a DDL-capable connection to production.
+  role and environment scoping, and not eliminated. A compromised Actions token is a DDL-capable
+  connection to production.
+- **The `build` job holds a production-scoped Fly token.** Fly's registry is per-app, so the job that
+  runs on every merge to `dev` can also deploy production. Unavoidable while one image is built and
+  promoted; the alternative — building twice — costs the property this ADR is named for.
+- **Third-party actions are pinned to commit SHAs; `actions/*` are left on major tags.** That is the
+  mainstream line and it is a judgement, not a proof: a compromise of GitHub's own action
+  organisation would still reach the `production` job's runner, where the migrator credential lives.
+- **Blue-green promotes a release the health check cannot fail.** `/api/health` never touches the
+  database, which is right in steady state — a blip must not de-route a healthy machine or, under
+  autostop, start a restart loop — but blue-green uses that same probe to decide whether the _new_
+  version is good. A release with a wrong `DATABASE_URL` or an unreachable database answers
+  `{"status":"ok"}`, passes, and replaces the version that was working. A deploy-only check that
+  does verify connectivity would close this; it is deliberately not in v1 because the probe's
+  steady-state behaviour is the one that runs continuously.
 - **Blue-green deployment on a single-machine app is unverified.** It briefly runs two machines,
   which is correct for expand/contract and which also means ADR-0009's in-memory rate limiter is a
   no-op for the duration of a deploy. `immediate` is the fallback if it fights

--- a/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
+++ b/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
@@ -1,0 +1,259 @@
+# Two environments, one artifact, one human gate
+
+Issue #15 asked how code gets from a pull request to production. Most of the mechanism was already
+fixed elsewhere and is recorded here only so nobody reopens it: ADR-0005 puts a long-lived Node
+server on Fly.io in `iad` and states in its consequences that **`drizzle-kit` migrations run on a CI
+runner against the direct 5432 connection string** — the same answer on both candidate hosts, so
+settled independently of the host choice. ADR-0004 bought two PS-5 Postgres databases in
+`us-east-1`. ADR-0017 fixed the pull-request gate as `turbo run lint check-types test db:check` and
+built the destructive-migration check, leaving the workflow file and the deploy gates here. The
+migration half of this ticket is ADR-0024; this ADR is the environments and the pipeline around it.
+
+Nothing is deployed and nothing is provisioned. The `workforpereira` PlanetScale organisation was
+created on 2026-08-16 and holds **zero databases**, with no payment method. `apps/web` is still the
+`create-turbo` scaffold. So every decision here is written for an application that does not exist —
+cheap now, expensive later, exactly as ADR-0017 said of the testing conventions.
+
+## `dev` is the trunk, `main` is what is running
+
+`dev` is the default branch. Merging to it **builds the image and deploys nothing**. **Staging is
+deployed by hand**, from that image, whenever someone wants to rehearse against it. Production is a
+**fast-forward merge of `dev` into `main`**, and `main` deploys **automatically**.
+
+The alternative was release tags. `main` already exists and does nothing, and a branch buys one
+thing a tag does not: _what is in production_ becomes a git ref you can `git log`, diff and revert,
+rather than a deploy history you must open a vendor dashboard to read. For a solo developer with no
+second pair of eyes, the environment that can be inspected with the tool already open wins.
+
+**The fast-forward is load-bearing, not stylistic.** Because `main` only ever advances to a commit
+that already exists on `dev`, the image built when that commit merged to `dev` is still addressable
+when it merges to `main`. So production **deploys an image it did not build**, with no rebuild —
+the same one staging ran, if staging was run at all. "It worked on staging" stops being a claim
+about a build and becomes a statement about the same bytes. A merge commit, a squash, or a
+cherry-pick all break this by producing a SHA that was never built, which is why the merge strategy
+is part of the decision rather than a preference.
+
+**This is also why merging to `dev` still builds.** Nothing is deployed by that merge, and building
+an image for an environment nobody may deploy looks like waste — but it is what keeps the promotion
+property true once staging is manual. Building on `main` instead would mean production compiled its
+own artifact, and the guarantee would quietly become a claim about a Dockerfile rather than about
+bytes. Actions is free on a public repository, so the build costs wall-clock and nothing else.
+
+## The merge is the gate
+
+Staging is deployed by hand and gated by nobody. Production deploys automatically on merge to
+`main`, and `environment: production` exists for secret scoping and the deployment record rather
+than for a pause.
+
+`planetscale-postgres-safety-review` asks for _"an explicit human-approved deployment step"_ before
+production DDL, and this satisfies it — **the fast-forward merge into `main` is that step.** Nothing
+advances `main` by accident: it is a deliberate act, taken by the one person who would also have
+clicked the approval, on a change they wrote. Layering a reviewer prompt in front of it would ask
+the same human to confirm a decision they had just made thirty seconds earlier, which is the shape
+of gate that gets clicked without reading — and a gate that is always approved is worse than no
+gate, because the record says a human considered it.
+
+The position still matters, and is unchanged: ADR-0024 applies migrations **before** the deploy, and
+a migration is the only step in this pipeline that cannot be undone by redeploying something. The
+deliberate act therefore sits in front of the one action with no inverse.
+
+**The honest cost is that the window between deciding and deploying is now zero**, so a merge to
+`main` made in error reaches production before it can be reconsidered. That is survivable only
+because rolling back is cheap and well-drilled — a previous image digest plus a revert, runbook
+procedure 3 — and because ADR-0024 means the schema does not move when it happens. If either of
+those stops being true, this is the first decision to reopen; attaching a required reviewer to the
+`production` environment is a one-setting change and needs no ADR to undo.
+
+## 512 MB, which ADR-0005 could not have known
+
+Both machines are **512 MB `shared-cpu-1x`** with a Fly swap file, staging autostopped
+(`min_machines_running = 0`).
+
+ADR-0005 costed Fly at $6.50–9.50/month for the pair and recorded, as an accepted risk, that the
+1 GB machine size behind those numbers was **an unverified assumption** — _"at 512 MB Fly is cheaper
+than Cloudflare and at 2 GB clearly worse, so the margin is sensitive to a number we have not
+measured."_ It still is unmeasured, because there is no application. What has changed is that the
+image is built in GitHub Actions and pushed to Fly's registry, so **the machine never compiles
+anything** and its memory ceiling is a runtime question about a Next.js Node server rather than a
+build question. At `observability.md`'s own $3.19/machine in `iad`, the pair lands near $3.70–4.20
+against the $6.50–9.50 assumed, which _creates_ headroom against #18's real remainder of
+$4.46–$7.46 rather than spending it.
+
+This is deliberately the reversible direction. Resizing up is a `fly.toml` line and a redeploy;
+Fly's free managed Prometheus already exposes the memory graph that would justify it. Starting at
+1 GB and never revisiting is the failure mode that costs money silently for a year.
+
+## Staging exists, and it is not a luxury
+
+Staging is the cheapest half of the pair — a suspended machine and a database ADR-0004 already
+bought — and the temptation for a solo developer is to skip it.
+
+It stays because **it is the only place PlanetScale-specific behaviour is exercised at all.**
+ADR-0017 lists what v1 deliberately does not test and names PlanetScale explicitly: _"Traffic
+Control, its extension set, its backup semantics."_ PGlite cannot reach any of them, and the local
+Docker Postgres is an ordinary `postgres:18.6-trixie` with no vendor behaviour in it. Without
+staging, the first contact between this application and its actual production database vendor would
+be production. The restore drill in ADR-0024 and the extension hazard in
+`0000_enable_extensions.sql` both need somewhere to be rehearsed, and this is it.
+
+## No preview environments, and the reason is not only money
+
+Pull requests get no ephemeral environment.
+
+Three things stack. PlanetScale branching is **paid**, which ADR-0004 accepted as a named risk, so a
+preview needs either a billed branch or a database that is not the real thing. A preview app is a
+third billed Machine. And ADR-0017 already gives every pull request a real Postgres through
+PGlite-over-socket, which is the part that catches defects.
+
+What is left that a preview URL adds is a human looking at a rendered page — and the human who would
+look is the author, who has `pnpm dev`. Revisit when there is a second person; the reason will have
+changed, and so should the answer.
+
+## Three holders of secrets, and the one that is uncomfortable
+
+- **Local** — the repo-root `.env`, gitignored, holding only the throwaway credentials of a
+  container bound to loopback. Unchanged from #17.
+- **Runtime** — `fly secrets`, the only place a real credential lives at rest.
+- **CI** — GitHub Actions secrets, holding exactly three values: `FLY_API_TOKEN`, and a staging and
+  a production `DATABASE_URL`.
+
+That third holder is the consequence worth stating plainly rather than discovering: **because
+migrations run on the CI runner, GitHub necessarily holds a production database credential.** No
+arrangement of this pipeline avoids it while ADR-0005's consequence stands.
+
+What makes it tolerable is **two roles per database rather than one**. The application connects as
+`app` with DML rights; CI connects as `migrator` with DDL rights. The credential CI holds cannot
+read a profile; the credential the application holds cannot drop a table. This is the least-privilege
+point `planetscale-postgres-safety-review` raises against the default role, and it pays a second
+time: rotating the application credential does not break CI, and revoking CI's does not take the
+site down.
+
+## Staging is public, and one earlier decision is what makes that safe
+
+Staging serves the same public Wall as production, on a `*.fly.dev` hostname, with `noindex` and a
+`robots.txt` and nothing else in front of it.
+
+ADR-0011 set a standing rule that reads like a prohibition on this: _"anything reachable without a
+session is permanently public and assumed scraped"_, and that `robots.txt`/`noindex` are **never**
+privacy controls. That rule is about **personal data**, and staging has none — this ticket made
+"production personal data never leaves production" a hard rule, so staging is seeded from a
+generator and holds no `Person` who exists.
+
+The coupling is the point. **Staging's openness is safe only because of the seeding rule**, and the
+two must be read together. Restoring a production dump into staging to reproduce a bug would be a
+breach in the same instant, and after ADR-0010 that dump carries **photographs**, which are art. 5
+sensitive data. There is also no _finalidad_ covering a copy of production into a second
+environment. So the seeding rule is not hygiene; it is the control, and it is why staging needs no
+gate of its own.
+
+The residue — a second surface that looks like _publicación de vacantes_ for #23's SPE question — is
+what `noindex` and `robots.txt` are actually for here: distribution, which is the only job ADR-0011
+ever gave them.
+
+## Temporary URLs, and a launch gate that was not visible before
+
+Both environments use their `*.fly.dev` hostnames. There is no custom domain and no Cloudflare zone.
+
+That is right for a repository with no application in it, and it moves something that should be
+recorded rather than absorbed. **Two decisions taken elsewhere are specified as Cloudflare edge
+mechanisms and have nowhere to live until a zone exists:**
+
+- ADR-0005's _"put Cloudflare's free CDN in front of the Fly origin"_ — the one portable finding #25
+  produced.
+- ADR-0011's anti-scraping requirement and ADR-0014's rate limiter for public Need search. ADR-0011
+  calls this a **launch requirement** in terms that leave no room: _"without a rate limit,
+  sample-not-index is a claim rather than a control"_, and its whole Ley 1581 posture rests on that
+  control being real.
+
+So **the custom domain is a launch gate, not a cosmetic step.** No zone, no edge; no edge, no
+anti-scraping control; no control, and ADR-0011's central argument is unbacked. Naming it here is
+cheaper than rediscovering it the week before launch.
+
+The CDN is **production-only** when it arrives. Staging is a test environment kept at the lowest
+cost that works, and caching it would add a variable to the one place whose job is to have fewer of
+them.
+
+## The developer loop stays in CI
+
+**No Husky, no lint-staged, no pre-commit hook.** The gate is ADR-0017's and it belongs where it
+cannot be bypassed with `--no-verify`. A hook running type-check and tests across ADR-0006's ten
+packages is slow enough that it will be bypassed, and lint-staged's real value — running the
+formatter over staged files only — evaporated with ADR-0019, since oxfmt formats the entire
+repository in well under a second.
+
+**The turbo cache is `actions/cache` on `.turbo`, not Vercel Remote Cache.** CI runners are always
+cold, so caching genuinely pays; but this map has priced vendor count carefully in every other
+decision, and a GitHub-native cache gets the same benefit with no account, no token and no row in
+the §6.3 processor register.
+
+## What this ticket found while answering
+
+- **`turbo --affected` compares against `main`/`master`, not the repository's configured default
+  branch.** The trunk here is `dev`, so every CI run needs `TURBO_SCM_BASE=origin/dev`. Without it
+  `--affected` diffs against a stale `main` and skips nearly everything, silently and green.
+- **Turbo errors on tasks that are not registered in `turbo.json`, and no-ops on registered tasks no
+  package defines.** So ADR-0017's gate command `turbo run lint check-types test db:check` fails
+  today for the wrong reason — `test` and `db:check` are unregistered, not merely unimplemented.
+  Registering them, with ADR-0017's `transit` node, makes the real gate command run green now and
+  need no edit when the test lane lands. Verified: six tasks, six successful.
+- **PlanetScale has invoice budget alerts, and this organisation's are off.** ADR-0005 and
+  `observability.md` are right that neither vendor offers a hard spend _cap_ — Fly's own docs say
+  _"we don't support billing alerts (yet)"_ — but PlanetScale carries an `invoice_budget_amount`
+  with alerts, set to `$20` on this account's two other organisations and to **`$0.00` with alerts
+  disabled** on `workforpereira`. It is free and it is the only spend signal either vendor gives.
+
+## Accepted risks
+
+- **A production database credential lives in GitHub Actions secrets**, mitigated by the `migrator`
+  role and not eliminated. A compromised Actions token is a DDL-capable connection to production.
+- **Blue-green deployment on a single-machine app is unverified.** It briefly runs two machines,
+  which is correct for expand/contract and which also means ADR-0009's in-memory rate limiter is a
+  no-op for the duration of a deploy. `immediate` is the fallback if it fights
+  `min_machines_running = 0`.
+- **512 MB is a guess against an application that does not exist**, in the direction that is cheap
+  to correct.
+- **Staging has no gate**, and its safety is entirely inherited from the seeding rule. That is one
+  rule between an open surface and a breach.
+- **There is no pause between deciding to ship and shipping.** A merge to `main` reaches production
+  with nothing in between, so a mistaken merge is a production deploy. Mitigated by cheap, drilled
+  rollback and by the schema never moving, not removed.
+- **Staging can go stale, and nothing says so.** Deploying it is now a choice, which means the
+  default is that nobody makes it — so the rehearsal surface this ADR argues is not a luxury is the
+  one thing most likely to be skipped. A staging that has not been deployed in weeks proves nothing
+  about the release it was meant to de-risk.
+- **The custom domain is a launch gate with no owner and no date.** It blocks a control ADR-0011
+  calls a launch requirement.
+- **PS-5's connection ceiling was never read.** The application connects direct on 5432 with a pool
+  of 5, which is the right shape for one long-lived Node server, but the ceiling is unverified.
+
+## Consequences
+
+- **`turbo.json` registers `test`, `db:check` and ADR-0017's `transit` node.** This is implementing a
+  closed decision rather than making a new one, and it is what lets `ci.yml` carry the real gate
+  command from its first run.
+- **`.github/workflows/ci.yml` ships green.** `deploy.yml` ships **disarmed** — its `push` triggers
+  commented out — because nothing is provisioned. Arming it is one documented edit, named in the
+  file. Its three jobs are asymmetric on purpose: `build` on merge to `dev`, `staging` on manual
+  dispatch only, `production` on merge to `main`.
+- **The `production` GitHub Environment carries no required reviewer.** It exists for secret scoping
+  and the deployment record. Adding a reviewer is a one-setting change if the no-pause risk above
+  ever bites.
+- **`next.config.ts` gains `output: "standalone"`**, without which the Dockerfile cannot be built.
+- **ADR-0004's "$15 remaining" was already corrected by #18 to $4.46–$7.46; this ADR moves it up
+  again**, to roughly $7.30–11.30, by halving the machine size. Nothing should be spent against that
+  until a real machine has been measured.
+- **#18's observability stack is unchanged and now has somewhere to run.** UptimeRobot is the actual
+  monitor: `observability.md` records that Fly health checks _"do not notify anyone"_ and only gate
+  routing, so the Fly check is a readiness probe and a database-dependent one would convert a
+  database blip into a restart loop that alerts nobody.
+- **Two tickets are graduated**, both blocked by this one: scheduled work on a single machine
+  (ADR-0015's outbox drainer, ADR-0020's deadline job and its dead-man's switch, ADR-0010's
+  reconciliation sweep), and the production public edge (CDN, ADR-0011's Wall cache and purge,
+  ADR-0014's edge limiter, and ADR-0009's persisted credential limiter with the Redis-versus-
+  `"database"` cost ADR-0013 flagged as never priced).
+- **`docs/runbook.md` exists and `CLAUDE.md` points at it.** It is written for an agent to execute.
+- **The art. 17(k) _manual interno_ is still homeless, and deliberately.** ADR-0020 observed that
+  _"#27 owns the retention schedule, #15 owns the runbook, neither owns this"_. It is a legal
+  procedure for handling _consultas_ and _reclamos_, not an operations document, ADR-0020 already
+  wrote its specification, and absorbing it into the runbook because the words sound alike would
+  bury it. It belongs in `docs/legal/` before launch.

--- a/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
+++ b/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
@@ -252,8 +252,9 @@ the §6.3 processor register.
   ADR-0014's edge limiter, and ADR-0009's persisted credential limiter with the Redis-versus-
   `"database"` cost ADR-0013 flagged as never priced).
 - **`docs/runbook.md` exists and `CLAUDE.md` points at it.** It is written for an agent to execute.
-- **The art. 17(k) _manual interno_ is still homeless, and deliberately.** ADR-0020 observed that
+- **The art. 17(k) _manual interno_ stays out of the runbook, deliberately.** ADR-0020 observed that
   _"#27 owns the retention schedule, #15 owns the runbook, neither owns this"_. It is a legal
   procedure for handling _consultas_ and _reclamos_, not an operations document, ADR-0020 already
   wrote its specification, and absorbing it into the runbook because the words sound alike would
-  bury it. It belongs in `docs/legal/` before launch.
+  bury it. It belongs in `docs/legal/` before launch — and it is no longer homeless: **#43 owns it**,
+  filed concurrently with this session.

--- a/docs/adr/0024-migrations-are-one-transaction-applied-before-the-deploy.md
+++ b/docs/adr/0024-migrations-are-one-transaction-applied-before-the-deploy.md
@@ -1,0 +1,198 @@
+# Migrations are one transaction, applied before the deploy
+
+Issue #15 asked how `drizzle-kit` migrations ride along with a deploy, and what happens when one
+fails mid-flight. Answering the second question turned up a fact no ADR had recorded, which changes
+what the first question is worth asking about.
+
+ADR-0022 owns the environments and the pipeline. This ADR owns what the pipeline does to the
+database.
+
+## The finding: every pending migration shares one transaction
+
+`drizzle-kit migrate` on the `pg` driver delegates to `drizzle-orm`'s migrator
+(`drizzle-kit/bin.cjs:78902`), whose PostgreSQL dialect opens **one** transaction and applies **every
+pending migration inside it**, committing the `drizzle.__drizzle_migrations` bookkeeping rows in the
+same transaction (`drizzle-orm/pg-core/dialect.js:60-71`):
+
+```js
+await session.transaction(async (tx) => {
+  for await (const migration of migrations) {
+    if (!lastDbMigration || Number(lastDbMigration.created_at) < migration.folderMillis) {
+      for (const stmt of migration.sql) await tx.execute(sql.raw(stmt));
+      await tx.execute(sql`insert into ... values(${migration.hash}, ${migration.folderMillis})`);
+    }
+  }
+});
+```
+
+Postgres has transactional DDL, so this actually holds. **A migration run either lands completely or
+leaves the database untouched, bookkeeping included.** The `--> statement-breakpoint` splitting that
+`meta/_journal.json` enables changes how statements are dispatched, not what they are wrapped in.
+
+So the ticket's question — _"what happens when one fails mid-deploy"_ — has a smaller answer than it
+expected. There is no partial application, no torn journal, no manual reconciliation, and no state a
+runbook has to teach anyone to unpick. **The failure procedure is: read the error, fix forward,
+run again.** That is worth writing down precisely because it is the opposite of the MySQL habit most
+people bring, where every migration is its own implicit commit and half-applied is the normal
+disaster.
+
+It is not free, and the rest of this ADR is the bill.
+
+## Migrate first, then deploy
+
+Every release applies migrations **before** the new image is released, on the CI runner, against the
+direct 5432 connection as the `migrator` role.
+
+The two orderings are not symmetric. Old code against a new **additive** schema is correct by
+construction — that is precisely what the expand/contract rule below guarantees. New code against an
+old schema is the hard direction: it selects a column that does not exist and errors for the whole
+window, and under ADR-0005's rolling replacement that window is unbounded if the migration then
+fails. Migrating first makes the safe direction the only direction.
+
+It also puts ADR-0022's single human approval in front of the one step in the pipeline that has no
+inverse.
+
+## What one transaction forbids
+
+**`CREATE INDEX CONCURRENTLY` cannot run inside a transaction block** — Postgres refuses it,
+SQLSTATE `25001`. So `drizzle-kit migrate` structurally cannot apply one, ever. Every index this
+repository adds is a plain `CREATE INDEX`, which takes a `SHARE` lock: reads continue, **writes
+block for the duration of the build**.
+
+This is not hypothetical. ADR-0008 requires an index on every foreign key unless it is already a
+leftmost prefix, and ADR-0014's search is _"a btree on `publication_skills (skill_id,
+publication_id)`"_ which _is_ the inverted index. Indexes will be added.
+
+**Two controls, and one named escape hatch.**
+
+First, the migration connection sets `lock_timeout` and `statement_timeout`. Without `lock_timeout`,
+a migration that queues behind a long-running query does not merely wait — every query arriving
+afterwards queues **behind the migration**, because Postgres lock requests are ordered. That is how a
+routine index build becomes a total outage, and it is the single most common way a healthy database
+is taken down by a deploy. A short `lock_timeout` converts it into a failed deploy, which under the
+paragraph above costs nothing.
+
+Second, a concurrent index is an **out-of-band operation**: the statement is run by hand against the
+direct connection and its migration file is recorded in the journal afterwards. **v1 defers this
+entirely**, because no table will be large enough for a plain `CREATE INDEX` to be perceptible.
+The threshold at which that stops being true is roughly **100,000 rows** in the table being indexed
+— below it the build is sub-second, above it the write-block is long enough for a user to notice.
+Reaching that number is the trigger to build a real out-of-band lane, not to improvise one during an
+incident.
+
+The alternative considered was a second migration directory applied by a bespoke runner outside the
+transaction. It was rejected as machinery for a problem this application does not yet have, and it
+would give drizzle-kit a second owner of migrations, which ADR-0004 and ADR-0006 both refuse.
+
+## A backfill over ~10,000 rows is not a migration
+
+It is a batched one-off script, run outside `drizzle-kit migrate`.
+
+Inside the migration it would sit in that same single transaction, holding row locks and generating
+dead tuples for its whole duration — the identical failure mode as the index above, approached from
+the other end. The transaction that makes failure clean is the transaction that makes a long
+operation dangerous, and both escape hatches exist for the same reason.
+
+## Expand and contract: two releases is the floor, three is the shape
+
+ADR-0017 built the **gate**: every new migration is scanned for `DROP TABLE`, `DROP COLUMN`,
+`ALTER COLUMN … SET NOT NULL`, `ALTER COLUMN … TYPE`, `DROP CONSTRAINT` and `RENAME`, and a match
+hard-fails unless the migration carries a marker naming an earlier migration **already present on
+`dev`**:
+
+```sql
+-- destructive: completes 0014_add_nullable_x
+```
+
+ADR-0017 left the **policy** here, and there is one thing in it the gate cannot enforce. The gate
+proves the two steps are at least one release apart. It cannot prove that _one_ intervening release
+is enough — and for a column removal that carries data, it is not:
+
+1. **Expand.** Add the new column, nullable. Deploy code that writes both and reads the old one.
+2. **Migrate and switch.** Backfill (out of band, per above). Deploy code that reads the new column
+   and still writes both.
+3. **Contract.** Deploy code that writes only the new column. Then drop the old one, with the
+   marker.
+
+Compressing this to two puts the read-switch and the drop in the same release, so the rollback of
+step 2 lands on a schema that no longer has the column it reads. **Two releases is what the gate
+enforces; three is what a backfill needs**, and only this document says so.
+
+Under ADR-0005's rolling deploy old and new code share one schema, so this is not ceremony — it is
+the reason the expand step exists at all.
+
+## Code rolls back. The schema does not.
+
+**`drizzle-kit` has no `down` command.** Its commands are `generate migrate introspect push up check
+drop export`, and `drop` only removes an un-applied file from the folder. There is no reverse
+migration and there will not be one.
+
+That is affordable only because of everything above. A code rollback never requires the schema to
+move, because the schema change was additive and the old code tolerates it by construction. So:
+
+- **Code rollback** is `fly deploy --image <previous digest>` — seconds, no rebuild — followed by
+  `git revert` on `main` in the same session. The image swap is the incident action; the revert is
+  what stops `main` from lying about what is running, which is the whole reason ADR-0022 made `main`
+  the production ref.
+- **A wrong migration is superseded by a new forward migration.** There is no other path.
+
+**A restore is not a rollback mechanism.** `planetscale-postgres-safety-review` says this in its own
+words — _"use PITR/backup restore branches for incident recovery, not as an automatic rollback
+mechanism"_ — and it needs stating because it is exactly what a frightened operator reaches for.
+Restoring to undo a schema change discards every row written since the restore point. It is
+data-loss recovery, it costs the full RPO below, and it is never the answer to "the migration was
+wrong".
+
+## RPO is 24 hours, and someone has to say so
+
+ADR-0004 accepted 2-day backup retention and no HA as named risks and left the number here: _"the
+real RPO is issue #15's to set."_
+
+**RPO: 24 hours. RTO: hours, not minutes.** A single-node PS-5 with two days of retention means a
+bad day loses up to a day of profiles, publications and offers, and recovery is measured in the time
+it takes one person to notice, restore, re-create the extensions and cut over.
+
+That is survivable for a platform that moves no money and stores no transaction anyone is owed. It
+is also the one place where "it is free" has a real cost, and leaving it implied would be dishonest
+to the people whose profiles those are. It goes in the runbook as a stated promise, not as an
+inference from a retention setting.
+
+**One restore drill runs before launch**, to a fresh branch. Its purpose is specific: to watch
+`pg_trgm` and `unaccent` come back **missing** exactly as `0000_enable_extensions.sql` predicts,
+because the restore also brings back `drizzle.__drizzle_migrations` with migration `0000` already
+recorded as applied — so the runner reports nothing to do while every query needing those
+extensions fails at runtime. The drill is what turns that comment into a tested procedure with a
+verified command in the runbook.
+
+## Accepted risks
+
+- **No concurrent index path exists.** Adding an index to a table past ~100,000 rows blocks writes,
+  and the remedy is an out-of-band procedure that has never been performed.
+- **`lock_timeout` and `statement_timeout` values are unmeasured.** They are set to fail fast on an
+  application with no traffic; the right numbers are a function of traffic that does not exist.
+- **The three-release choreography is enforced by prose.** ADR-0017's gate proves one release of
+  separation, not two, and nothing detects a compressed backfill except review.
+- **A 24-hour RPO is a policy, not a mechanism.** Nothing enforces it and PlanetScale's retention is
+  what it is; the number describes the loss we have agreed to accept.
+- **The restore drill has not been run**, so the recovery commands in the runbook are written from
+  documentation rather than from having done it once.
+- **The single-transaction behaviour is a property of `drizzle-orm@0.45.2` and `drizzle-kit@0.31.10`
+  as read**, not a documented guarantee. A future version could batch differently, and everything in
+  this ADR downstream of it would need re-reading.
+
+## Consequences
+
+- **The runbook's migration-failure entry is three lines**, because there is nothing to unpick.
+- **`packages/db` gains no rollback tooling**, and any proposal for a `down` lane should be read
+  against this ADR first.
+- **ADR-0017's destructive gate is unchanged**; this ADR supplies the policy behind it and adds the
+  case the gate cannot see.
+- **ADR-0004's RPO placeholder is filled.**
+- **ADR-0014's `pg_upgrade` collation caveat lands in the runbook** rather than in a test. ADR-0017
+  recorded it as untestable and left it here: PG18 reads full-text and `pg_trgm` dictionaries via
+  the cluster's default collation provider rather than always libc, and recommends reindexing those
+  indexes after a `pg_upgrade`. PlanetScale has no in-place major upgrade, so this reaches us only
+  through a migration between databases — which is precisely when nobody remembers it.
+- **The ~100,000-row and ~10,000-row thresholds are named so they can be argued with.** Both are
+  order-of-magnitude judgements, not measurements, and either is worth revising the first time a
+  real table gets close.

--- a/docs/adr/0024-migrations-are-one-transaction-applied-before-the-deploy.md
+++ b/docs/adr/0024-migrations-are-one-transaction-applied-before-the-deploy.md
@@ -65,7 +65,11 @@ publication_id)`"_ which _is_ the inverted index. Indexes will be added.
 
 **Two controls, and one named escape hatch.**
 
-First, the migration connection sets `lock_timeout` and `statement_timeout`. Without `lock_timeout`,
+First, the migration connection sets **`lock_timeout=5s` and `statement_timeout=120s`**, applied by
+`.github/scripts/with-migration-timeouts.mjs`. They ride on the connection URL because there is
+nowhere else to put them: `drizzle.config.ts` passes `dbCredentials: { url }`, and drizzle-kit's
+`pg` path builds its pool from `connectionString` alone and ignores every other field on that
+object. Without `lock_timeout`,
 a migration that queues behind a long-running query does not merely wait — every query arriving
 afterwards queues **behind the migration**, because Postgres lock requests are ordered. That is how a
 routine index build becomes a total outage, and it is the single most common way a healthy database

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -28,7 +28,8 @@ failure leaves the database exactly as it was, `drizzle.__drizzle_migrations` in
 **Verification.** `pnpm --filter @repo/db exec drizzle-kit check` passes, and the deploy job's
 migrate step exits zero.
 
-**The database needed no repair.** Reach for a restore only under procedure 6.
+**The database needed no repair.** Reach for a restore only under procedure 6. If the migrate step
+_succeeded_ and the deploy then failed, that is procedure 9 instead — a different state entirely.
 
 ---
 
@@ -85,7 +86,7 @@ what stops `main` from lying about production — it is not optional cleanup.
 1. `flyctl logs --app encuentra` — confirm the cause is memory rather than a crash on boot.
 2. Open the memory graph: `flyctl dashboard metrics --app encuentra` (Fly's managed Grafana, free,
    ~15 days of retention).
-3. Raise `memory_mb` in `fly.toml` to the next size and redeploy.
+3. Raise `memory` under `[[vm]]` in `fly.toml` to the next size and redeploy — the key is `memory`, not `memory_mb`.
 
 **Verification.** `flyctl status --app encuentra` shows one machine `started` with no restarts for
 ten minutes, and the memory graph plateaus below the new ceiling.
@@ -129,9 +130,9 @@ written since the restore point; a wrong migration is superseded by a new forwar
 2. Run procedure 2 against the restored branch — the extensions will be missing.
 3. Verify the data is present and the application connects.
 4. Cut over by pointing `DATABASE_URL` at the restored branch: `flyctl secrets set` on the app, then
-   update the GitHub Actions secret so CI migrates the same database.
+   update the `PRODUCTION_DATABASE_URL` **environment secret** so CI migrates the same database.
 
-**Verification.** Both `DATABASE_URL` values — the Fly secret and the Actions secret — name the
+**Verification.** Both `DATABASE_URL` values — the Fly secret and the environment secret — name the
 restored branch. A cutover that updates one of the two leaves the next deploy migrating the
 abandoned database.
 
@@ -174,6 +175,32 @@ at `$0.00` with alerts off, which is the state that lets a bill grow unobserved.
 
 ---
 
+## 9. The migration applied but the deploy did not
+
+**Fires when** the `Migrate` step succeeded and the `Deploy` step failed.
+
+**This is the one asymmetric state in the pipeline**: production is carrying a new schema while the
+old image is still serving. It is safe rather than urgent — ADR-0024's expand/contract rule means
+the schema change is additive and the running code tolerates it by construction — which is exactly
+why that rule is not ceremony.
+
+The image is resolved before the migration runs, so the common cause of this state is gone; what is
+left is an infrastructure failure between the two steps.
+
+1. Read the failure. A missing image is impossible here — the resolve step runs first — so the cause
+   is Fly-side.
+2. Re-run the failed job. It is idempotent: the migration will find nothing pending, and the deploy
+   will resolve the same digest.
+3. If Fly is unavailable, leave it. The old image against the new schema is a correct state, not a
+   degraded one.
+
+**Verification.** `flyctl status --app encuentra` shows the intended digest, and `pnpm db:migrate`
+against that database reports nothing to apply.
+
+**Do not roll the schema back.** There is no `down` migration and none is needed (ADR-0024).
+
+---
+
 ## Provisioning checklist
 
 Nothing below has been done. The `workforpereira` PlanetScale organisation holds zero databases and
@@ -190,12 +217,28 @@ no payment method; no Fly app exists. Work top to bottom — later steps need th
 5. **Fly**: create `encuentra` and `encuentra-staging` in `iad`, 512 MB `shared-cpu-1x`, staging with
    `min_machines_running = 0`.
 6. **Fly**: `flyctl secrets set DATABASE_URL=…` on each app, using the `app` role.
-7. **GitHub**: add repository secrets `FLY_API_TOKEN`, `STAGING_DATABASE_URL`,
-   `PRODUCTION_DATABASE_URL` — the last two using the `migrator` role.
-8. **GitHub**: create the `staging` and `production` environments, **neither with a required
-   reviewer**. They scope secrets and record deployments; the human gate is the fast-forward merge
-   into `main` itself (ADR-0022).
-9. **Arm `deploy.yml`** — one edit, named in the file.
-10. **Run the restore drill** (procedures 6 and 2 against a throwaway branch) and record the result
+7. **Fly**: create **two app-scoped deploy tokens**, not one org token —
+   `flyctl tokens create deploy --app encuentra` and `--app encuentra-staging`. An org token would
+   let the `staging` job, which is dispatchable from any branch, deploy or destroy production.
+8. **GitHub**: create the `staging` and `production` environments first, **neither with a required
+   reviewer**. They record deployments and scope the secrets in step 9; the human gate is the
+   fast-forward merge into `main` itself (ADR-0022).
+9. **GitHub**: add these as **environment secrets, never repository secrets** — a repository secret
+   is readable by every job in every workflow on every branch, which would make the `environment:`
+   key in `deploy.yml` scope nothing:
+
+   | Environment  | Secrets                                                           |
+   | ------------ | ----------------------------------------------------------------- |
+   | `staging`    | `FLY_STAGING_TOKEN`, `STAGING_DATABASE_URL` (the `migrator` role) |
+   | `production` | `FLY_PRODUCTION_TOKEN`, `PRODUCTION_DATABASE_URL` (`migrator`)    |
+
+   **`FLY_PRODUCTION_TOKEN` also needs to reach the `build` job**, which has no environment because
+   it deploys nothing — so it is additionally a repository secret. That is the one credential this
+   design cannot scope down: Fly's registry is namespaced per app, so pushing
+   `registry.fly.io/encuentra:…` requires the production app's token. Recorded as an accepted risk
+   in ADR-0022 rather than hidden.
+
+10. **Arm `deploy.yml`** — one edit, named in the file.
+11. **Run the restore drill** (procedures 6 and 2 against a throwaway branch) and record the result
     here. ADR-0024 treats this as a launch requirement, because the recovery commands above are
     written from documentation rather than from having done it once.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,201 @@
+# Runbook
+
+Operational procedures, written for an agent to execute. Every procedure ends on a **verification**
+step whose output tells you it worked. Run the verification; a procedure without its verification is
+not finished.
+
+Decisions behind these procedures live in [ADR-0022](adr/0022-two-environments-one-artifact-one-human-gate.md)
+(environments, pipeline) and [ADR-0024](adr/0024-migrations-are-one-transaction-applied-before-the-deploy.md)
+(migrations, rollback, recovery). Read the ADR when a procedure looks wrong; edit the ADR before
+editing a procedure.
+
+Commands assume the repository root and a `flyctl` authenticated against the `workforpereira`
+organisation. App names are `encuentra` (production) and `encuentra-staging`.
+
+---
+
+## 1. A migration failed
+
+**Fires when** the `migrate` step of `deploy.yml` exits non-zero.
+
+`drizzle-kit migrate` applies every pending migration inside **one** transaction (ADR-0024). A
+failure leaves the database exactly as it was, `drizzle.__drizzle_migrations` included.
+
+1. Read the Postgres error in the job log. It names the failing statement.
+2. Fix the migration on a branch, open a pull request, merge.
+3. Re-run the deploy.
+
+**Verification.** `pnpm --filter @repo/db exec drizzle-kit check` passes, and the deploy job's
+migrate step exits zero.
+
+**The database needed no repair.** Reach for a restore only under procedure 6.
+
+---
+
+## 2. Extensions are missing after a restore
+
+**Fires when** queries fail with `function unaccent(text) does not exist` or
+`operator does not exist: text %> text`, on a database that was restored from a backup.
+
+PlanetScale does not restore extensions. Re-running migrations **does not fix this**: the restore
+also brings back `drizzle.__drizzle_migrations`, which already records `0000_enable_extensions` as
+applied, so `drizzle-kit migrate` reports nothing to do while `pg_trgm` and `unaccent` are absent.
+Run the statements directly.
+
+1. Connect to the restored database as the `migrator` role.
+2. Execute:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+```
+
+**Verification.**
+
+```sql
+SELECT extname, extversion FROM pg_extension WHERE extname IN ('pg_trgm', 'unaccent');
+```
+
+Returns two rows: `pg_trgm 1.6` and `unaccent 1.1`. A different version is a finding — record it,
+because `0000_enable_extensions.sql` pins those numbers against PlanetScale's documented set.
+
+---
+
+## 3. Roll back production code
+
+**Fires when** a release is bad and the fix is not immediate.
+
+The image is addressable by digest and the schema does not move (ADR-0024), so this is a swap, not a
+migration.
+
+1. `flyctl releases --app encuentra` — note the digest of the last known-good release.
+2. `flyctl deploy --app encuentra --image <digest>`.
+3. **In the same session**, `git revert` the offending commit on `main` and push.
+
+**Verification.** `flyctl status --app encuentra` shows the machine running the intended digest,
+**and** `git log -1 origin/main` describes the code that is now running. Both, because step 3 is
+what stops `main` from lying about production — it is not optional cleanup.
+
+---
+
+## 4. The machine is out of memory or will not start
+
+**Fires when** `flyctl status` shows restarts, or logs contain OOM kills.
+
+1. `flyctl logs --app encuentra` — confirm the cause is memory rather than a crash on boot.
+2. Open the memory graph: `flyctl dashboard metrics --app encuentra` (Fly's managed Grafana, free,
+   ~15 days of retention).
+3. Raise `memory_mb` in `fly.toml` to the next size and redeploy.
+
+**Verification.** `flyctl status --app encuentra` shows one machine `started` with no restarts for
+ten minutes, and the memory graph plateaus below the new ceiling.
+
+**Record the number.** ADR-0022 chose 512 MB against an application that did not exist and named
+this as the measurement that replaces the guess. Amend the ADR with what you observed.
+
+---
+
+## 5. Health checks pass but the site is down
+
+**Fires when** UptimeRobot alerts and Fly reports the app healthy.
+
+Fly health checks **gate routing and notify nobody** — they are a readiness probe, not a monitor,
+and the health endpoint deliberately does not touch the database (ADR-0022). So a healthy Fly app
+with a broken site means the failure is below the probe.
+
+1. `flyctl logs --app encuentra` — look for database connection errors first.
+2. Check PlanetScale for the branch's status and any active anomaly.
+3. If the database is the cause, treat it as an incident against the RPO in procedure 6 rather than
+   as a deploy problem.
+
+**Verification.** UptimeRobot returns to `up` and the log stream is free of connection errors for
+five minutes.
+
+---
+
+## 6. Data loss, and the restore
+
+**Fires when** rows are gone and no forward fix recovers them.
+
+**The promise, stated so it is not inferred: RPO is 24 hours and RTO is hours, not minutes**
+(ADR-0024). A single-node PS-5 with two-day retention can lose up to a day of profiles,
+publications and offers. Confirm the loss is real before spending it.
+
+A restore is **data-loss recovery only**. Using it to undo a schema change discards every row
+written since the restore point; a wrong migration is superseded by a new forward migration
+(ADR-0024).
+
+1. Restore to a **new branch**, never over the live one.
+2. Run procedure 2 against the restored branch — the extensions will be missing.
+3. Verify the data is present and the application connects.
+4. Cut over by pointing `DATABASE_URL` at the restored branch: `flyctl secrets set` on the app, then
+   update the GitHub Actions secret so CI migrates the same database.
+
+**Verification.** Both `DATABASE_URL` values — the Fly secret and the Actions secret — name the
+restored branch. A cutover that updates one of the two leaves the next deploy migrating the
+abandoned database.
+
+---
+
+## 7. Reindex after a major-version move
+
+**Fires when** the database moves between Postgres majors. PlanetScale has no in-place major
+upgrade, so this arrives as a migration into a new database rather than as an upgrade.
+
+PG18 reads full-text and `pg_trgm` dictionaries through the cluster's default collation provider
+rather than always libc, and recommends reindexing those indexes afterwards (ADR-0014, ADR-0024).
+
+1. Complete the data move.
+2. `REINDEX INDEX CONCURRENTLY <name>;` for every `pg_trgm` and full-text index.
+
+**Verification.** `SELECT indexrelid::regclass, indisvalid FROM pg_index WHERE indisvalid = false;`
+returns no rows.
+
+**`REINDEX … CONCURRENTLY` runs outside a migration**, by hand. `drizzle-kit migrate` wraps
+everything in one transaction and Postgres refuses concurrent index operations there (ADR-0024).
+
+---
+
+## 8. Check spend
+
+**Fires** monthly, and after any traffic event.
+
+Neither vendor offers a hard cap. Fly's documentation says plainly that billing alerts are not
+supported, so the Fly figure is a manual read; PlanetScale carries an invoice budget with alerts,
+which is the only automatic signal in the stack.
+
+1. `flyctl dashboard billing` — read the month-to-date figure.
+2. Read PlanetScale's usage for the `workforpereira` organisation.
+3. Compare against the ceiling: **$25/month total**, with committed spend and the current remainder
+   recorded in ADR-0022.
+
+**Verification.** PlanetScale's `invoice_budget_amount` is `25.0` with alerts **enabled**. It ships
+at `$0.00` with alerts off, which is the state that lets a bill grow unobserved.
+
+---
+
+## Provisioning checklist
+
+Nothing below has been done. The `workforpereira` PlanetScale organisation holds zero databases and
+no payment method; no Fly app exists. Work top to bottom — later steps need the earlier ones.
+
+1. **PlanetScale**: add a payment method; set the organisation invoice budget to `25.0` and enable
+   alerts.
+2. **PlanetScale**: create `encuentra-production` and `encuentra-staging` — PS-5, `us-east-1`,
+   **Postgres 18**. There is no in-place major upgrade, so the version is chosen once, here.
+3. **PlanetScale**: create two roles per database — `app` (DML) and `migrator` (DDL). The
+   application never connects as the default role (ADR-0022).
+4. **PlanetScale**: enable `pg_strict` in warn mode on staging. Production stays unenforced until
+   real queries exist.
+5. **Fly**: create `encuentra` and `encuentra-staging` in `iad`, 512 MB `shared-cpu-1x`, staging with
+   `min_machines_running = 0`.
+6. **Fly**: `flyctl secrets set DATABASE_URL=…` on each app, using the `app` role.
+7. **GitHub**: add repository secrets `FLY_API_TOKEN`, `STAGING_DATABASE_URL`,
+   `PRODUCTION_DATABASE_URL` — the last two using the `migrator` role.
+8. **GitHub**: create the `staging` and `production` environments, **neither with a required
+   reviewer**. They scope secrets and record deployments; the human gate is the fast-forward merge
+   into `main` itself (ADR-0022).
+9. **Arm `deploy.yml`** — one edit, named in the file.
+10. **Run the restore drill** (procedures 6 and 2 against a throwaway branch) and record the result
+    here. ADR-0024 treats this as a launch requirement, because the recovery commands above are
+    written from documentation rather than from having done it once.

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,0 +1,45 @@
+# Staging. Deployed with `flyctl deploy --config fly.staging.toml`.
+#
+# Kept in step with `fly.toml`; every difference below carries its reason. ADR-0022 owns the
+# decisions. Nothing here has been applied — see the provisioning checklist in `docs/runbook.md`.
+#
+# **Staging is public and holds no real personal data.** Its safety rests entirely on one rule:
+# production personal data never leaves production. Staging is seeded from a generator, so ADR-0011's
+# scraping rule — which is about personal data — has nothing to bite on. Restoring a production dump
+# here would be a breach in the same instant, and after ADR-0010 that dump carries photographs.
+
+app = "encuentra-staging"
+primary_region = "iad"
+
+[env]
+NODE_ENV = "production"
+PORT = "3000"
+
+[http_service]
+internal_port = 3000
+force_https = true
+auto_start_machines = true
+# Differs from production: staging bills only while it is being used. This is the difference that
+# keeps the pair inside #18's remaining budget.
+auto_stop_machines = "suspend"
+min_machines_running = 0
+processes = ["app"]
+
+[[http_service.checks]]
+grace_period = "10s"
+interval = "30s"
+method = "GET"
+path = "/api/health"
+timeout = "5s"
+
+[[vm]]
+size = "shared-cpu-1x"
+memory = "512mb"
+
+[deploy]
+# Differs from production: a suspended machine has nothing to go blue-green against, and a
+# seconds-long gap on a test environment costs nothing. This is also the fallback production takes
+# if bluegreen fights `min_machines_running`.
+strategy = "immediate"
+
+swap_size_mb = 512

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,54 @@
+# Production. Staging is `fly.staging.toml` — the two are deliberately near-identical, and a change
+# to one is a change to both unless there is a reason written beside it.
+#
+# ADR-0022 owns everything here. Nothing in this file has ever been applied: no Fly app exists yet.
+# `docs/runbook.md` carries the provisioning checklist.
+
+app = "encuentra"
+primary_region = "iad"
+
+# No `[build]` section. The image is built and pushed by `.github/workflows/deploy.yml` and
+# deployed by digest with `flyctl deploy --image`, so that the artifact production runs is the
+# identical one staging ran — not a rebuild of the same commit.
+
+# No `release_command`. ADR-0005 settled that drizzle-kit runs on a CI runner against the direct
+# 5432 connection; a release command would force drizzle-kit and the whole `migrations/` directory
+# into the production image, and hide the one irreversible step of the pipeline behind a deploy.
+
+[env]
+NODE_ENV = "production"
+PORT = "3000"
+
+[http_service]
+internal_port = 3000
+force_https = true
+auto_start_machines = true
+auto_stop_machines = "off"
+min_machines_running = 1
+processes = ["app"]
+
+# A readiness probe, not a monitor: Fly health checks gate routing and notify nobody
+# (`observability.md`). `/api/health` never touches the database for that reason.
+[[http_service.checks]]
+grace_period = "10s"
+interval = "30s"
+method = "GET"
+path = "/api/health"
+timeout = "5s"
+
+[[vm]]
+size = "shared-cpu-1x"
+# ADR-0022: 512 MB, chosen against an application that does not exist yet, in the direction that
+# is cheap to correct. Procedure 4 in the runbook is how it gets replaced by a measurement.
+memory = "512mb"
+
+[deploy]
+# Zero downtime on one machine's steady-state cost: bluegreen brings up a second machine, health
+# checks it, then swaps. Two versions briefly share one schema, which is exactly what ADR-0024's
+# expand/contract rule makes safe. Unverified against `min_machines_running` — ADR-0022 records
+# `immediate` as the fallback if the two fight.
+strategy = "bluegreen"
+
+# A Node server that occasionally spikes should page rather than be killed. Cheaper than the next
+# machine size up, and only touched under memory pressure.
+swap_size_mb = 512

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,16 @@
     "dev": {
       "cache": false,
       "persistent": true
-    }
+    },
+    // ADR-0017's transit node. `test` reads dependency *source* (every package is JIT, so there is
+    // no build output to wait for), but a change in `@repo/db` must still invalidate a dependent's
+    // cached test result. `dependsOn: []` would be fast and silently wrong; `^test` would serialise.
+    "transit": { "dependsOn": ["^transit"] },
+    // Registered before either is implemented, deliberately (ADR-0022). Turbo *errors* on a task
+    // missing from this file and *no-ops* a registered task no package defines — so registering them
+    // is what lets `.github/workflows/ci.yml` carry ADR-0017's real gate command,
+    // `turbo run lint check-types test db:check`, and stay green until the testing lane lands.
+    "test": { "dependsOn": ["transit"] },
+    "db:check": {}
   }
 }


### PR DESCRIPTION
Resolves #15.

Two ADRs, an agent-executable runbook, and a pipeline that is deliberately disarmed because nothing is provisioned.

## ADR-0022 — Two environments, one artifact, one human gate

- **`dev` is the trunk. Merging to it builds the image and deploys nothing. Staging is deployed by hand; production deploys automatically on a fast-forward merge of `dev` into `main`.** The fast-forward is load-bearing rather than stylistic: because `main` only advances to a commit that already exists on `dev`, the `dev`-built image is still addressable, so **production deploys an image it did not build**. A squash or a merge commit breaks it — which is also why merging to `dev` still builds even though nothing deploys.
- **The merge is the gate.** `planetscale-postgres-safety-review` asks for *"an explicit human-approved deployment step"* before production DDL, and the fast-forward merge into `main` is that step: nothing advances `main` by accident. A reviewer prompt on top would ask the same person to confirm a decision they took thirty seconds earlier, and a gate that is always approved is worse than none. The honest cost — **zero pause between deciding and shipping** — is recorded in the ADR's accepted risks, alongside the risk that a staging nobody chooses to deploy goes stale.
- **512 MB machines.** ADR-0005 costed the pair at \$6.50–9.50/month and recorded the 1 GB size behind that as *an unverified assumption*. Building the image in Actions means the machine never compiles anything, so at `observability.md`'s own \$3.19/machine the pair lands near \$3.70–4.20 — headroom created, not spent.
- **No preview environments**, and not only on cost: PlanetScale branching is paid, and ADR-0017 already gives every PR a real Postgres.
- **Secrets in three places**, with one uncomfortable consequence stated plainly: because migrations run on the CI runner, **GitHub necessarily holds a production database credential**. Two roles per database (`app` DML, `migrator` DDL) is what makes that tolerable.
- **Staging is public, and it is safe only because of the seeding rule.** Production personal data never leaves production, so staging holds no `Person` who exists and ADR-0011's scraping rule has nothing to bite on. That coupling is now written down: a production dump into staging would be a breach in the same instant, and after ADR-0010 it carries photographs.
- **The custom domain is a launch gate.** With `.fly.dev` URLs there is no Cloudflare zone, and ADR-0005's CDN plus **ADR-0011's anti-scraping control and ADR-0014's public-Need-search limiter** are all specified as edge mechanisms. ADR-0011 calls that control a launch requirement — *"without a rate limit, sample-not-index is a claim rather than a control"* — so no zone means the argument is unbacked.

## ADR-0024 — Migrations are one transaction, applied before the deploy

The finding this turns on had not been recorded anywhere: **`drizzle-kit migrate` applies every pending migration inside a single transaction**, committing the `__drizzle_migrations` rows with it (`drizzle-kit/bin.cjs:78902` → `drizzle-orm/pg-core/dialect.js:60-71`). So the ticket's "what happens when one fails mid-deploy" has almost no answer — nothing is applied, read the error and fix forward.

The bill:

- **`CREATE INDEX CONCURRENTLY` can never appear in a migration** (Postgres refuses it in a transaction block, SQLSTATE 25001), and ADR-0008 requires an index on every FK. Controls: `lock_timeout` and `statement_timeout` on the migration connection — without `lock_timeout` a queued migration blocks every query behind it — plus a named out-of-band escape hatch, deferred until ~100,000 rows.
- **A backfill over ~10,000 rows is a batched script, not a migration** — same failure mode from the other end.
- **Expand/contract is two releases as a floor and three when data moves.** ADR-0017's gate proves one release of separation; only this ADR says one is not enough for a backfill.
- **`drizzle-kit` has no `down`.** Code rolls back by image digest plus `git revert` on `main`; the schema never rolls back, because expand/contract makes that unnecessary. **A restore is not a rollback mechanism.**
- **RPO 24 hours, RTO hours not minutes** — filling the placeholder ADR-0004 left — plus one pre-launch restore drill, whose purpose is to watch `pg_trgm` and `unaccent` come back missing exactly as `0000_enable_extensions.sql` predicts.

## What actually ships here

| File | State |
| --- | --- |
| `docs/runbook.md` | Eight procedures, each ending on a verification, plus the provisioning checklist. Written for an agent to execute. |
| `turbo.json` | Registers `test`, `db:check` and ADR-0017's `transit` node |
| `.github/workflows/ci.yml` | **Green today.** Carries ADR-0017's real gate verbatim |
| `.github/workflows/deploy.yml` | **Disarmed** — `workflow_dispatch` only, with the one-line arming edit named in the file |
| `Dockerfile`, `.dockerignore` | **Verified**: built and run — `/api/health` 200, root 200, uid 1001 non-root, 303 MB |
| `fly.toml`, `fly.staging.toml` | Inert; no Fly app exists |
| `apps/web/app/api/health/route.ts` | Readiness probe that deliberately never touches the database |
| `next.config.ts` | `output: "standalone"` |

**Turbo errors on an unregistered task and no-ops a registered one nothing implements** — which is why `turbo run lint check-types test db:check` runs green now and needs no edit when #16's testing lane lands.

## Verified, not asserted

- The single-transaction behaviour, read from `drizzle-orm@0.45.2` / `drizzle-kit@0.31.10` source.
- `drizzle-kit` has no `down` — its commands are `generate migrate introspect push up check drop export`.
- The image builds, runs, and serves.
- The gate: 6 tasks, 6 successful.
- **`turbo --affected` compares against `main`/`master`, never the configured default branch** — so CI sets `TURBO_SCM_BASE=origin/dev` or every PR diffs a stale `main` and passes for the wrong reason.
- **PlanetScale has invoice budget alerts and this org's are off.** `workforpereira` holds zero databases, no payment method, `invoice_budget_amount: 0.0`, alerts disabled — while the account's other two orgs sit at \$20. It is free and it is the only spend signal either vendor gives.

## Departures from the skills #15 names

- `setup-pre-commit` is entirely Prettier-shaped; ADR-0019 deleted Prettier. **No Husky** — the gate belongs in CI where `--no-verify` cannot reach it.
- `drizzle-orm-patterns` recommends `deletedAt` over hard deletes; **ADR-0008 refused that**, and for a load-bearing reason.
- The `turborepo` skill calls a root `.env` an anti-pattern; #17 chose one on purpose.

## Note

ADR numbers **0021 and 0023 were claimed by concurrent sessions mid-flight**, so these landed on 0022 and 0024.
