### PR TITLE
The skill picker is one search box (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,12 @@ packages run first.
 
 ## Conventions worth knowing
 
+- **English everywhere except UI copy** (ADR-0001). Code, columns, routes, file names and enum values
+  are English; Spanish is confined to what a user reads. **A prototype's own controls are chrome, not
+  UI copy, so they are English too** — variant switchers, toggles, state readouts, banners, and the
+  search-param values behind them. Only the surface being prototyped speaks Spanish. Same rule for
+  seed scripts, CLI output, log messages and test names. Worked example:
+  `docs/design/skill-picker-prototype/`.
 - **Oxlint is the linter and TypeScript is 7.x — the two are one decision** (ADR-0018). TypeScript 7
   ships no stable programmatic API until 7.1, and typescript-eslint is built on that API and throws
   on sight of TS 7, so the linter had to go before the compiler could move. Don't reintroduce an

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,6 +10,13 @@ concern. Each term below carries the Spanish word used in copy, so the UI stays 
 the schema inheriting Colombian labour-law vocabulary. A small set of legal terms of art stay
 Spanish everywhere, because translating them loses the tie to the statute.
 
+**Address rule.** UI copy addresses the reader as **`tú`**, never `usted` and never `vos` — _"¿Qué
+sabes hacer?"_, not _"¿Qué sabe hacer?"_. `usted` reads as respect rather than distance in the Eje
+Cafetero and was the first choice for that reason; `tú` won because it is what a Colombian consumer
+product is expected to sound like, and it costs nothing in dignity. `vos` is Paisa-marked and would
+sound wrong to the "anyone, anywhere" hirer. The verb belongs to the reader — _escoge_, _quita_,
+_cuéntanos_ — never the system (_se requiere_). See ADR-0023.
+
 ## Language
 
 ### People
@@ -132,6 +139,11 @@ which someone types when looking for a Skill. It is a way **into** the vocabular
 Denomination is never stored on a Publication and never matched on. Choosing one offers the Skills that
 title usually implies, which the Person then edits. This is the only form in which occupations survive
 in the product, and they survive as a search aid rather than as a claim about anybody.
+
+A Denomination is reached **inside search, never as the first question**: typing one returns it
+alongside the individual Skills, and choosing it adds its Skills straight to the selection with an
+invitation to prune them in place. Leading with it would make _"what were you employed as"_ the first
+thing the product asks, which is what the vocabulary exists to escape (ADR-0023).
 _Spanish (UI)_: denominación / oficio
 _Avoid_: Job title, Role, Alias, Synonym (too weak — it names an occupation, not another word for a
 Skill)
@@ -151,6 +163,12 @@ Skill: it never enters the vocabulary at runtime, never appears on a Publication
 on. The operator reads it, and the term it argues for may be authored into a later release. It exists
 because the vocabulary is the only route to being found, so a gap in it makes someone invisible — and
 because a list of what people could not find is the only honest measure of how good the vocabulary is.
+
+It is offered **always, not only when a search fails** — behind a failed search it reads as an error
+state, and it would never hear from the person who searched an approximate word and settled. It may
+never promise the term will be added, and it may never be the end of the road: writing one and
+choosing the nearest existing Skill happen in the same breath, because a Publication with no Skill is
+unreachable today whatever gets authored next quarter (ADR-0023).
 _Spanish (UI)_: sugerencia
 _Avoid_: Custom skill, Free skill, Other, Pending skill
 

--- a/docs/adr/0001-english-code-in-a-spanish-only-product.md
+++ b/docs/adr/0001-english-code-in-a-spanish-only-product.md
@@ -49,3 +49,32 @@ and the English pair "processing policy" / "privacy notice" reads to an English 
 names for one thing. The route slugs are `/legal/processing-policy` and `/legal/privacy-notice`; each
 page's own heading carries the Spanish statutory name, which is where a reader who needs the
 distinction will actually be looking.
+
+## Prototype and tooling chrome
+
+**Amended (issue #30): a prototype's own controls are English. Only the copy inside the thing being
+prototyped is Spanish.**
+
+The main rule confines Spanish to "UI copy", and a prototype breaks that phrase in half. A
+`/prototype` artifact renders two things on one screen: the product surface under review, whose
+words are the design, and the harness around it — variant switcher, toggles, state readout, banner —
+whose words are instrumentation. The first is UI copy. **The second is not, and never becomes it:**
+it is deleted when the prototype is captured, so no Spanish string in it will ever reach a user.
+
+So `Publication · profile | need`, `Cap · counter | hard stop | choose`, `Suggestion · after search |
+always`, `Reset`. Not `Objeto`, `Tope`, `Sugerencia`, `Reiniciar`.
+
+Two reasons beyond consistency:
+
+- **The switcher's search-param values are identifiers**, and the amendment above already puts every
+  identifier in English. `?cap=hard-stop` and `?cap=tope` differ in nothing but which rule you
+  noticed. A prototype whose controls are Spanish tends to grow Spanish state keys behind them —
+  `state.cap === "elegir"` — which is the two-language codebase this ADR exists to prevent, arriving
+  through a file nobody thought counted.
+- **Spanish chrome camouflages itself as design.** The harness is supposed to be visibly not part of
+  the thing being judged; sharing the product's language is the one way to blur that on a screen
+  where every other signal (dark pill, monospace, fixed position) is trying to keep it separate.
+
+The rule reaches every developer-facing surface the same way: prototype switchers, seed and fixture
+scripts, CLI output, log messages, test names, commit messages. `docs/design/skill-picker-prototype/`
+is the worked example.

--- a/docs/adr/0023-the-skill-picker-is-one-search-box.md
+++ b/docs/adr/0023-the-skill-picker-is-one-search-box.md
@@ -1,0 +1,218 @@
+# The skill picker is one search box, and the cap of 20 is a choice rather than a limit
+
+ADR-0012 made the vocabulary the only searchable field, which makes the picker the screen where this
+product either works for its audience or quietly excludes them: a person who cannot find themselves
+in ~300 terms cannot be found by anyone else. #30 asked which gesture that screen leads with.
+
+**Search-first.** One hero box — _"¿Qué sabes hacer?"_ — over Skills and Denominations in the same
+result list. Browsing by Skill Group survives as a secondary path; the Denomination survives inside
+search; neither is the opening move.
+
+Decided against a prototype of all three, kept at
+[`docs/design/skill-picker-prototype/`](../design/skill-picker-prototype/) on branch
+`prototype/skill-picker`. Its fixture vocabulary — 256 terms in 14 Groups, 57 Denominations — is
+sample data sized to ADR-0012's target so the alternatives could be judged at real density. It is
+not the seed.
+
+## Why not browse-first
+
+Browsing 14 Group cards is the gentlest gesture on paper: recognition beats recall, and nobody has to
+know the word. It loses on what a Group **is**.
+
+ADR-0012 built Skill Groups as _"browsing scaffolding — a label on the flat list, never stored on a
+Publication and never an input to anything"_, and was explicit that they are _"not the second level
+the vocabulary deliberately lacks"_. Leading with them promotes that scaffolding to the structure of
+the product. A person who meets _Cocina y alimentos_ · _Construcción y obra_ · _Cuidado de personas_
+as the first screen reads them as **categories of person**, picks the one that matches the job they
+lost, and never opens the other thirteen — which reconstitutes the occupation tier ADR-0012 rejected,
+out of labels that were never supposed to mean anything.
+
+The density is the second problem and the smaller one. At ~20 terms per Group the list is well past
+the 5–9 chunking the UX guidance wants, so a Group is not one glance either; it is a scroll inside a
+scroll.
+
+## Why not Denomination-first
+
+Denomination-first tested best on the thing the ticket worried about most — a person with low digital
+literacy has a job title ready and often has nothing else. The prototype's version put a mandatory
+full-screen edit after it (_"Quita lo que no hagas · Nadie hace todo lo de una lista"_), which does
+answer #30's _starting point or shortcut_ question honestly.
+
+It still loses, on one sentence: **it makes _"what were you employed as"_ the first question the
+product asks.** ADR-0012 exists because _"a hotel receptionist can do many things she was never
+employed to do"_, and because _"this product exists precisely because that job is gone"_. An edit
+step downstream cannot undo the frame set by the first screen. The person has already been asked to
+introduce themselves as their lost job, and the bundle they are then editing is that job's contents.
+
+The escape hatch does not rescue it. The prototype's _"No tengo un oficio fijo — prefiero escoger
+yo"_ works, but a first screen whose honest answer for many people is _"none of these"_ is a first
+screen that sorts its audience into those who fit a title and those who do not.
+
+## Why search-first wins
+
+It is the only one of the three that asks the person to name **what they do**, in their own first
+word, and lets everything else follow from that word. `cocinar`, `moto`, `aseo`, `mesero` all work
+and all land in the same list.
+
+That last one matters more than it looks: **the Denomination is still reachable, it is just not the
+frame.** Typing `mesero` returns `Mesero · añade 6 habilidades` alongside the individual Skills. The
+person who thinks in job titles gets the shortcut ADR-0012 designed; the person who thinks in tasks
+never has to meet one. Search is the only gesture that serves both without asking anyone which they
+are.
+
+The known cost, stated plainly: **search demands you know a word.** The mitigations are that the
+vocabulary is authored in Colombian Spanish rather than imported (ADR-0012), that Denominations
+widen the entry points from ~300 to ~14,762, that an empty box shows eight common Skills as chips
+rather than nothing, that _"Ver todas las categorías"_ is one tap away, and that a failed search is
+the one place the Skill Suggestion is guaranteed to appear. A zero-result search is a measured event
+under ADR-0014, so the cost is observable rather than assumed.
+
+## The Denomination bundle adds to the tray, and the edit is invited
+
+Tapping `Mesero · añade 6 habilidades` puts all six Skills in the tray and posts one note above them:
+_"Añadimos 6 habilidades de mesero. Quita las que no hagas."_ The note clears as soon as anything
+else is added by hand.
+
+Two alternatives were rejected. Pushing into a full-screen review is a modal detour in the middle of
+a search-first flow, and it re-imports the framing problem above at the one moment the person was
+being efficient. Adding silently is the _"bundle accepted unedited"_ failure ADR-0012 names outright.
+
+**This is weaker than a forced edit and the weakness is accepted.** Nothing compels the person to
+prune. What replaces compulsion is that the edit surface is already on screen — the chips sit
+directly under the note, each with its own ×, so removing one is a tap rather than a navigation. The
+bet is that a bundle is at worst an over-broad Capability Profile, which ADR-0012 already priced when
+it set the cap at 20 and accepted _"weaker signal"_ as the cost of asserting willingness rather than
+experience. Where a forced step **is** justified is the Need, and that is #35's call, not this one.
+
+## The cap of 20 is a choice, and it is silent until 15
+
+Three treatments were built. **`choose` ships.**
+
+|             | Behaviour                          | Verdict    |
+| ----------- | ---------------------------------- | ---------- |
+| `counter`   | `8 de 20` from the first selection | Rejected   |
+| `hard-stop` | Nothing, then a refusal at 20      | Rejected   |
+| `choose`    | Silent below 15, then a prompt     | **Chosen** |
+
+Below 15 the picker says nothing about the cap, because most people will never reach it and a limit
+you cannot hit is noise. From 15: _"Te quedan 5. Deja las que más quieras hacer, no todas las que
+aceptarías."_ At 20: _"Estas son tus 20. Para añadir otra, quita la que menos te interese."_
+
+This is the only treatment that carries ADR-0012's actual reasoning into the copy. The cap exists
+because _"the rational move for someone desperate for income is to tick everything"_, and the
+purpose of refusing that is to make someone state what they **want** to do rather than everything
+they would accept. `counter` frames 20 as a quota from the first tap and quietly instructs people to
+fill it — the exact behaviour the cap was built to prevent. `hard-stop` refuses without ever saying
+why, which to this audience reads as the platform deciding they have claimed too much.
+
+The number is not re-litigated here. ADR-0012 fixed it at 20 and noted the cap is asymmetric —
+raising is one line, lowering means telling published people to delete skills.
+
+## The Skill Suggestion is always visible
+
+Not only after a failed search. It sits under the tray in the primary flow and at the foot of every
+opened Group.
+
+Behind a failed search it reads as an **error state**, and error states are where people leave. It
+would also under-collect the one thing ADR-0012 wants from it: the queue is _"the only honest
+evidence of how good 300 terms actually are"_, and someone who searches an approximate word, finds a
+near-enough term and settles never fails a search at all — so the gap they felt is never recorded.
+
+Two copy rules, and neither may be relaxed:
+
+- **It may not promise the term will be added.** ADR-0006 makes `@repo/catalog` read-only at runtime,
+  so nothing a person writes becomes a Skill. The receipt is _"Gracias. Lo leemos nosotros"_, never
+  _"lo agregaremos"_.
+- **It may not dead-end.** Sending a Suggestion and choosing an approximate Skill are not
+  alternatives. The receipt is followed in the same breath by the three nearest existing Skills as
+  chips, with _"así ya quedas visible hoy"_ — because a Publication with no Skill is unreachable
+  today whatever we author next quarter.
+
+It also states, unprompted, the two things ADR-0012 makes true and a person would otherwise assume
+the opposite of: _"No entra a tu publicación y no se usa para buscarte."_
+
+## The near-empty state, and a meter that names the floor
+
+ADR-0012's minimum of 1 creates a cliff, so the picker says where it is:
+
+- **0 Skills** — the continue action is disabled under _"Escoge al menos 1 para poder publicar tu
+  perfil."_ Blocking is honest: below 1 there is nothing to publish that anyone could reach.
+- **exactly 1** — one note: _"Con 1 ya puedes publicar. Entre más habilidades escojas, en más
+  búsquedas vas a aparecer."_ It states a fact about reach, promises no work, and **does not
+  escalate** — no repeat at 3, 5 or 10. Encouragement that returns is pressure, and this audience is
+  the last one to apply it to.
+- **2 and above** — silence.
+
+There **is** a completion meter, and its shape is the whole decision. It is **not a percentage of
+20**: a bar that fills toward 20 tells someone with four real skills they are 20% of a person, which
+turns ADR-0012's versatility into a score and is the pressure #30 asks about. What ships is a bar
+with **two marks** — the fill, and a tick on the track at **1** — under a legend that names both
+ends: _"Con 1 ya puedes publicar · 20 es el máximo"_. The only number it calls sufficient is 1;
+everything above reads as reach rather than debt.
+
+This supersedes the shape `NEXTJS_HANDOFF.md` specifies for `CompletionMeter` / `ProfileCompletion`.
+Progress may be shown; completeness may not be scored. It pairs with `choose`, which is silent until
+15 — so the two never nag at once.
+
+## UI copy addresses the reader as `tú`
+
+Every string, everywhere: _"¿Qué sabes hacer?"_, _"Quita la que menos te interese"_, _"Cuéntanos qué
+sabes hacer"_.
+
+`usted` was tried first, on the reasonable ground that it is the Eje Cafetero default _between
+friends and family_ and so reads as respect rather than distance. It was overruled: `tú` is what a
+Colombian consumer product is expected to sound like, and the warmth it buys costs nothing in
+dignity. `vos` was never a candidate — it is Paisa-marked, and the destination says hirers are
+"anyone, anywhere".
+
+Recorded here rather than in a voice guide, which is its own effort past this map's destination.
+`CONTEXT.md` carries the rule.
+
+## The Need picker is not decided here
+
+`CONTEXT.md` makes a Need a Publication, ADR-0016 caps it at five Skills, and the prototype shows the
+same picker works for one mechanically. That is all it shows.
+
+The person publishing a Need has money and is usually thinking in job titles, which is the single
+case where Denomination-first is obviously right — and also the case where ADR-0012 least wants a job
+title framing the object, and the one UAESPE Res. 129 art. 5 makes risky (ADR-0011). Deciding it here
+would be deciding it from the worker's screen. **#35 owns it**, having already named the Need path as
+_"not the mirror image"_, and inherits the prototype's `?mode=need` as a sketch rather than an answer.
+
+## Accessibility
+
+The `NEXTJS_HANDOFF.md` bar binds: WCAG 2.2 AA, keyboard, live regions, no meaning by colour alone,
+tested at 390/768/1024/1440. Choosing search-first concentrates the whole risk in one component, so
+the requirements are stated rather than left to implementation:
+
+- A real combobox per the WAI-ARIA Authoring Practices — `role="combobox"` with `aria-expanded`,
+  `aria-controls` and `aria-activedescendant`; `↑`/`↓`/`Enter`/`Escape` over the listbox.
+- **One** polite live region, announcing result counts, every add and remove with the running total,
+  and every cap refusal. A refusal that is only visual is a silent failure for a screen-reader user.
+- Real `<input type="checkbox">` wherever a list is checkable. Targets ≥ 40px. A 2px
+  `--color-brand-500` focus ring. `prefers-reduced-motion` honoured, and no animation on keyboard
+  navigation.
+- The meter is decorative to assistive tech: it carries an `aria-label` naming the same two numbers
+  its legend does, and it is never the only place the count appears.
+
+**Not cleared, and named so it is not mistaken for done:** the result list is unvirtualised, the
+Group accordion has no roving tabindex, and nothing has been through a real screen reader. ADR-0017
+puts all browser end-to-end testing out of v1, so this component has no automated guard either. Treat
+the prototype as a demonstrated pattern, not verified conformance.
+
+## Consequences
+
+- **ADR-0014's typeahead becomes the product's front door**, not a convenience. Its seeded
+  `search_text` over ~300 Skills, ~14,462 Denominations and 1,122 municipalities is now on the path
+  every new Person walks, which raises the cost of getting the seed-time normalisation wrong.
+- **#35 inherits** the picker as the largest step inside the first run, the Need picker as an open
+  question, and the `tú` rule for every screen it designs.
+- **ADR-0012's Denomination and Skill Suggestion entries gain behaviour**: the bundle is added and
+  edited in place, and the Suggestion is unconditional. `CONTEXT.md` is amended for both.
+- **`NEXTJS_HANDOFF.md`'s `CompletionMeter` shape is superseded** — progress shown, completeness never
+  scored.
+- **ADR-0001 was amended in the course of this ticket** for a reason unrelated to the picker: a
+  prototype's own controls are English, and only the copy inside the thing being prototyped is
+  Spanish.
+- **Authoring the ~300 terms and running ADR-0012's proxy rule over them remains an implementation
+  ticket.** The prototype's 256 fixture terms are not it, and must not be seeded.

--- a/docs/design/skill-picker-prototype/README.md
+++ b/docs/design/skill-picker-prototype/README.md
@@ -12,12 +12,33 @@ in it is the real vocabulary.
 > Three variants of the skill picker, switchable via `?variant=`, plus three cross-cutting toggles
 > (`?cap=`, `?mode=`, `?sug=`) for the decisions #30 asks that are orthogonal to the primary gesture.
 
-## Verdict so far
+## Verdict
 
-**Variant A (search-first) wins the primary gesture, and the Skill Suggestion is `always`.** Those
-two are settled; `?cap=`, `?mode=` and the Denomination question are still open, so all three
-variants and every toggle are still here to flip through. The defaults on load are the two decided
-values — `?variant=A&sug=always`.
+**#30 is decided.** The file still carries every variant and every toggle, because the losing
+options are the evidence for the winner — but the defaults on load are now the decisions:
+`?variant=A&cap=choose&sug=always&meter=on`.
+
+| Question            | Answer                                                                                                                                                                              |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary gesture     | **A — search-first.** One hero box over Skills and Denominations together.                                                                                                          |
+| Denomination bundle | **Adds straight into the tray, then a note asks you to edit it** — _"Añadimos 6 habilidades de mesero. Quita las que no hagas."_ No second screen; the tray is already on the page. |
+| The cap of 20       | **`choose`.** Silent below 15, then a prompt, never a quota.                                                                                                                        |
+| Skill Suggestion    | **`always`.** Present whether or not a search failed.                                                                                                                               |
+| Needs               | **Not decided here — handed to #35**, which already owns the Need path as _"not the mirror image"_. `?mode=need` stays in the file as the sketch #35 inherits, not as a decision.   |
+| Voice               | **`tú`, not `usted`.**                                                                                                                                                              |
+| Completion meter    | **Yes**, with the shape below.                                                                                                                                                      |
+
+### The two that moved after the first pass
+
+**`tú`.** The prototype shipped in `usted` on Eje Cafetero grounds; overruled. Every string is now
+`tú` — _"¿Qué sabes hacer?"_, _"Quita la que menos te interese"_, _"Cuéntanos qué sabes hacer"_.
+
+**The completion meter is back**, against the position the first draft took. What it is _not_ is a
+percentage of 20 — that is the version that turns versatility into a score, which was the original
+objection and it still stands. What shipped instead: a bar between the **floor** and the **ceiling**,
+with the floor marked on the track and named in the legend — _"Con 1 ya puedes publicar · 20 es el
+máximo"_. It fills toward 20 but nothing on it says 20 is the target, and the one number it calls
+sufficient is 1. Flip `Meter · off` in the black bar to compare against no meter at all.
 
 ## Language
 
@@ -94,22 +115,24 @@ everything they would accept out of desperation. `choose` is the only one of the
 that reasoning into the copy; `hard-stop` is the version that loses it. `counter` is the neutral default
 most products ship.
 
-### `?mode=` — does a Need use the same picker?
+### `?mode=` — does a Need use the same picker? **(handed to #35, not decided here)**
 
 `profile` (cap 20) vs `need` (cap **5** — ADR-0016 lowered the Need's cap and gave it
 ADR-0014's reason verbatim). The same three variants render in both. What changes:
 
-- The headline: _"¿Qué sabe hacer?"_ → _"¿Qué necesita que le hagan?"_, and in C
-  _"¿En qué ha trabajado antes?"_ → _"¿A quién necesita?"_
-- The tray heading: _Lo que sabe hacer_ → _Lo que necesita_
+- The headline: _"¿Qué sabes hacer?"_ → _"¿Qué necesitas que te hagan?"_, and in C
+  _"¿En qué has trabajado antes?"_ → _"¿A quién necesitas?"_
+- The tray heading: _Lo que sabes hacer_ → _Lo que necesitas_
 - The lede stops promising findability and starts promising match quality:
-  _"Entre más puntual sea, mejores personas le vamos a mostrar."_
+  _"Entre más puntual seas, mejores personas te vamos a mostrar."_
 
-**The thing to judge is whether variant C survives the flip.** The person publishing a Need has money
+**This toggle is now a sketch #35 inherits, not an answer.** Flipping it shows that the picker
+_mechanically_ works for a Need, and that is all it shows. The person publishing a Need has money
 and is usually thinking in job titles — which is the one case where Denomination-first is obviously
-right, and also the case where ADR-0012 least wants a job title stored. Nothing is stored either way
-(a Denomination is never persisted), but the _framing_ differs, and it is the Need that UAESPE
-Res. 129 art. 5 makes risky.
+right, and also the case where ADR-0012 least wants a job title framing the object. Nothing is stored
+either way (a Denomination is never persisted), but the framing differs, and it is the Need that
+UAESPE Res. 129 art. 5 makes risky. #35 already owns the Need path as _"not the mirror image"_, so
+the surface is decided there with the rest of the first run rather than assumed here.
 
 ### `?sug=` — where the Skill Suggestion appears
 
@@ -125,24 +148,46 @@ _"así ya queda visible hoy"_. Sending a Suggestion and choosing an approximate 
 alternatives; the UI does both in one breath.
 
 It also states the two things ADR-0012 makes true and a person would otherwise assume otherwise:
-_"No entra a su publicación y no se usa para buscarlo."_
+_"No entra a tu publicación y no se usa para buscarte."_
+
+### `?meter=` — the completion meter
+
+`on` (the decision) vs `off` (what the first draft shipped, kept for comparison).
+
+The meter is a bar with **two marks, not one**: the fill shows where you are, a green tick on the
+track marks **1**, and the legend reads _"Con 1 ya puedes publicar · 20 es el máximo"_. It is not a
+percentage of 20, and no state of it ever says you are incomplete.
+
+That shape is the whole argument. `NEXTJS_HANDOFF.md` specifies a `CompletionMeter` and a
+`ProfileCompletion`, and a naive percentage-of-20 on this page would tell someone with four real
+skills they are 20% of a person — turning ADR-0012's versatility into a score. Naming the floor
+inverts it: the only number the meter calls _sufficient_ is 1, and everything above it reads as
+reach rather than debt. Paired with `cap=choose`, which stays silent until 15 and then asks you to
+choose rather than to fill, the two never both nag.
 
 ## The near-empty state
 
 Live in every variant, driven by the real selection count:
 
-- **0 selected** — dashed box: _"Escoja al menos 1 para poder publicar su perfil."_ The CTA is
+- **0 selected** — dashed box: _"Escoge al menos 1 para poder publicar tu perfil."_ The CTA is
   disabled. This is the cliff ADR-0012's minimum-of-1 creates, stated plainly.
-- **exactly 1** — green-bordered note: _"Con 1 ya puede publicar. Entre más habilidades escoja, en
-  más búsquedas va a aparecer."_ Encouragement, once, and it **does not escalate**: at 2 it
-  disappears entirely.
-- **2–14** — nothing. No nudge, no meter.
+- **exactly 1** — green-bordered note: _"Con 1 ya puedes publicar. Entre más habilidades escojas, en
+  más búsquedas vas a aparecer."_ Encouragement, once, and it **does not escalate**: at 2 it
+  disappears entirely. (Confirmed on review — no repeat nudge at 3, 5 or 10.)
+- **2–14** — nothing but the meter.
 
-**There is no completion meter anywhere, deliberately.** `NEXTJS_HANDOFF.md` specifies a
-`CompletionMeter` and a `ProfileCompletion`; a percentage-of-done bar on a page where the honest
-maximum is _"whatever you can actually do"_ turns versatility into a score and tells someone with
-four real skills they are 20% of a person. That is the pressure the ticket asks about. If you want
-it back, it needs an argument.
+## The Denomination bundle in variant A
+
+Tapping `Mesero · añade 6 habilidades` drops all six into the tray and posts one note above the
+chips: _"Añadimos 6 habilidades de mesero. Quita las que no hagas."_ The note clears the moment you
+add anything else by hand.
+
+This is the middle of the three options considered, and it is where variant A pays for winning:
+variant C's full-screen review does not exist here, so nothing _forces_ the edit. What replaces the
+force is that **the edit surface is already on screen** — the chips are right under the note, each
+with its own ×. The rejected alternatives were pushing into C's step 2 (a modal detour inside a
+search-first flow) and adding the bundle silently, which is the _"accepted unedited"_ failure
+ADR-0012 names.
 
 ## Voice
 
@@ -153,15 +198,15 @@ sketch, held only tightly enough that the copy above is judgeable:
   refuse.
 - **Extremes:** Directness **5**, Warmth **4**, Sophistication **1** (short sentences, common words,
   no product vocabulary). Everything else moderate. Humor **1** — not solemn, just not funny here.
-- **Person: `usted`.** This is a real call and worth confirming. Pereira is Eje Cafetero, where
-  `usted` is the default _between friends and family_ — it reads as respect, not distance, and it
-  does not exclude older users the way `tú` can. The cost is that it reads slightly formal to a
-  younger urban reader. `vos` was not considered: it is Paisa-marked and would exclude the "anyone,
-  anywhere" hirer.
-- **Never:** any word implying the platform will find you work; _"complete su perfil"_; a percentage;
-  the word _víctima_, _damnificado_, _ayuda_ or _apoyo_ about the person; _"lo agregaremos"_ on a
-  Suggestion.
-- **Always:** the second person doing the verb — _"escoja"_, _"quite"_, _"cuéntenos"_ — never
+- **Person: `tú`.** Decided on review. The first draft used `usted` on the grounds that it is the Eje
+  Cafetero default _between friends and family_ and so reads as respect rather than distance; that
+  was overruled for `tú`, which is what a Colombian product is expected to sound like and which
+  carries the warmth setting above without the formality tax on a younger reader. `vos` was never on
+  the table: it is Paisa-marked and would sound wrong to the "anyone, anywhere" hirer.
+- **Never:** any word implying the platform will find you work; _"completa tu perfil"_; a bare
+  percentage; the word _víctima_, _damnificado_, _ayuda_ or _apoyo_ about the person;
+  _"lo agregaremos"_ on a Suggestion.
+- **Always:** the second person doing the verb — _"escoge"_, _"quita"_, _"cuéntanos"_ — never
   _"se requiere"_, never the system as subject.
 
 ## Accessibility
@@ -197,9 +242,9 @@ implementation ticket, which #30 puts out of scope explicitly. CUOC ships 14,462
   and sub-shape B would mean standing up half the app to render a picker, against a map whose
   destination says _plan only, this map builds nothing_. The repo already carries exactly this
   convention: `apps/landing/option-2.html` is a single-file prototype.
-- **The switcher bar carries three extra toggles.** UI.md specifies arrows and a label. #30 asks four
+- **The switcher bar carries four extra toggles.** UI.md specifies arrows and a label. #30 asks four
   questions, three of which are orthogonal to the primary gesture; folding them into the variant axis
-  would have meant nine variants, well past UI.md's cap of five.
+  would have meant nine variants, well past UI.md's cap of five. `?meter=` was added on review.
 - **`shadcn` was not loaded.** The repo has no `components.json` and `@repo/design-system` does not
   exist yet (ADR-0006 creates it, unbuilt). There is nothing for it to act on.
 - **`brand-voice` was not run as specified.** It produces a full voice guide from an intake

--- a/docs/design/skill-picker-prototype/README.md
+++ b/docs/design/skill-picker-prototype/README.md
@@ -1,0 +1,204 @@
+# Prototype — the skill picker (#30)
+
+**Throwaway.** One self-contained HTML file. Double-click `index.html`, or:
+
+```sh
+open docs/design/skill-picker-prototype/index.html
+```
+
+No build, no server, no dependencies. Nothing here is production code, and none of the vocabulary
+in it is the real vocabulary.
+
+> Three variants of the skill picker, switchable via `?variant=`, plus three cross-cutting toggles
+> (`?cap=`, `?mode=`, `?sug=`) for the decisions #30 asks that are orthogonal to the primary gesture.
+
+## The question
+
+#19 (ADR-0012) settled the vocabulary: ~300 flat Skills in 12–15 Groups, max 20 per Publication and
+minimum 1, ~14,462 Denominations as the way in, a Skill Suggestion capture for the gaps. #30 asks
+what a person actually meets — and the ticket's own framing is that these are **different products**
+for someone with low digital literacy:
+
+- search demands you know the word,
+- browsing demands patience through 300 items,
+- Denomination-first demands you identify with a job title, which is exactly the framing ADR-0012
+  spent a whole ticket escaping.
+
+## The three variants
+
+Flip with the arrows in the black bar, the `←`/`→` keys, or `?variant=A|B|C`.
+
+| Key   | Name     | Primary gesture                                                                    | What it bets on                                                                                                                                         |
+| ----- | -------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A** | Buscar   | A hero search box over Skills **and** Denominations in one list                    | That people can name what they do, and that a Denomination row (`Mesero · añade 6 habilidades`) is a shortcut inside search rather than a separate mode |
+| **B** | Explorar | 14 Group cards, tap to expand into checkboxes                                      | That recognition beats recall, and that Groups make 256 items browsable in ~20-item chunks                                                              |
+| **C** | Oficio   | _"¿En qué ha trabajado antes?"_ → up to 3 job titles → a **mandatory** edit screen | That the job title is the only word people reliably have — and that a full-screen edit step is what keeps it a starting point rather than a shortcut    |
+
+They deliberately disagree about more than layout:
+
+- **Where the tray lives.** A puts selected chips inline under the search; B relies on a sticky
+  counter bar because browsing scrolls; in C the tray _is_ the second screen.
+- **Where Denominations appear.** A mixes them into the result list, B hides them entirely (search
+  only), C makes them the entire first step.
+- **Whether the Suggestion is a fallback or a fixture.** See `?sug=` below.
+
+### Variant C answers the ticket's "starting point or shortcut" question in the affirmative
+
+Step 2 is a full screen with the bundle pre-ticked, headed _"Quite lo que no haga"_ and subtitled
+_"Nadie hace todo lo de una lista."_ There is no way to accept a bundle without seeing it item by
+item. The alternative — a confirm dialog — is what would reproduce the occupation model through the
+back door. **This is a design position, not a neutral rendering; disagree with it if it feels
+paternalistic.**
+
+Also in C: **"No tengo un oficio fijo — prefiero escoger yo"** drops you into variant B. A
+Denomination-first product that dead-ends people who don't identify with a title is worse than
+either of the others.
+
+## The toggles
+
+These are the cross-cutting decisions #30 lists. They are independent of the variant on purpose —
+the answer to "how do we communicate the cap" shouldn't be smuggled in with the answer to "search or
+browse".
+
+### `?cap=` — how the cap of 20 is communicated
+
+| Value      | Behaviour                                                                                                                                                                                            |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contador` | `8 de 20` always visible. At 20: _"Llegó a 20. Quite una para añadir otra."_                                                                                                                         |
+| `tope`     | **No counter at all** until you hit the wall, then a refusal: _"No puede añadir más de 20."_ Checkboxes go disabled.                                                                                 |
+| `elegir`   | From 15 on, the counter becomes a prompt: _"Le quedan 5. Deje las que más quiera hacer, no todas las que aceptaría."_ At 20: _"Estas son sus 20. Para añadir otra, quite la que menos le interese."_ |
+
+ADR-0012's reasoning was that the cap makes someone state what they _want_ to do rather than
+everything they would accept out of desperation. `elegir` is the only one of the three that carries
+that reasoning into the copy; `tope` is the version that loses it. `contador` is the neutral default
+most products ship.
+
+### `?mode=` — does a Need use the same picker?
+
+`perfil` (cap 20) vs `necesidad` (cap **5** — ADR-0016 lowered the Need's cap and gave it
+ADR-0014's reason verbatim). The same three variants render in both. What changes:
+
+- The headline: _"¿Qué sabe hacer?"_ → _"¿Qué necesita que le hagan?"_, and in C
+  _"¿En qué ha trabajado antes?"_ → _"¿A quién necesita?"_
+- The tray heading: _Lo que sabe hacer_ → _Lo que necesita_
+- The lede stops promising findability and starts promising match quality:
+  _"Entre más puntual sea, mejores personas le vamos a mostrar."_
+
+**The thing to judge is whether variant C survives the flip.** The person publishing a Need has money
+and is usually thinking in job titles — which is the one case where Denomination-first is obviously
+right, and also the case where ADR-0012 least wants a job title stored. Nothing is stored either way
+(a Denomination is never persisted), but the _framing_ differs, and it is the Need that UAESPE
+Res. 129 art. 5 makes risky.
+
+### `?sug=` — where the Skill Suggestion appears
+
+| Value     | Behaviour                                                                     |
+| --------- | ----------------------------------------------------------------------------- |
+| `buscar`  | Only after a search returns nothing.                                          |
+| `siempre` | Always present — in A under the tray, in B at the foot of every opened Group. |
+
+Both share the copy, which is written to a hard rule: **it may not promise the term will be added,
+and it may not dead-end.** So the receipt is _"Gracias. Lo leemos nosotros"_ — never _"lo
+agregaremos"_ — followed immediately by the three nearest existing Skills as chips, with
+_"así ya queda visible hoy"_. Sending a Suggestion and choosing an approximate Skill are not
+alternatives; the UI does both in one breath.
+
+It also states the two things ADR-0012 makes true and a person would otherwise assume otherwise:
+_"No entra a su publicación y no se usa para buscarlo."_
+
+## The near-empty state
+
+Live in every variant, driven by the real selection count:
+
+- **0 selected** — dashed box: _"Escoja al menos 1 para poder publicar su perfil."_ The CTA is
+  disabled. This is the cliff ADR-0012's minimum-of-1 creates, stated plainly.
+- **exactly 1** — green-bordered note: _"Con 1 ya puede publicar. Entre más habilidades escoja, en
+  más búsquedas va a aparecer."_ Encouragement, once, and it **does not escalate**: at 2 it
+  disappears entirely.
+- **2–14** — nothing. No nudge, no meter.
+
+**There is no completion meter anywhere, deliberately.** `NEXTJS_HANDOFF.md` specifies a
+`CompletionMeter` and a `ProfileCompletion`; a percentage-of-done bar on a page where the honest
+maximum is _"whatever you can actually do"_ turns versatility into a score and tells someone with
+four real skills they are 20% of a person. That is the pressure the ticket asks about. If you want
+it back, it needs an argument.
+
+## Voice
+
+No voice guide exists for Encuentra yet, and writing one is past this map's destination. This is a
+sketch, held only tightly enough that the copy above is judgeable:
+
+- **Archetype: Everyman**, not Caregiver. Caregiver is the charity register the product exists to
+  refuse.
+- **Extremes:** Directness **5**, Warmth **4**, Sophistication **1** (short sentences, common words,
+  no product vocabulary). Everything else moderate. Humor **1** — not solemn, just not funny here.
+- **Person: `usted`.** This is a real call and worth confirming. Pereira is Eje Cafetero, where
+  `usted` is the default _between friends and family_ — it reads as respect, not distance, and it
+  does not exclude older users the way `tú` can. The cost is that it reads slightly formal to a
+  younger urban reader. `vos` was not considered: it is Paisa-marked and would exclude the "anyone,
+  anywhere" hirer.
+- **Never:** any word implying the platform will find you work; _"complete su perfil"_; a percentage;
+  the word _víctima_, _damnificado_, _ayuda_ or _apoyo_ about the person; _"lo agregaremos"_ on a
+  Suggestion.
+- **Always:** the second person doing the verb — _"escoja"_, _"quite"_, _"cuéntenos"_ — never
+  _"se requiere"_, never the system as subject.
+
+## Accessibility
+
+The bar from `NEXTJS_HANDOFF.md` still binds and the ticket calls this out as the hardest part.
+Present in all three: a real `role="combobox"` with `aria-expanded` / `aria-controls` /
+`aria-activedescendant`, arrow-key + Enter + Escape navigation over the listbox, one polite live
+region announcing every add, remove, result count and cap refusal, real `<input type="checkbox">`
+in B and C (not divs), 40px+ targets, a 2px `--color-brand-500` focus ring, no meaning by colour
+alone, and `prefers-reduced-motion` honoured.
+
+**Not cleared here, and worth knowing before deciding:** the 300-item listbox is virtualised nowhere
+and announces "40 resultados" rather than paging; variant B's accordion has no roving tabindex; none
+of it has been through a real screen reader. Treat the a11y as _demonstrated pattern_, not _verified
+conformance_.
+
+## The fixture data is not the vocabulary
+
+256 Skills across 14 Groups (ADR-0012 targets 250–350 in 12–15) and 57 Denominations, authored for
+this prototype so that browsing 300 items _feels_ like browsing 300 items. Every Denomination bundle
+resolves to real Skills — the file fails loudly in the console otherwise. Slugs are generated by
+ADR-0012's rule and come out right (`atención al cliente` → `atencion-al-cliente`).
+
+It is **not** the seed. Authoring the real list and running the proxy rule over it is an
+implementation ticket, which #30 puts out of scope explicitly. CUOC ships 14,462 denominaciones;
+57 are sampled. Do not mistake this for the term list.
+
+## Departures from the named skills
+
+- **`/prototype` UI branch wants a route** (sub-shape A on an existing page, or B as a throwaway
+  route). This is a single HTML file instead. `apps/web` is still the bare `create-turbo` scaffold —
+  no design system, no shadcn, no seeded catalog, nothing rendered — so sub-shape A has no host page
+  and sub-shape B would mean standing up half the app to render a picker, against a map whose
+  destination says _plan only, this map builds nothing_. The repo already carries exactly this
+  convention: `apps/landing/option-2.html` is a single-file prototype.
+- **The switcher bar carries three extra toggles.** UI.md specifies arrows and a label. #30 asks four
+  questions, three of which are orthogonal to the primary gesture; folding them into the variant axis
+  would have meant nine variants, well past UI.md's cap of five.
+- **`shadcn` was not loaded.** The repo has no `components.json` and `@repo/design-system` does not
+  exist yet (ADR-0006 creates it, unbuilt). There is nothing for it to act on.
+- **`brand-voice` was not run as specified.** It produces a full voice guide from an intake
+  interview; that is its own effort and sits past this map's destination. Its dimension vocabulary is
+  used for the sketch above, which is the "lightweight voice sketch" its own instructions permit when
+  no guide exists.
+- **`userinterface-wiki` has no combobox rule.** Its ARIA-shaped guidance stops at Laws of UX. The
+  combobox semantics come from the WAI-ARIA Authoring Practices, not from that skill. What it _did_
+  bind: minimum target size, chunking into 5–9 (Groups are ~20, which is over — noted, not fixed),
+  progressive disclosure, tabular figures on the counter, and no animation on keyboard navigation.
+
+## Open calls this prototype takes without being asked to
+
+Flag any of these that are wrong — they are positions, not defaults:
+
+1. **`usted`, not `tú`.**
+2. **No completion meter, ever**, superseding `NEXTJS_HANDOFF.md`'s `CompletionMeter`.
+3. **The one-skill note appears once and never escalates.** No repeat nudge at 3, 5 or 10.
+4. **Denominations are multi-select (up to 3) in C.** The ticket implies one. Someone who was a
+   _mesero_ and a _domiciliario_ is the normal case here, and picking one erases the versatility the
+   product exists to reveal.
+5. **A Suggestion always ships with three nearest Skills.** The capture alone would be a dead end
+   even when it doesn't read like one.

--- a/docs/design/skill-picker-prototype/README.md
+++ b/docs/design/skill-picker-prototype/README.md
@@ -12,6 +12,27 @@ in it is the real vocabulary.
 > Three variants of the skill picker, switchable via `?variant=`, plus three cross-cutting toggles
 > (`?cap=`, `?mode=`, `?sug=`) for the decisions #30 asks that are orthogonal to the primary gesture.
 
+## Verdict so far
+
+**Variant A (search-first) wins the primary gesture, and the Skill Suggestion is `always`.** Those
+two are settled; `?cap=`, `?mode=` and the Denomination question are still open, so all three
+variants and every toggle are still here to flip through. The defaults on load are the two decided
+values — `?variant=A&sug=always`.
+
+## Language
+
+**The prototype's controls are English. Only the copy inside the picker is Spanish.**
+
+The black bar, its labels and values (`Publication · profile | need`, `Cap · counter | hard stop |
+choose`, `Suggestion · after search | always`, `Reset`), the banner, the state readout and the
+search-param values are all instrumentation — they get deleted when this prototype is captured, so
+no string in them will ever reach a user. Everything the picker itself says is Spanish, because that
+is the design under review.
+
+This is ADR-0001 as amended by #30; the reasoning lives there, not here. The trap it closes is that
+Spanish chrome grows Spanish state keys behind it (`state.cap === "elegir"`), which is the
+two-language codebase ADR-0001 exists to prevent, arriving through a file nobody thought counted.
+
 ## The question
 
 #19 (ADR-0012) settled the vocabulary: ~300 flat Skills in 12–15 Groups, max 20 per Publication and
@@ -62,20 +83,20 @@ browse".
 
 ### `?cap=` — how the cap of 20 is communicated
 
-| Value      | Behaviour                                                                                                                                                                                            |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contador` | `8 de 20` always visible. At 20: _"Llegó a 20. Quite una para añadir otra."_                                                                                                                         |
-| `tope`     | **No counter at all** until you hit the wall, then a refusal: _"No puede añadir más de 20."_ Checkboxes go disabled.                                                                                 |
-| `elegir`   | From 15 on, the counter becomes a prompt: _"Le quedan 5. Deje las que más quiera hacer, no todas las que aceptaría."_ At 20: _"Estas son sus 20. Para añadir otra, quite la que menos le interese."_ |
+| Value       | Behaviour                                                                                                                                                                                            |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `counter`   | `8 de 20` always visible. At 20: _"Llegó a 20. Quite una para añadir otra."_                                                                                                                         |
+| `hard-stop` | **No counter at all** until you hit the wall, then a refusal: _"No puede añadir más de 20."_ Checkboxes go disabled.                                                                                 |
+| `choose`    | From 15 on, the counter becomes a prompt: _"Le quedan 5. Deje las que más quiera hacer, no todas las que aceptaría."_ At 20: _"Estas son sus 20. Para añadir otra, quite la que menos le interese."_ |
 
 ADR-0012's reasoning was that the cap makes someone state what they _want_ to do rather than
-everything they would accept out of desperation. `elegir` is the only one of the three that carries
-that reasoning into the copy; `tope` is the version that loses it. `contador` is the neutral default
+everything they would accept out of desperation. `choose` is the only one of the three that carries
+that reasoning into the copy; `hard-stop` is the version that loses it. `counter` is the neutral default
 most products ship.
 
 ### `?mode=` — does a Need use the same picker?
 
-`perfil` (cap 20) vs `necesidad` (cap **5** — ADR-0016 lowered the Need's cap and gave it
+`profile` (cap 20) vs `need` (cap **5** — ADR-0016 lowered the Need's cap and gave it
 ADR-0014's reason verbatim). The same three variants render in both. What changes:
 
 - The headline: _"¿Qué sabe hacer?"_ → _"¿Qué necesita que le hagan?"_, and in C
@@ -92,10 +113,10 @@ Res. 129 art. 5 makes risky.
 
 ### `?sug=` — where the Skill Suggestion appears
 
-| Value     | Behaviour                                                                     |
-| --------- | ----------------------------------------------------------------------------- |
-| `buscar`  | Only after a search returns nothing.                                          |
-| `siempre` | Always present — in A under the tray, in B at the foot of every opened Group. |
+| Value          | Behaviour                                                                     |
+| -------------- | ----------------------------------------------------------------------------- |
+| `after-search` | Only after a search returns nothing.                                          |
+| `always`       | Always present — in A under the tray, in B at the foot of every opened Group. |
 
 Both share the copy, which is written to a hard rule: **it may not promise the term will be added,
 and it may not dead-end.** So the receipt is _"Gracias. Lo leemos nosotros"_ — never _"lo

--- a/docs/design/skill-picker-prototype/index.html
+++ b/docs/design/skill-picker-prototype/index.html
@@ -440,6 +440,46 @@
         padding: var(--space-4);
         border-radius: var(--radius-md);
       }
+      .note--bundle {
+        color: var(--color-ink);
+        background: var(--color-surface-brand);
+        border-left: 3px solid var(--color-brand-500);
+        padding: var(--space-3) var(--space-4);
+        border-radius: var(--radius-sm);
+        font-weight: 500;
+      }
+
+      /* completion meter */
+      .meter {
+        margin: 0 0 var(--space-4);
+      }
+      .meter__track {
+        position: relative;
+        height: 8px;
+        border-radius: 999px;
+        background: var(--color-border);
+        overflow: hidden;
+      }
+      .meter__fill {
+        height: 100%;
+        border-radius: 999px;
+        background: var(--color-brand-500);
+        transition: width 220ms var(--ease-out);
+      }
+      .meter__floor {
+        position: absolute;
+        top: -2px;
+        bottom: -2px;
+        width: 2px;
+        background: var(--color-success);
+      }
+      .meter__legend {
+        margin: var(--space-2) 0 0;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
 
       .stickybar {
         position: sticky;
@@ -661,6 +701,8 @@
       <div class="switcher__row">
         <span class="switcher__label">Suggestion</span>
         <span id="sugCtl"></span>
+        <span class="switcher__label">Meter</span>
+        <span id="meterCtl"></span>
         <button id="reset">Reset</button>
         <span id="stateDump" style="opacity: 0.55; margin-left: auto"></span>
       </div>
@@ -1637,12 +1679,14 @@
       const CAPS = { counter: "counter", "hard-stop": "hard stop", choose: "choose" };
       const MODES = { profile: "profile", need: "need" };
       const SUGS = { "after-search": "after search", always: "always" };
+      const METERS = { on: "on", off: "off" };
 
       const state = {
         variant: "A",
-        cap: "counter",
+        cap: "choose",
         mode: "profile",
         sug: "always",
+        meter: "on",
         selected: [], // array of skill slugs, insertion-ordered
         query: "",
         active: -1, // active option index in the combobox
@@ -1653,6 +1697,7 @@
         sugOpen: false,
         sugSent: null,
         blocked: null, // cap message currently shown
+        bundled: null, // {name, count} of the last Denomination bundle added
       };
 
       const maxFor = () => (state.mode === "need" ? 5 : 20);
@@ -1665,6 +1710,7 @@
         if (CAPS[p.get("cap")]) state.cap = p.get("cap");
         if (MODES[p.get("mode")]) state.mode = p.get("mode");
         if (SUGS[p.get("sug")]) state.sug = p.get("sug");
+        if (METERS[p.get("meter")]) state.meter = p.get("meter");
       }
       function writeUrl() {
         const p = new URLSearchParams({
@@ -1672,44 +1718,50 @@
           cap: state.cap,
           mode: state.mode,
           sug: state.sug,
+          meter: state.meter,
         });
         history.replaceState(null, "", location.pathname + "?" + p.toString());
       }
 
-      /* ---------- copy (Colombian Spanish, usted) ---------- */
+      /* ---------- copy (Colombian Spanish, tú) ---------- */
       const t = {
-        trayTitle: () => (state.mode === "need" ? "Lo que necesita" : "Lo que sabe hacer"),
+        trayTitle: () => (state.mode === "need" ? "Lo que necesitas" : "Lo que sabes hacer"),
         cta: () => "Continuar",
         emptyZero: () =>
           state.mode === "need"
-            ? "Escoja al menos 1 para poder publicar su necesidad."
-            : "Escoja al menos 1 para poder publicar su perfil.",
+            ? "Escoge al menos 1 para poder publicar tu necesidad."
+            : "Escoge al menos 1 para poder publicar tu perfil.",
         emptyOne: () =>
           state.mode === "need"
-            ? "Con 1 ya puede publicar. Entre más puntual sea, mejores personas le vamos a mostrar."
-            : "Con 1 ya puede publicar. Entre más habilidades escoja, en más búsquedas va a aparecer.",
+            ? "Con 1 ya puedes publicar. Entre más puntual seas, mejores personas te vamos a mostrar."
+            : "Con 1 ya puedes publicar. Entre más habilidades escojas, en más búsquedas vas a aparecer.",
         capNote: () => {
           const n = state.selected.length;
           const max = maxFor();
           if (state.cap === "counter") {
-            return n >= max ? `Llegó a ${max}. Quite una para añadir otra.` : null;
+            return n >= max ? `Llegaste a ${max}. Quita una para añadir otra.` : null;
           }
           if (state.cap === "hard-stop") {
             return null; // nothing until you hit the wall; see state.blocked
           }
           // choose
           if (n >= max)
-            return `Estas son sus ${max}. Para añadir otra, quite la que menos le interese.`;
+            return `Estas son tus ${max}. Para añadir otra, quita la que menos te interese.`;
           if (n >= max - 5)
-            return `Le quedan ${max - n}. Deje las que más quiera hacer, no todas las que aceptaría.`;
+            return `Te quedan ${max - n}. Deja las que más quieras hacer, no todas las que aceptarías.`;
           return null;
         },
         capBlocked: () => {
           const max = maxFor();
-          if (state.cap === "hard-stop") return `No puede añadir más de ${max}.`;
-          if (state.cap === "counter") return `Llegó a ${max}. Quite una para añadir otra.`;
-          return `Ya tiene ${max}. Quite la que menos le interese para añadir esta.`;
+          if (state.cap === "hard-stop") return `No puedes añadir más de ${max}.`;
+          if (state.cap === "counter") return `Llegaste a ${max}. Quita una para añadir otra.`;
+          return `Ya tienes ${max}. Quita la que menos te interese para añadir esta.`;
         },
+        bundled: () =>
+          state.bundled
+            ? `Añadimos ${state.bundled.count} habilidad${state.bundled.count === 1 ? "" : "es"} de ${state.bundled.name.toLowerCase()}. Quita las que no hagas.`
+            : null,
+        meterLegend: () => `Con 1 ya puedes publicar · ${maxFor()} es el máximo`,
       };
 
       /* ==================================================================
@@ -1755,6 +1807,7 @@
         }
         state.selected.push(skillSlug);
         state.blocked = null;
+        state.bundled = null; // any single add dismisses the bundle note
         if (!opts.silent)
           say(`Añadida: ${BY_SLUG.get(skillSlug).label}. ${state.selected.length} de ${maxFor()}.`);
         return true;
@@ -1783,6 +1836,7 @@
           state.selected.push(s.slug);
           added++;
         });
+        state.bundled = added ? { name: den.name, count: added } : null;
         state.blocked = skipped ? t.capBlocked() : null;
         say(
           `${added} habilidades añadidas de ${den.name}.` +
@@ -1807,6 +1861,25 @@
         return `<span class="counter${warn}">${n} de ${max}</span>`;
       }
 
+      /* The completion meter. Deliberately NOT a percentage: the bar shows where you are
+         between the floor (1, which is what actually makes you publishable) and the ceiling
+         (the cap), and the floor is marked on the track so the ceiling never reads as the goal. */
+      function meterHtml() {
+        if (state.meter !== "on") return "";
+        const n = state.selected.length;
+        const max = maxFor();
+        const pct = Math.min(100, (n / max) * 100);
+        const floorPct = (1 / max) * 100;
+        return `<div class="meter">
+          <div class="meter__track" role="img"
+               aria-label="${n} de ${max} habilidades. Con 1 ya puedes publicar.">
+            <div class="meter__fill" style="width:${pct}%"></div>
+            <div class="meter__floor" style="left:${floorPct}%"></div>
+          </div>
+          <p class="meter__legend">${t.meterLegend()}</p>
+        </div>`;
+      }
+
       function trayHtml() {
         const n = state.selected.length;
         const chips = state.selected
@@ -1818,8 +1891,10 @@
           .join("");
 
         let note = "";
-        if (n === 0) note = `<p class="note note--empty">${t.emptyZero()}</p>`;
-        else if (n === 1) note = `<p class="note note--soft">${t.emptyOne()}</p>`;
+        const bundled = t.bundled();
+        if (bundled) note += `<p class="note note--bundle">${esc(bundled)}</p>`;
+        if (n === 0) note += `<p class="note note--empty">${t.emptyZero()}</p>`;
+        else if (n === 1) note += `<p class="note note--soft">${t.emptyOne()}</p>`;
         const capNote = t.capNote();
         if (capNote) note += `<p class="note note--cap">${capNote}</p>`;
         if (state.blocked && state.cap === "hard-stop")
@@ -1830,6 +1905,7 @@
             <h2 id="trayTitle">${t.trayTitle()}</h2>
             ${counterHtml()}
           </div>
+          ${meterHtml()}
           ${n ? `<ul class="chips">${chips}</ul>` : ""}
           ${note}
         </section>`;
@@ -1854,24 +1930,24 @@
                 .join("")}</ul>`;
           return `<div class="sug">
             <h3>Gracias. Lo leemos nosotros.</h3>
-            <p>No entra a su publicación y no se usa para buscarlo. Mientras tanto, escoja lo más
-            parecido que encuentre — así ya queda visible hoy.</p>
+            <p>No entra a tu publicación y no se usa para buscarte. Mientras tanto, escoge lo más
+            parecido que encuentres — así ya quedas visible hoy.</p>
             ${nearHtml}
           </div>`;
         }
         if (!state.sugOpen) {
           return `<div class="sug">
-            <h3>¿No encuentra lo que usted hace?</h3>
-            <p>Cuéntenos con sus palabras. Lo leemos nosotros.</p>
-            <button class="btn btn--ghost" data-sugopen="1">Cuéntenos qué sabe hacer</button>
+            <h3>¿No encuentras lo que haces?</h3>
+            <p>Cuéntanos con tus palabras. Lo leemos nosotros.</p>
+            <button class="btn btn--ghost" data-sugopen="1">Cuéntanos qué sabes hacer</button>
           </div>`;
         }
         return `<form class="sug" data-sugform="1">
-          <h3>Cuéntenos qué sabe hacer</h3>
-          <p>Lo leemos nosotros y puede que lo agreguemos más adelante. No entra a su publicación
-          y no se usa para buscarlo.</p>
-          <label class="visually-hidden" for="sugText">Escríbalo con sus palabras</label>
-          <textarea id="sugText" name="sugText" placeholder="Escríbalo con sus palabras">${esc(query || "")}</textarea>
+          <h3>Cuéntanos qué sabes hacer</h3>
+          <p>Lo leemos nosotros y puede que lo agreguemos más adelante. No entra a tu publicación
+          y no se usa para buscarte.</p>
+          <label class="visually-hidden" for="sugText">Escríbelo con tus palabras</label>
+          <textarea id="sugText" name="sugText" placeholder="Escríbelo con tus palabras">${esc(query || "")}</textarea>
           <div style="display:flex;gap:var(--space-3);margin-top:var(--space-3)">
             <button class="btn" type="submit">Enviar</button>
             <button class="btn btn--ghost" type="button" data-sugclose="1">Cancelar</button>
@@ -1929,11 +2005,11 @@
         const showSug = state.sug === "always" || noHits || state.sugOpen || state.sugSent;
 
         return `
-          <h1>${state.mode === "need" ? "¿Qué necesita que le hagan?" : "¿Qué sabe hacer?"}</h1>
+          <h1>${state.mode === "need" ? "¿Qué necesitas que te hagan?" : "¿Qué sabes hacer?"}</h1>
           <p class="lede">${
             state.mode === "need"
-              ? "Escriba la tarea o el oficio. Escoja hasta 5."
-              : "Escriba lo que sabe hacer, o el oficio en el que ha trabajado. No necesita hoja de vida."
+              ? "Escribe la tarea o el oficio. Escoge hasta 5."
+              : "Escribe lo que sabes hacer, o el oficio en el que has trabajado. No necesitas hoja de vida."
           }</p>
 
           <div class="field field--hero">
@@ -1948,9 +2024,9 @@
             showList
               ? options.length
                 ? `<ul class="listbox" id="results" role="listbox" aria-label="Resultados">${optHtml}</ul>`
-                : `<p class="note note--empty" id="results">No encontramos «${esc(q)}». Pruebe con otra palabra — o cuéntenos.</p>`
+                : `<p class="note note--empty" id="results">No encontramos «${esc(q)}». Prueba con otra palabra — o cuéntanos.</p>`
               : `<div id="results" hidden></div>
-                 <p class="note" style="margin-top:var(--space-5)">O empiece por aquí</p>
+                 <p class="note" style="margin-top:var(--space-5)">O empieza por aquí</p>
                  <ul class="chips" style="margin-top:var(--space-2)">${popularHtml}</ul>
                  <p style="margin-top:var(--space-4)"><button class="btn--link" data-openbrowse="1">Ver todas las categorías</button></p>`
           }
@@ -2037,11 +2113,11 @@
           .join("");
 
         return `
-          <h1>${state.mode === "need" ? "¿Qué necesita que le hagan?" : "Escoja lo que sabe hacer"}</h1>
+          <h1>${state.mode === "need" ? "¿Qué necesitas que te hagan?" : "Escoge lo que sabes hacer"}</h1>
           <p class="lede">${
             state.mode === "need"
-              ? "Abra una categoría y marque hasta 5 cosas."
-              : "Abra una categoría y marque todo lo que esté dispuesto a hacer. No tiene que haberlo hecho por un sueldo."
+              ? "Abre una categoría y marca hasta 5 cosas."
+              : "Abre una categoría y marca todo lo que estés dispuesto a hacer. No tienes que haberlo hecho por un sueldo."
           }</p>
 
           <div class="field">
@@ -2049,7 +2125,7 @@
             <input id="q" type="text" role="combobox" autocomplete="off"
               aria-expanded="${showList}" aria-controls="results" aria-autocomplete="list"
               ${state.active >= 0 ? `aria-activedescendant="opt-${state.active}"` : ""}
-              placeholder="¿Busca algo puntual?" value="${esc(q)}" />
+              placeholder="¿Buscas algo puntual?" value="${esc(q)}" />
           </div>
 
           ${
@@ -2105,11 +2181,11 @@
           .join("");
 
         return `
-          <h1>${state.mode === "need" ? "¿A quién necesita?" : "¿En qué ha trabajado antes?"}</h1>
+          <h1>${state.mode === "need" ? "¿A quién necesitas?" : "¿En qué has trabajado antes?"}</h1>
           <p class="lede">${
             state.mode === "need"
-              ? "Escoja el oficio más parecido. En el siguiente paso ajusta lo que de verdad necesita."
-              : "Escoja hasta 3 oficios. Con eso le proponemos habilidades y usted las ajusta — nadie hace todo lo de una lista."
+              ? "Escoge el oficio más parecido. En el siguiente paso ajustas lo que de verdad necesitas."
+              : "Escoge hasta 3 oficios. Con eso te proponemos habilidades y tú las ajustas — nadie hace todo lo de una lista."
           }</p>
 
           <div class="field field--hero">
@@ -2187,13 +2263,13 @@
 
         return `
           <p class="stepnote" style="margin:0 0 var(--space-2)">Paso 2 de 2</p>
-          <h1>Quite lo que no haga</h1>
-          <p class="lede">Marcamos lo que suele hacer alguien en ese oficio. Usted sabe cuál sí y cuál
-          no — y puede añadir lo que hace por fuera del oficio.</p>
+          <h1>Quita lo que no hagas</h1>
+          <p class="lede">Marcamos lo que suele hacer alguien en ese oficio. Tú sabes cuál sí y cuál
+          no — y puedes añadir lo que haces por fuera del oficio.</p>
 
           ${bundles}
 
-          <div class="bundlehead"><h2>Añada lo que también sabe hacer</h2></div>
+          <div class="bundlehead"><h2>Añade lo que también sabes hacer</h2></div>
           <div class="field">
             <label class="visually-hidden" for="q">Añadir otra habilidad</label>
             <input id="q" type="text" role="combobox" autocomplete="off"
@@ -2219,6 +2295,7 @@
               : ""
           }
 
+          ${meterHtml()}
           ${(() => {
             const n = state.selected.length;
             let note = "";
@@ -2286,6 +2363,12 @@
         document.getElementById("modeCtl").innerHTML = seg("mode", MODES, state.mode, "setmode");
         document.getElementById("capCtl").innerHTML = seg("cap", CAPS, state.cap, "setcap");
         document.getElementById("sugCtl").innerHTML = seg("sug", SUGS, state.sug, "setsug");
+        document.getElementById("meterCtl").innerHTML = seg(
+          "meter",
+          METERS,
+          state.meter,
+          "setmeter",
+        );
         document.getElementById("stateDump").textContent =
           `${state.selected.length}/${maxFor()} · ${SKILLS.length} skills · ${DENOMINATIONS.length} denominations`;
       }
@@ -2422,6 +2505,7 @@
         state.step = 1;
         state.browseOpen = false;
         state.blocked = null;
+        state.bundled = null;
         render();
       }
       document.getElementById("prev").onclick = () => cycle(-1);
@@ -2436,6 +2520,7 @@
         state.sugOpen = false;
         state.sugSent = null;
         state.blocked = null;
+        state.bundled = null;
         render();
       };
       document.querySelector(".switcher").addEventListener("click", (e) => {
@@ -2449,6 +2534,8 @@
           state.blocked = null;
         } else if (d.setsug) {
           state.sug = d.setsug;
+        } else if (d.setmeter) {
+          state.meter = d.setmeter;
         } else return;
         render();
       });

--- a/docs/design/skill-picker-prototype/index.html
+++ b/docs/design/skill-picker-prototype/index.html
@@ -633,7 +633,7 @@
     </header>
 
     <p class="flag" style="margin-top: var(--space-4)">
-      Prototipo desechable · ticket #30 · datos de muestra, no es el vocabulario definitivo
+      Throwaway prototype · ticket #30 · sample data, not the real vocabulary
     </p>
 
     <main id="root" class="shell"></main>
@@ -646,22 +646,22 @@
       style="position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0)"
     ></div>
 
-    <div class="switcher" role="group" aria-label="Controles del prototipo">
+    <div class="switcher" role="group" aria-label="Prototype controls">
       <div class="switcher__row">
-        <button id="prev" aria-label="Variante anterior">&larr;</button>
+        <button id="prev" aria-label="Previous variant">&larr;</button>
         <span class="switcher__title" id="variantTitle"></span>
-        <button id="next" aria-label="Variante siguiente">&rarr;</button>
+        <button id="next" aria-label="Next variant">&rarr;</button>
       </div>
       <div class="switcher__row">
-        <span class="switcher__label">Objeto</span>
+        <span class="switcher__label">Publication</span>
         <span id="modeCtl"></span>
-        <span class="switcher__label">Tope</span>
+        <span class="switcher__label">Cap</span>
         <span id="capCtl"></span>
       </div>
       <div class="switcher__row">
-        <span class="switcher__label">Sugerencia</span>
+        <span class="switcher__label">Suggestion</span>
         <span id="sugCtl"></span>
-        <button id="reset">Reiniciar</button>
+        <button id="reset">Reset</button>
         <span id="stateDump" style="opacity: 0.55; margin-left: auto"></span>
       </div>
     </div>
@@ -1627,20 +1627,22 @@
       /* ==================================================================
          STATE
          ================================================================== */
+      /* The prototype's own controls are ENGLISH — see README, "Language".
+         Only the copy inside the picker is Spanish. */
       const VARIANTS = {
-        A: "Buscar — el buscador es la pantalla",
-        B: "Explorar — categorías primero",
-        C: "Oficio — “¿en qué ha trabajado?”",
+        A: "Search-first",
+        B: "Browse by group",
+        C: "Denomination-first",
       };
-      const CAPS = { contador: "contador", tope: "tope duro", elegir: "elegir" };
-      const MODES = { perfil: "perfil", necesidad: "necesidad" };
-      const SUGS = { buscar: "tras buscar", siempre: "siempre" };
+      const CAPS = { counter: "counter", "hard-stop": "hard stop", choose: "choose" };
+      const MODES = { profile: "profile", need: "need" };
+      const SUGS = { "after-search": "after search", always: "always" };
 
       const state = {
         variant: "A",
-        cap: "contador",
-        mode: "perfil",
-        sug: "buscar",
+        cap: "counter",
+        mode: "profile",
+        sug: "always",
         selected: [], // array of skill slugs, insertion-ordered
         query: "",
         active: -1, // active option index in the combobox
@@ -1653,7 +1655,7 @@
         blocked: null, // cap message currently shown
       };
 
-      const maxFor = () => (state.mode === "necesidad" ? 5 : 20);
+      const maxFor = () => (state.mode === "need" ? 5 : 20);
       const atCap = () => state.selected.length >= maxFor();
 
       /* ---------- url sync so a variant is shareable and reload-stable ----- */
@@ -1676,26 +1678,26 @@
 
       /* ---------- copy (Colombian Spanish, usted) ---------- */
       const t = {
-        trayTitle: () => (state.mode === "necesidad" ? "Lo que necesita" : "Lo que sabe hacer"),
+        trayTitle: () => (state.mode === "need" ? "Lo que necesita" : "Lo que sabe hacer"),
         cta: () => "Continuar",
         emptyZero: () =>
-          state.mode === "necesidad"
+          state.mode === "need"
             ? "Escoja al menos 1 para poder publicar su necesidad."
             : "Escoja al menos 1 para poder publicar su perfil.",
         emptyOne: () =>
-          state.mode === "necesidad"
+          state.mode === "need"
             ? "Con 1 ya puede publicar. Entre más puntual sea, mejores personas le vamos a mostrar."
             : "Con 1 ya puede publicar. Entre más habilidades escoja, en más búsquedas va a aparecer.",
         capNote: () => {
           const n = state.selected.length;
           const max = maxFor();
-          if (state.cap === "contador") {
+          if (state.cap === "counter") {
             return n >= max ? `Llegó a ${max}. Quite una para añadir otra.` : null;
           }
-          if (state.cap === "tope") {
+          if (state.cap === "hard-stop") {
             return null; // nothing until you hit the wall; see state.blocked
           }
-          // elegir
+          // choose
           if (n >= max)
             return `Estas son sus ${max}. Para añadir otra, quite la que menos le interese.`;
           if (n >= max - 5)
@@ -1704,8 +1706,8 @@
         },
         capBlocked: () => {
           const max = maxFor();
-          if (state.cap === "tope") return `No puede añadir más de ${max}.`;
-          if (state.cap === "contador") return `Llegó a ${max}. Quite una para añadir otra.`;
+          if (state.cap === "hard-stop") return `No puede añadir más de ${max}.`;
+          if (state.cap === "counter") return `Llegó a ${max}. Quite una para añadir otra.`;
           return `Ya tiene ${max}. Quite la que menos le interese para añadir esta.`;
         },
       };
@@ -1800,7 +1802,7 @@
       function counterHtml() {
         const n = state.selected.length,
           max = maxFor();
-        if (state.cap === "tope" && n < max) return "";
+        if (state.cap === "hard-stop" && n < max) return "";
         const warn = n >= max ? " counter--warn" : "";
         return `<span class="counter${warn}">${n} de ${max}</span>`;
       }
@@ -1820,7 +1822,7 @@
         else if (n === 1) note = `<p class="note note--soft">${t.emptyOne()}</p>`;
         const capNote = t.capNote();
         if (capNote) note += `<p class="note note--cap">${capNote}</p>`;
-        if (state.blocked && state.cap === "tope")
+        if (state.blocked && state.cap === "hard-stop")
           note += `<p class="note note--cap">${esc(state.blocked)}</p>`;
 
         return `<section class="tray" aria-labelledby="trayTitle">
@@ -1924,12 +1926,12 @@
           })
           .join("");
 
-        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+        const showSug = state.sug === "always" || noHits || state.sugOpen || state.sugSent;
 
         return `
-          <h1>${state.mode === "necesidad" ? "¿Qué necesita que le hagan?" : "¿Qué sabe hacer?"}</h1>
+          <h1>${state.mode === "need" ? "¿Qué necesita que le hagan?" : "¿Qué sabe hacer?"}</h1>
           <p class="lede">${
-            state.mode === "necesidad"
+            state.mode === "need"
               ? "Escriba la tarea o el oficio. Escoja hasta 5."
               : "Escriba lo que sabe hacer, o el oficio en el que ha trabajado. No necesita hoja de vida."
           }</p>
@@ -1989,7 +1991,7 @@
                     .map((l) => {
                       const s = BY_LABEL.get(l);
                       const on = state.selected.includes(s.slug);
-                      const dis = !on && atCap() && state.cap === "tope" ? "disabled" : "";
+                      const dis = !on && atCap() && state.cap === "hard-stop" ? "disabled" : "";
                       return `<label class="check">
                         <input type="checkbox" data-toggle="${s.slug}" ${on ? "checked" : ""} ${dis} />
                         <span>${esc(s.label)}</span>
@@ -1998,7 +2000,7 @@
                     .join("")}
                 </div>
                 ${
-                  state.sug === "siempre"
+                  state.sug === "always"
                     ? `<p style="margin-top:var(--space-3)"><button class="btn--link" data-sugopen="1">¿No está lo suyo en esta categoría?</button></p>`
                     : ""
                 }
@@ -2021,7 +2023,7 @@
         const res = searchAll(q);
         const showList = q.trim().length > 0;
         const noHits = showList && res.skills.length + res.oficios.length === 0;
-        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+        const showSug = state.sug === "always" || noHits || state.sugOpen || state.sugSent;
 
         const optHtml = res.skills
           .slice(0, 30)
@@ -2035,9 +2037,9 @@
           .join("");
 
         return `
-          <h1>${state.mode === "necesidad" ? "¿Qué necesita que le hagan?" : "Escoja lo que sabe hacer"}</h1>
+          <h1>${state.mode === "need" ? "¿Qué necesita que le hagan?" : "Escoja lo que sabe hacer"}</h1>
           <p class="lede">${
-            state.mode === "necesidad"
+            state.mode === "need"
               ? "Abra una categoría y marque hasta 5 cosas."
               : "Abra una categoría y marque todo lo que esté dispuesto a hacer. No tiene que haberlo hecho por un sueldo."
           }</p>
@@ -2079,7 +2081,7 @@
         const res = searchAll(q);
         const showList = q.trim().length > 0;
         const noHits = showList && res.oficios.length === 0;
-        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+        const showSug = state.sug === "always" || noHits || state.sugOpen || state.sugSent;
 
         const optHtml = res.oficios
           .slice(0, 25)
@@ -2103,9 +2105,9 @@
           .join("");
 
         return `
-          <h1>${state.mode === "necesidad" ? "¿A quién necesita?" : "¿En qué ha trabajado antes?"}</h1>
+          <h1>${state.mode === "need" ? "¿A quién necesita?" : "¿En qué ha trabajado antes?"}</h1>
           <p class="lede">${
-            state.mode === "necesidad"
+            state.mode === "need"
               ? "Escoja el oficio más parecido. En el siguiente paso ajusta lo que de verdad necesita."
               : "Escoja hasta 3 oficios. Con eso le proponemos habilidades y usted las ajusta — nadie hace todo lo de una lista."
           }</p>
@@ -2147,7 +2149,7 @@
         const res = searchAll(q);
         const showList = q.trim().length > 0;
         const noHits = showList && res.skills.length === 0;
-        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+        const showSug = state.sug === "always" || noHits || state.sugOpen || state.sugSent;
 
         const bundles = chosen
           .map((d) => {
@@ -2156,7 +2158,7 @@
                 const s = BY_LABEL.get(l);
                 if (!s) return "";
                 const on = state.selected.includes(s.slug);
-                const dis = !on && atCap() && state.cap === "tope" ? "disabled" : "";
+                const dis = !on && atCap() && state.cap === "hard-stop" ? "disabled" : "";
                 return `<label class="check">
                   <input type="checkbox" data-toggle="${s.slug}" ${on ? "checked" : ""} ${dis} />
                   <span>${esc(s.label)}</span>
@@ -2224,7 +2226,7 @@
             else if (n === 1) note = `<p class="note note--soft">${t.emptyOne()}</p>`;
             const c = t.capNote();
             if (c) note += `<p class="note note--cap">${c}</p>`;
-            if (state.blocked && state.cap === "tope")
+            if (state.blocked && state.cap === "hard-stop")
               note += `<p class="note note--cap">${esc(state.blocked)}</p>`;
             return note;
           })()}
@@ -2285,7 +2287,7 @@
         document.getElementById("capCtl").innerHTML = seg("cap", CAPS, state.cap, "setcap");
         document.getElementById("sugCtl").innerHTML = seg("sug", SUGS, state.sug, "setsug");
         document.getElementById("stateDump").textContent =
-          `${state.selected.length}/${maxFor()} · ${SKILLS.length} habilidades · ${DENOMINATIONS.length} oficios`;
+          `${state.selected.length}/${maxFor()} · ${SKILLS.length} skills · ${DENOMINATIONS.length} denominations`;
       }
 
       /* ==================================================================

--- a/docs/design/skill-picker-prototype/index.html
+++ b/docs/design/skill-picker-prototype/index.html
@@ -1,0 +1,2466 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>PROTOTIPO — Selector de habilidades (Encuentra, #30)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=DM+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ------------------------------------------------------------------
+         THROWAWAY PROTOTYPE — ticket #30, wayfinder map #1.
+         Tokens copied verbatim from apps/landing/NEXTJS_HANDOFF.md, which the
+         map records as STILL BINDING after the pivot.
+         Not production code. No tests, no error handling, no abstractions.
+         ------------------------------------------------------------------ */
+      :root {
+        --color-brand-500: #2457e6;
+        --color-brand-700: #172d70;
+        --color-ink: #172747;
+        --color-text-muted: #62708a;
+        --color-surface: #ffffff;
+        --color-page: #f7f9ff;
+        --color-surface-brand: #e8efff;
+        --color-border: #dce2ef;
+        --color-success: #387e65;
+        --color-success-surface: #e6f6ed;
+        --color-warning: #946016;
+        --color-warning-surface: #fff1c7;
+        --color-danger: #c53b5d;
+        --color-danger-surface: #fff5f7;
+
+        --font-sans: "Manrope", ui-sans-serif, system-ui, sans-serif;
+        --font-mono: "DM Mono", ui-monospace, monospace;
+        --text-2xs: 0.5rem;
+        --text-xs: 0.625rem;
+        --text-sm: 0.75rem;
+        --text-md: 0.875rem;
+        --text-lg: 1.125rem;
+        --text-display: clamp(1.75rem, 4vw, 2.5rem);
+
+        --space-1: 0.25rem;
+        --space-2: 0.5rem;
+        --space-3: 0.75rem;
+        --space-4: 1rem;
+        --space-5: 1.25rem;
+        --space-6: 1.5rem;
+        --space-8: 2rem;
+        --space-10: 2.5rem;
+        --space-12: 3rem;
+        --radius-sm: 0.3125rem;
+        --radius-md: 0.5rem;
+        --radius-lg: 0.75rem;
+        --shadow-card: 0 8px 19px rgb(38 74 150 / 8%);
+        --shadow-search: 0 13px 30px rgb(42 65 127 / 15%);
+        --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+      html {
+        -webkit-text-size-adjust: 100%;
+      }
+      body {
+        margin: 0;
+        background: var(--color-page);
+        color: var(--color-ink);
+        font-family: var(--font-sans);
+        font-size: 1rem;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+        padding-bottom: 190px; /* room for the switcher */
+      }
+
+      :focus-visible {
+        outline: 2px solid var(--color-brand-500);
+        outline-offset: 2px;
+        border-radius: var(--radius-sm);
+      }
+
+      .shell {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: var(--space-6) var(--space-5) var(--space-10);
+      }
+
+      /* ---------- shared bits (header only; each variant owns its layout) --- */
+      .topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-4) var(--space-5);
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-surface);
+      }
+      .wordmark {
+        font-weight: 800;
+        letter-spacing: -0.06em;
+        font-size: var(--text-lg);
+      }
+      .wordmark span {
+        color: var(--color-brand-500);
+      }
+      .stepnote {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+
+      h1 {
+        font-size: var(--text-display);
+        letter-spacing: -0.06em;
+        line-height: 1.1;
+        margin: 0 0 var(--space-2);
+        text-wrap: balance;
+      }
+      .lede {
+        color: var(--color-text-muted);
+        margin: 0 0 var(--space-6);
+        font-size: 1rem;
+        text-wrap: pretty;
+      }
+      h2 {
+        font-size: 1.0625rem;
+        letter-spacing: -0.04em;
+        margin: 0;
+      }
+
+      /* ---------- controls ---------- */
+      .btn {
+        font: inherit;
+        font-weight: 700;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border-radius: var(--radius-md);
+        border: 1px solid transparent;
+        background: var(--color-brand-500);
+        color: #fff;
+        cursor: pointer;
+        transition: transform 160ms var(--ease-out);
+      }
+      .btn:active {
+        transform: scale(0.97);
+      }
+      .btn[disabled] {
+        background: var(--color-border);
+        color: var(--color-text-muted);
+        cursor: not-allowed;
+      }
+      .btn[disabled]:active {
+        transform: none;
+      }
+      .btn--ghost {
+        background: transparent;
+        color: var(--color-brand-500);
+        border-color: var(--color-border);
+      }
+      .btn--link {
+        background: none;
+        border: none;
+        color: var(--color-brand-500);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        padding: var(--space-2) 0;
+        min-height: 40px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      .field {
+        position: relative;
+      }
+      .field input[type="text"],
+      .field input[type="search"],
+      textarea {
+        width: 100%;
+        font: inherit;
+        color: var(--color-ink);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        min-height: 52px;
+      }
+      textarea {
+        min-height: 96px;
+        resize: vertical;
+      }
+      .field--hero input {
+        font-size: 1.0625rem;
+        min-height: 60px;
+        box-shadow: var(--shadow-search);
+        border-color: transparent;
+      }
+      label.visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+      }
+
+      /* ---------- listbox (combobox results) ---------- */
+      .listbox {
+        list-style: none;
+        margin: var(--space-2) 0 0;
+        padding: var(--space-1);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-card);
+        max-height: 340px;
+        overflow-y: auto;
+      }
+      .opt {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        min-height: 48px;
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+      }
+      .opt[aria-selected="true"] {
+        background: var(--color-surface-brand);
+      }
+      .opt__label {
+        flex: 1;
+      }
+      .opt__meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+      }
+      .opt__group {
+        display: block;
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+      }
+      .opt__mark {
+        width: 22px;
+        text-align: center;
+        font-weight: 800;
+        color: var(--color-brand-500);
+      }
+      .opt--added .opt__label {
+        color: var(--color-text-muted);
+      }
+      .opt--oficio .opt__label::after {
+        content: "";
+      }
+
+      .tag {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--color-brand-700);
+        background: var(--color-surface-brand);
+        border-radius: var(--radius-sm);
+        padding: 2px 6px;
+      }
+
+      /* ---------- chips ---------- */
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        min-height: 40px;
+        padding: 0 var(--space-2) 0 var(--space-4);
+        border-radius: 999px;
+        border: 1px solid var(--color-border);
+        background: var(--color-surface);
+        font: inherit;
+        font-size: var(--text-md);
+        cursor: pointer;
+        transition: transform 160ms var(--ease-out);
+      }
+      .chip:active {
+        transform: scale(0.97);
+      }
+      .chip--on {
+        background: var(--color-surface-brand);
+        border-color: var(--color-brand-500);
+        color: var(--color-brand-700);
+        font-weight: 600;
+      }
+      .chip--plain {
+        padding: 0 var(--space-4);
+      }
+      .chip__x {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border-radius: 999px;
+        background: rgb(23 45 112 / 8%);
+        font-size: var(--text-md);
+        line-height: 1;
+      }
+
+      /* ---------- cards / groups ---------- */
+      .card {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-card);
+      }
+      .grouplist {
+        display: grid;
+        gap: var(--space-3);
+      }
+      .group__head {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        min-height: 60px;
+        padding: var(--space-3) var(--space-4);
+        background: none;
+        border: none;
+        font: inherit;
+        font-weight: 700;
+        letter-spacing: -0.03em;
+        text-align: left;
+        cursor: pointer;
+        border-radius: var(--radius-lg);
+      }
+      .group__count {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .group__picked {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-brand-700);
+        background: var(--color-surface-brand);
+        border-radius: 999px;
+        padding: 2px 8px;
+        font-variant-numeric: tabular-nums;
+      }
+      .group__chev {
+        margin-left: auto;
+        color: var(--color-text-muted);
+      }
+      .group__body {
+        padding: 0 var(--space-4) var(--space-4);
+        border-top: 1px solid var(--color-border);
+      }
+      .checks {
+        display: grid;
+        gap: 2px;
+        margin: var(--space-3) 0 0;
+      }
+      .check {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        min-height: 44px;
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-md);
+        cursor: pointer;
+      }
+      .check input {
+        width: 20px;
+        height: 20px;
+        accent-color: var(--color-brand-500);
+        flex: none;
+      }
+      .check input:disabled + span {
+        color: var(--color-text-muted);
+      }
+
+      /* ---------- tray / cap ---------- */
+      .tray {
+        margin-top: var(--space-6);
+      }
+      .tray__head {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-3);
+        margin-bottom: var(--space-3);
+      }
+      .counter {
+        font-family: var(--font-mono);
+        font-variant-numeric: tabular-nums;
+        font-size: var(--text-md);
+        color: var(--color-text-muted);
+      }
+      .counter--warn {
+        color: var(--color-warning);
+        background: var(--color-warning-surface);
+        border-radius: var(--radius-sm);
+        padding: 2px 6px;
+      }
+      .note {
+        margin: var(--space-3) 0 0;
+        font-size: var(--text-md);
+        color: var(--color-text-muted);
+        text-wrap: pretty;
+      }
+      .note--cap {
+        color: var(--color-ink);
+        background: var(--color-warning-surface);
+        border-left: 3px solid var(--color-warning);
+        padding: var(--space-3) var(--space-4);
+        border-radius: var(--radius-sm);
+      }
+      .note--soft {
+        background: var(--color-success-surface);
+        border-left: 3px solid var(--color-success);
+        color: var(--color-ink);
+        padding: var(--space-3) var(--space-4);
+        border-radius: var(--radius-sm);
+      }
+      .note--empty {
+        background: var(--color-surface);
+        border: 1px dashed var(--color-border);
+        padding: var(--space-4);
+        border-radius: var(--radius-md);
+      }
+
+      .stickybar {
+        position: sticky;
+        bottom: 150px;
+        z-index: 5;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        margin-top: var(--space-6);
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-search);
+      }
+
+      /* ---------- suggestion ---------- */
+      .sug {
+        margin-top: var(--space-5);
+        padding: var(--space-4);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        background: var(--color-surface);
+      }
+      .sug h3 {
+        margin: 0 0 var(--space-2);
+        font-size: 1rem;
+        letter-spacing: -0.03em;
+      }
+      .sug p {
+        margin: 0 0 var(--space-3);
+        color: var(--color-text-muted);
+        font-size: var(--text-md);
+        text-wrap: pretty;
+      }
+
+      /* ---------- oficio tiles (variant C) ---------- */
+      .tiles {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+        gap: var(--space-3);
+        list-style: none;
+        margin: var(--space-4) 0 0;
+        padding: 0;
+      }
+      .tile {
+        width: 100%;
+        min-height: 76px;
+        padding: var(--space-3) var(--space-4);
+        text-align: left;
+        font: inherit;
+        font-weight: 700;
+        letter-spacing: -0.03em;
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        cursor: pointer;
+        transition: transform 160ms var(--ease-out);
+      }
+      .tile:active {
+        transform: scale(0.97);
+      }
+      .tile--on {
+        border-color: var(--color-brand-500);
+        background: var(--color-surface-brand);
+        color: var(--color-brand-700);
+      }
+      .tile small {
+        display: block;
+        font-weight: 500;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        margin-top: 2px;
+      }
+      .tile--on small {
+        color: var(--color-brand-700);
+      }
+
+      .bundlehead {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-2);
+        margin: var(--space-6) 0 var(--space-2);
+      }
+      .bundlehead h2 {
+        font-size: var(--text-md);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--color-text-muted);
+        font-family: var(--font-mono);
+        font-weight: 500;
+      }
+
+      /* ---------- the switcher (deliberately NOT part of the design) ------- */
+      .switcher {
+        position: fixed;
+        left: 50%;
+        bottom: var(--space-4);
+        transform: translateX(-50%);
+        z-index: 50;
+        width: min(680px, calc(100vw - 24px));
+        background: #0d1730;
+        color: #fff;
+        border-radius: var(--radius-lg);
+        box-shadow: 0 12px 40px rgb(8 16 40 / 40%);
+        padding: var(--space-3);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+      }
+      .switcher__row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .switcher__row + .switcher__row {
+        margin-top: var(--space-2);
+        padding-top: var(--space-2);
+        border-top: 1px solid rgb(255 255 255 / 12%);
+      }
+      .switcher__title {
+        flex: 1;
+        text-align: center;
+        font-size: var(--text-md);
+        letter-spacing: 0.02em;
+      }
+      .switcher button {
+        font: inherit;
+        min-height: 36px;
+        padding: 0 var(--space-3);
+        border-radius: var(--radius-sm);
+        border: 1px solid rgb(255 255 255 / 20%);
+        background: transparent;
+        color: #fff;
+        cursor: pointer;
+      }
+      .switcher button[aria-pressed="true"] {
+        background: #fff;
+        color: #0d1730;
+        border-color: #fff;
+        font-weight: 500;
+      }
+      .switcher__label {
+        opacity: 0.6;
+        padding-right: var(--space-1);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: var(--text-xs);
+      }
+      .switcher :focus-visible {
+        outline-color: #fff;
+      }
+
+      .flag {
+        margin: 0 auto var(--space-4);
+        max-width: 720px;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--color-danger);
+        background: var(--color-danger-surface);
+        border: 1px solid currentColor;
+        border-radius: var(--radius-sm);
+        padding: var(--space-2) var(--space-3);
+        text-align: center;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          transition: none !important;
+          animation: none !important;
+        }
+      }
+      @media (max-width: 520px) {
+        body {
+          padding-bottom: 230px;
+        }
+        .stickybar {
+          bottom: 190px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="wordmark">Encuentra<span>.</span></div>
+      <div class="stepnote" id="stepnote"></div>
+    </header>
+
+    <p class="flag" style="margin-top: var(--space-4)">
+      Prototipo desechable · ticket #30 · datos de muestra, no es el vocabulario definitivo
+    </p>
+
+    <main id="root" class="shell"></main>
+
+    <!-- one live region for the whole prototype -->
+    <div
+      id="live"
+      role="status"
+      aria-live="polite"
+      style="position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0)"
+    ></div>
+
+    <div class="switcher" role="group" aria-label="Controles del prototipo">
+      <div class="switcher__row">
+        <button id="prev" aria-label="Variante anterior">&larr;</button>
+        <span class="switcher__title" id="variantTitle"></span>
+        <button id="next" aria-label="Variante siguiente">&rarr;</button>
+      </div>
+      <div class="switcher__row">
+        <span class="switcher__label">Objeto</span>
+        <span id="modeCtl"></span>
+        <span class="switcher__label">Tope</span>
+        <span id="capCtl"></span>
+      </div>
+      <div class="switcher__row">
+        <span class="switcher__label">Sugerencia</span>
+        <span id="sugCtl"></span>
+        <button id="reset">Reiniciar</button>
+        <span id="stateDump" style="opacity: 0.55; margin-left: auto"></span>
+      </div>
+    </div>
+
+    <script>
+      /* ==================================================================
+         FIXTURE DATA — a plausible sample, authored for this prototype only.
+         ADR-0012 targets ~250–350 Skills in 12–15 Groups; this is 256 in 14.
+         The real list (and the proxy-rule audit over it) is an implementation
+         ticket, explicitly out of scope for #30.
+         CUOC ships 14,462 denominaciones; 56 are sampled here.
+         ================================================================== */
+      const GROUPS = [
+        {
+          name: "Cocina y alimentos",
+          skills: [
+            "preparación de comida casera",
+            "cocina a la parrilla y asados",
+            "preparación de desayunos",
+            "repostería y tortas",
+            "panadería",
+            "preparación de jugos y bebidas",
+            "preparación de arepas y envueltos",
+            "manejo de freidora",
+            "alistamiento de ingredientes",
+            "lavado de loza y cocina",
+            "atención de barra y cafetería",
+            "preparación de café",
+            "manejo de horno industrial",
+            "conservación y refrigeración de alimentos",
+            "manipulación higiénica de alimentos",
+            "elaboración de tamales",
+            "venta de comida en la calle",
+            "preparación de comida para grupos grandes",
+            "empaque de comida para domicilio",
+            "control de inventario de cocina",
+          ],
+        },
+        {
+          name: "Ventas y atención al cliente",
+          skills: [
+            "atención al cliente",
+            "manejo de caja",
+            "venta en mostrador",
+            "venta por catálogo",
+            "venta ambulante",
+            "venta por WhatsApp",
+            "toma de pedidos",
+            "cobro con datáfono",
+            "empaque de mercancía",
+            "surtido de estantería",
+            "conteo de inventario",
+            "recepción de mercancía",
+            "atención telefónica",
+            "manejo de quejas y reclamos",
+            "volanteo y promoción",
+            "demostración de producto",
+            "venta puerta a puerta",
+            "apertura y cierre de local",
+            "arqueo de caja",
+            "atención en punto de pago",
+          ],
+        },
+        {
+          name: "Limpieza y mantenimiento",
+          skills: [
+            "aseo general de vivienda",
+            "lavado y planchado de ropa",
+            "lavado de baños",
+            "limpieza de vidrios y ventanas",
+            "brillado y encerado de pisos",
+            "aseo de oficinas",
+            "aseo de locales comerciales",
+            "limpieza después de obra",
+            "lavado de alfombras y tapetes",
+            "lavado de muebles",
+            "organización de espacios",
+            "manejo de productos de aseo",
+            "recolección y separación de basuras",
+            "aseo de zonas comunes",
+            "limpieza de fachadas",
+            "desinfección de espacios",
+            "lavado de cortinas",
+            "limpieza de cocinas industriales",
+            "mantenimiento de piscinas",
+            "manejo de máquina brilladora",
+          ],
+        },
+        {
+          name: "Cuidado de personas",
+          skills: [
+            "cuidado de niños",
+            "acompañamiento de adultos mayores",
+            "acompañamiento de personas enfermas",
+            "ayuda con tareas escolares",
+            "preparación de comida para dietas especiales",
+            "apoyo en el baño y aseo personal",
+            "administración de medicamentos según fórmula",
+            "acompañamiento a citas médicas",
+            "toma de signos vitales",
+            "primeros auxilios",
+            "cuidado de personas con discapacidad",
+            "movilización y traslado de pacientes",
+            "acompañamiento nocturno",
+            "estimulación temprana",
+            "recreación con niños",
+            "lengua de señas",
+            "cuidado de recién nacidos",
+            "apoyo en terapia física",
+            "acompañamiento en hospitalización",
+            "organización de rutinas de cuidado",
+          ],
+        },
+        {
+          name: "Construcción y obra",
+          skills: [
+            "albañilería",
+            "pega de ladrillo",
+            "pañete y estuco",
+            "enchape de baldosa",
+            "instalación de cerámica",
+            "armado de estructuras metálicas",
+            "figurado y amarre de hierro",
+            "preparación de mezcla",
+            "carga y descarga",
+            "demolición",
+            "excavación manual",
+            "instalación de drywall",
+            "techado y cubiertas",
+            "impermeabilización",
+            "pintura de interiores",
+            "pintura de fachadas",
+            "instalación de guardaescobas",
+            "acabados de obra blanca",
+            "apoyo general en obra",
+            "armado de andamios",
+          ],
+        },
+        {
+          name: "Transporte y domicilios",
+          skills: [
+            "conducción de motocicleta",
+            "entrega de domicilios",
+            "conducción de automóvil",
+            "conducción de camión",
+            "conducción de taxi",
+            "mensajería urbana",
+            "transporte de pasajeros",
+            "transporte de carga",
+            "entrega de paquetería",
+            "manejo de rutas de reparto",
+            "conducción de bicicleta de carga",
+            "trasteos y mudanzas",
+            "acomodo de carga en vehículo",
+            "manejo de montacargas",
+            "conducción de camioneta",
+            "recolección de encomiendas",
+            "acompañamiento en ruta escolar",
+            "mantenimiento básico de motocicleta",
+          ],
+        },
+        {
+          name: "Oficios y reparaciones",
+          skills: [
+            "plomería",
+            "electricidad residencial",
+            "carpintería",
+            "soldadura",
+            "ebanistería",
+            "reparación de electrodomésticos",
+            "reparación de celulares",
+            "reparación de computadores",
+            "latonería y pintura de vehículos",
+            "mecánica de motocicletas",
+            "mecánica automotriz",
+            "instalación de aire acondicionado",
+            "refrigeración",
+            "cerrajería",
+            "vidriería",
+            "instalación de cámaras de seguridad",
+            "instalación de redes e internet",
+            "reparación de bicicletas",
+            "tapicería",
+            "afilado de herramientas",
+          ],
+        },
+        {
+          name: "Belleza y cuidado personal",
+          skills: [
+            "corte de cabello",
+            "peinados",
+            "tintura de cabello",
+            "manicura",
+            "pedicura",
+            "depilación",
+            "maquillaje",
+            "barbería",
+            "alisado y tratamientos capilares",
+            "masajes de relajación",
+            "uñas acrílicas",
+            "maquillaje para eventos",
+            "asesoría de imagen",
+            "limpieza facial",
+            "extensiones de cabello",
+            "peluquería canina",
+          ],
+        },
+        {
+          name: "Campo y animales",
+          skills: [
+            "siembra y cosecha",
+            "recolección de café",
+            "despulpado y secado de café",
+            "cuidado de huerta",
+            "poda de árboles",
+            "jardinería",
+            "corte de césped",
+            "manejo de vivero",
+            "ordeño",
+            "cuidado de ganado",
+            "cría de aves de corral",
+            "cuidado de cerdos",
+            "paseo de perros",
+            "guardería de mascotas",
+            "baño de mascotas",
+            "apicultura",
+            "fumigación de cultivos",
+            "manejo de sistemas de riego",
+          ],
+        },
+        {
+          name: "Oficina y trámites",
+          skills: [
+            "digitación de datos",
+            "archivo y organización de documentos",
+            "atención de recepción",
+            "agendamiento de citas",
+            "manejo de correo electrónico",
+            "elaboración de facturas",
+            "manejo de Excel",
+            "contabilidad básica",
+            "manejo de caja menor",
+            "trámites bancarios",
+            "trámites en notaría",
+            "transcripción de textos",
+            "toma de actas",
+            "elaboración de cartas y comunicados",
+            "manejo de inventarios en sistema",
+            "cotizaciones y compras",
+            "atención de chat y mensajería",
+            "radicación de documentos",
+          ],
+        },
+        {
+          name: "Computador e internet",
+          skills: [
+            "manejo de redes sociales",
+            "edición de fotografía",
+            "edición de video",
+            "diseño de piezas gráficas",
+            "creación de contenido para redes",
+            "manejo de tiendas en línea",
+            "publicación de anuncios en línea",
+            "soporte técnico básico",
+            "instalación de programas",
+            "manejo de Word",
+            "manejo de Google Drive",
+            "digitalización de documentos",
+            "fotografía de producto",
+            "redacción de textos",
+            "manejo de WhatsApp Business",
+            "atención de pedidos en aplicaciones",
+            "manejo de impresoras y escáner",
+            "respaldo de información",
+          ],
+        },
+        {
+          name: "Eventos, música y creatividad",
+          skills: [
+            "meseo en eventos",
+            "montaje y desmontaje de eventos",
+            "decoración de eventos",
+            "animación de fiestas infantiles",
+            "sonido y amplificación",
+            "iluminación de eventos",
+            "fotografía de eventos",
+            "video de eventos",
+            "interpretación de instrumento musical",
+            "canto",
+            "baile",
+            "presentación y animación de eventos",
+            "arreglos florales",
+            "globoflexia",
+            "pintura y muralismo",
+            "manualidades",
+            "elaboración de piñatas",
+            "servicio de bar en eventos",
+          ],
+        },
+        {
+          name: "Confección y textiles",
+          skills: [
+            "costura a máquina",
+            "costura a mano",
+            "arreglo de ropa",
+            "toma de medidas",
+            "corte de tela",
+            "confección de uniformes",
+            "bordado",
+            "tejido a mano",
+            "tejido a máquina",
+            "estampado de camisetas",
+            "reparación de calzado",
+            "elaboración de bolsos",
+            "ojal y botón",
+            "terminado y pulido de prendas",
+            "planchado industrial",
+            "revisión de calidad de prendas",
+          ],
+        },
+        {
+          name: "Seguridad y vigilancia",
+          skills: [
+            "vigilancia de instalaciones",
+            "portería",
+            "control de acceso",
+            "rondas de seguridad",
+            "monitoreo de cámaras",
+            "manejo de radio de comunicaciones",
+            "control de ingreso de vehículos",
+            "apoyo en evacuaciones",
+            "control de aglomeraciones",
+            "manejo de extintores",
+            "registro de visitantes",
+            "apoyo logístico en eventos masivos",
+            "custodia de bienes",
+            "elaboración de minuta de turno",
+          ],
+        },
+      ];
+
+      const DENOMINATIONS = [
+        {
+          name: "Mesero",
+          alt: ["mesera"],
+          skills: [
+            "atención al cliente",
+            "toma de pedidos",
+            "meseo en eventos",
+            "servicio de bar en eventos",
+            "lavado de loza y cocina",
+            "manejo de caja",
+          ],
+        },
+        {
+          name: "Niñera",
+          alt: ["aya", "cuidadora de niños"],
+          skills: [
+            "cuidado de niños",
+            "ayuda con tareas escolares",
+            "recreación con niños",
+            "preparación de comida casera",
+            "aseo general de vivienda",
+            "cuidado de recién nacidos",
+          ],
+        },
+        {
+          name: "Domiciliario",
+          alt: ["repartidor", "rappitendero"],
+          skills: [
+            "entrega de domicilios",
+            "conducción de motocicleta",
+            "manejo de rutas de reparto",
+            "atención de pedidos en aplicaciones",
+            "mensajería urbana",
+            "mantenimiento básico de motocicleta",
+          ],
+        },
+        {
+          name: "Empleada doméstica",
+          alt: ["señora del aseo", "interna"],
+          skills: [
+            "aseo general de vivienda",
+            "lavado y planchado de ropa",
+            "preparación de comida casera",
+            "lavado de baños",
+            "organización de espacios",
+            "cuidado de niños",
+          ],
+        },
+        {
+          name: "Cocinero",
+          alt: ["cocinera", "chef"],
+          skills: [
+            "preparación de comida casera",
+            "alistamiento de ingredientes",
+            "manipulación higiénica de alimentos",
+            "preparación de comida para grupos grandes",
+            "control de inventario de cocina",
+            "manejo de horno industrial",
+          ],
+        },
+        {
+          name: "Ayudante de cocina",
+          alt: ["auxiliar de cocina"],
+          skills: [
+            "alistamiento de ingredientes",
+            "lavado de loza y cocina",
+            "manipulación higiénica de alimentos",
+            "manejo de freidora",
+          ],
+        },
+        {
+          name: "Panadero",
+          alt: ["panadera", "pastelero"],
+          skills: [
+            "panadería",
+            "repostería y tortas",
+            "manejo de horno industrial",
+            "manipulación higiénica de alimentos",
+            "empaque de comida para domicilio",
+          ],
+        },
+        {
+          name: "Barista",
+          alt: [],
+          skills: [
+            "preparación de café",
+            "atención de barra y cafetería",
+            "atención al cliente",
+            "manejo de caja",
+          ],
+        },
+        {
+          name: "Vendedor",
+          alt: ["vendedora", "asesor comercial"],
+          skills: [
+            "atención al cliente",
+            "venta en mostrador",
+            "manejo de caja",
+            "surtido de estantería",
+            "conteo de inventario",
+            "toma de pedidos",
+          ],
+        },
+        {
+          name: "Vendedor ambulante",
+          alt: ["venteros"],
+          skills: [
+            "venta ambulante",
+            "venta de comida en la calle",
+            "venta puerta a puerta",
+            "manejo de caja",
+          ],
+        },
+        {
+          name: "Cajero",
+          alt: ["cajera"],
+          skills: [
+            "manejo de caja",
+            "cobro con datáfono",
+            "arqueo de caja",
+            "atención en punto de pago",
+            "atención al cliente",
+          ],
+        },
+        {
+          name: "Tendero",
+          alt: ["tendera"],
+          skills: [
+            "venta en mostrador",
+            "manejo de caja",
+            "surtido de estantería",
+            "conteo de inventario",
+            "apertura y cierre de local",
+          ],
+        },
+        {
+          name: "Impulsadora",
+          alt: ["impulsador"],
+          skills: [
+            "demostración de producto",
+            "volanteo y promoción",
+            "atención al cliente",
+            "venta en mostrador",
+          ],
+        },
+        {
+          name: "Aseador",
+          alt: ["aseadora", "auxiliar de aseo"],
+          skills: [
+            "aseo de oficinas",
+            "aseo de locales comerciales",
+            "lavado de baños",
+            "manejo de productos de aseo",
+            "recolección y separación de basuras",
+            "brillado y encerado de pisos",
+          ],
+        },
+        {
+          name: "Auxiliar de servicios generales",
+          alt: [],
+          skills: [
+            "aseo de oficinas",
+            "aseo de zonas comunes",
+            "recolección y separación de basuras",
+            "manejo de productos de aseo",
+            "limpieza de vidrios y ventanas",
+          ],
+        },
+        {
+          name: "Lavandera",
+          alt: ["lavandero", "planchadora"],
+          skills: ["lavado y planchado de ropa", "lavado de cortinas", "planchado industrial"],
+        },
+        {
+          name: "Celador",
+          alt: ["vigilante", "guarda de seguridad"],
+          skills: [
+            "vigilancia de instalaciones",
+            "rondas de seguridad",
+            "monitoreo de cámaras",
+            "control de acceso",
+            "elaboración de minuta de turno",
+          ],
+        },
+        {
+          name: "Portero",
+          alt: ["portera"],
+          skills: [
+            "portería",
+            "control de acceso",
+            "registro de visitantes",
+            "rondas de seguridad",
+          ],
+        },
+        {
+          name: "Albañil",
+          alt: ["maestro de obra", "oficial de obra"],
+          skills: [
+            "albañilería",
+            "pega de ladrillo",
+            "pañete y estuco",
+            "preparación de mezcla",
+            "enchape de baldosa",
+            "acabados de obra blanca",
+          ],
+        },
+        {
+          name: "Ayudante de construcción",
+          alt: ["ayudante de albañilería", "obrero"],
+          skills: [
+            "apoyo general en obra",
+            "carga y descarga",
+            "preparación de mezcla",
+            "demolición",
+            "excavación manual",
+            "armado de andamios",
+          ],
+        },
+        {
+          name: "Pintor",
+          alt: ["pintora"],
+          skills: [
+            "pintura de interiores",
+            "pintura de fachadas",
+            "pañete y estuco",
+            "impermeabilización",
+          ],
+        },
+        {
+          name: "Plomero",
+          alt: ["fontanero"],
+          skills: ["plomería", "instalación de cerámica", "impermeabilización"],
+        },
+        {
+          name: "Electricista",
+          alt: [],
+          skills: [
+            "electricidad residencial",
+            "instalación de cámaras de seguridad",
+            "instalación de redes e internet",
+          ],
+        },
+        {
+          name: "Carpintero",
+          alt: ["ebanista"],
+          skills: ["carpintería", "ebanistería", "tapicería", "instalación de guardaescobas"],
+        },
+        {
+          name: "Soldador",
+          alt: ["ornamentador"],
+          skills: [
+            "soldadura",
+            "armado de estructuras metálicas",
+            "figurado y amarre de hierro",
+            "afilado de herramientas",
+          ],
+        },
+        {
+          name: "Mecánico de motos",
+          alt: ["motorista"],
+          skills: [
+            "mecánica de motocicletas",
+            "mantenimiento básico de motocicleta",
+            "reparación de bicicletas",
+            "soldadura",
+          ],
+        },
+        {
+          name: "Mecánico automotriz",
+          alt: ["latonero"],
+          skills: ["mecánica automotriz", "latonería y pintura de vehículos", "soldadura"],
+        },
+        {
+          name: "Conductor",
+          alt: ["conductora", "chofer"],
+          skills: [
+            "conducción de automóvil",
+            "conducción de camión",
+            "transporte de carga",
+            "transporte de pasajeros",
+            "acomodo de carga en vehículo",
+          ],
+        },
+        {
+          name: "Conductor de camión",
+          alt: ["camionero"],
+          skills: [
+            "conducción de camión",
+            "transporte de carga",
+            "acomodo de carga en vehículo",
+            "manejo de rutas de reparto",
+          ],
+        },
+        {
+          name: "Taxista",
+          alt: [],
+          skills: [
+            "conducción de taxi",
+            "conducción de automóvil",
+            "transporte de pasajeros",
+            "atención al cliente",
+          ],
+        },
+        {
+          name: "Mensajero",
+          alt: ["mensajera"],
+          skills: [
+            "mensajería urbana",
+            "conducción de motocicleta",
+            "radicación de documentos",
+            "trámites bancarios",
+            "recolección de encomiendas",
+          ],
+        },
+        {
+          name: "Bodeguero",
+          alt: ["auxiliar de bodega"],
+          skills: [
+            "recepción de mercancía",
+            "conteo de inventario",
+            "manejo de montacargas",
+            "carga y descarga",
+            "manejo de inventarios en sistema",
+          ],
+        },
+        {
+          name: "Estilista",
+          alt: ["peluquera", "peluquero"],
+          skills: [
+            "corte de cabello",
+            "peinados",
+            "tintura de cabello",
+            "alisado y tratamientos capilares",
+            "extensiones de cabello",
+          ],
+        },
+        { name: "Barbero", alt: [], skills: ["barbería", "corte de cabello", "peinados"] },
+        {
+          name: "Manicurista",
+          alt: ["pedicurista"],
+          skills: ["manicura", "pedicura", "uñas acrílicas", "depilación"],
+        },
+        {
+          name: "Maquilladora",
+          alt: ["maquillador"],
+          skills: [
+            "maquillaje",
+            "maquillaje para eventos",
+            "asesoría de imagen",
+            "limpieza facial",
+          ],
+        },
+        {
+          name: "Jardinero",
+          alt: ["jardinera"],
+          skills: [
+            "jardinería",
+            "corte de césped",
+            "poda de árboles",
+            "manejo de sistemas de riego",
+            "manejo de vivero",
+          ],
+        },
+        {
+          name: "Recolector de café",
+          alt: ["cafetero", "chapolero"],
+          skills: ["recolección de café", "despulpado y secado de café", "siembra y cosecha"],
+        },
+        {
+          name: "Ordeñador",
+          alt: ["vaquero", "mayordomo de finca"],
+          skills: ["ordeño", "cuidado de ganado", "cría de aves de corral"],
+        },
+        {
+          name: "Paseador de perros",
+          alt: ["cuidador de mascotas"],
+          skills: ["paseo de perros", "baño de mascotas", "guardería de mascotas"],
+        },
+        {
+          name: "Secretaria",
+          alt: ["secretario", "asistente administrativa"],
+          skills: [
+            "atención de recepción",
+            "agendamiento de citas",
+            "archivo y organización de documentos",
+            "manejo de correo electrónico",
+            "digitación de datos",
+            "elaboración de cartas y comunicados",
+          ],
+        },
+        {
+          name: "Recepcionista",
+          alt: [],
+          skills: [
+            "atención de recepción",
+            "registro de visitantes",
+            "agendamiento de citas",
+            "atención telefónica",
+            "atención al cliente",
+          ],
+        },
+        {
+          name: "Auxiliar contable",
+          alt: ["asistente contable"],
+          skills: [
+            "contabilidad básica",
+            "elaboración de facturas",
+            "manejo de Excel",
+            "manejo de caja menor",
+            "radicación de documentos",
+          ],
+        },
+        {
+          name: "Digitador",
+          alt: ["digitadora"],
+          skills: [
+            "digitación de datos",
+            "transcripción de textos",
+            "manejo de Word",
+            "digitalización de documentos",
+          ],
+        },
+        {
+          name: "Community manager",
+          alt: ["manejo de redes"],
+          skills: [
+            "manejo de redes sociales",
+            "creación de contenido para redes",
+            "diseño de piezas gráficas",
+            "publicación de anuncios en línea",
+            "edición de fotografía",
+          ],
+        },
+        {
+          name: "Diseñador gráfico",
+          alt: ["diseñadora gráfica"],
+          skills: [
+            "diseño de piezas gráficas",
+            "edición de fotografía",
+            "edición de video",
+            "creación de contenido para redes",
+          ],
+        },
+        {
+          name: "Fotógrafo",
+          alt: ["fotógrafa", "camarógrafo"],
+          skills: [
+            "fotografía de eventos",
+            "fotografía de producto",
+            "edición de fotografía",
+            "video de eventos",
+          ],
+        },
+        {
+          name: "Sonidista",
+          alt: ["dj", "luminotécnico"],
+          skills: [
+            "sonido y amplificación",
+            "iluminación de eventos",
+            "montaje y desmontaje de eventos",
+          ],
+        },
+        {
+          name: "Animador de fiestas",
+          alt: ["recreacionista", "payaso"],
+          skills: [
+            "animación de fiestas infantiles",
+            "recreación con niños",
+            "globoflexia",
+            "elaboración de piñatas",
+            "presentación y animación de eventos",
+          ],
+        },
+        {
+          name: "Decorador de eventos",
+          alt: ["decoradora", "florista"],
+          skills: [
+            "decoración de eventos",
+            "arreglos florales",
+            "montaje y desmontaje de eventos",
+            "globoflexia",
+            "manualidades",
+          ],
+        },
+        {
+          name: "Modista",
+          alt: ["costurera", "sastre"],
+          skills: [
+            "costura a máquina",
+            "arreglo de ropa",
+            "toma de medidas",
+            "corte de tela",
+            "confección de uniformes",
+          ],
+        },
+        {
+          name: "Operario de confección",
+          alt: ["operaria de confección", "satelital"],
+          skills: [
+            "costura a máquina",
+            "ojal y botón",
+            "terminado y pulido de prendas",
+            "revisión de calidad de prendas",
+            "planchado industrial",
+          ],
+        },
+        {
+          name: "Zapatero",
+          alt: ["remontadora"],
+          skills: ["reparación de calzado", "elaboración de bolsos", "costura a mano"],
+        },
+        {
+          name: "Cuidador de adulto mayor",
+          alt: ["cuidadora", "acompañante"],
+          skills: [
+            "acompañamiento de adultos mayores",
+            "apoyo en el baño y aseo personal",
+            "administración de medicamentos según fórmula",
+            "acompañamiento a citas médicas",
+            "preparación de comida para dietas especiales",
+            "acompañamiento nocturno",
+          ],
+        },
+        {
+          name: "Auxiliar de enfermería",
+          alt: ["enfermera"],
+          skills: [
+            "toma de signos vitales",
+            "administración de medicamentos según fórmula",
+            "acompañamiento en hospitalización",
+            "movilización y traslado de pacientes",
+            "primeros auxilios",
+          ],
+        },
+        {
+          name: "Técnico de celulares",
+          alt: ["técnico de computadores"],
+          skills: [
+            "reparación de celulares",
+            "reparación de computadores",
+            "soporte técnico básico",
+            "instalación de programas",
+          ],
+        },
+        {
+          name: "Instalador de redes",
+          alt: ["técnico de internet"],
+          skills: [
+            "instalación de redes e internet",
+            "instalación de cámaras de seguridad",
+            "soporte técnico básico",
+          ],
+        },
+      ];
+
+      const POPULAR = [
+        "atención al cliente",
+        "cuidado de niños",
+        "aseo general de vivienda",
+        "preparación de comida casera",
+        "conducción de motocicleta",
+        "manejo de caja",
+        "entrega de domicilios",
+        "costura a máquina",
+      ];
+
+      const COMMON_OFICIOS = [
+        "Mesero",
+        "Niñera",
+        "Domiciliario",
+        "Empleada doméstica",
+        "Vendedor",
+        "Albañil",
+        "Conductor",
+        "Cocinero",
+        "Aseador",
+        "Celador",
+        "Estilista",
+        "Ayudante de construcción",
+      ];
+
+      /* ---------- derived indexes ---------- */
+      const DIACRITICS = /[̀-ͯ]/g;
+      const slug = (s) =>
+        s
+          .normalize("NFD")
+          .replace(DIACRITICS, "")
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-|-$/g, "");
+      const norm = (s) => s.normalize("NFD").replace(DIACRITICS, "").toLowerCase();
+
+      const SKILLS = [];
+      GROUPS.forEach((g, gi) => {
+        g.slug = slug(g.name);
+        g.index = gi;
+        g.skills.forEach((label) => {
+          SKILLS.push({
+            slug: slug(label),
+            label,
+            group: g.name,
+            groupIndex: gi,
+            search: norm(label),
+          });
+        });
+      });
+      const BY_SLUG = new Map(SKILLS.map((s) => [s.slug, s]));
+      const BY_LABEL = new Map(SKILLS.map((s) => [s.label, s]));
+
+      // fixture integrity: every denomination bundle must reference a real skill
+      const BROKEN = [];
+      DENOMINATIONS.forEach((d) => {
+        d.slug = slug(d.name);
+        d.search = [norm(d.name)].concat((d.alt || []).map(norm));
+        d.skills.forEach((l) => {
+          if (!BY_LABEL.has(l)) BROKEN.push(d.name + " → " + l);
+        });
+      });
+      if (BROKEN.length) console.warn("Fixture references unknown skills:", BROKEN);
+
+      /* ==================================================================
+         STATE
+         ================================================================== */
+      const VARIANTS = {
+        A: "Buscar — el buscador es la pantalla",
+        B: "Explorar — categorías primero",
+        C: "Oficio — “¿en qué ha trabajado?”",
+      };
+      const CAPS = { contador: "contador", tope: "tope duro", elegir: "elegir" };
+      const MODES = { perfil: "perfil", necesidad: "necesidad" };
+      const SUGS = { buscar: "tras buscar", siempre: "siempre" };
+
+      const state = {
+        variant: "A",
+        cap: "contador",
+        mode: "perfil",
+        sug: "buscar",
+        selected: [], // array of skill slugs, insertion-ordered
+        query: "",
+        active: -1, // active option index in the combobox
+        openGroup: null,
+        browseOpen: false, // variant A only: the "ver todas las categorías" panel
+        step: 1, // variant C
+        oficios: [], // variant C, denomination slugs
+        sugOpen: false,
+        sugSent: null,
+        blocked: null, // cap message currently shown
+      };
+
+      const maxFor = () => (state.mode === "necesidad" ? 5 : 20);
+      const atCap = () => state.selected.length >= maxFor();
+
+      /* ---------- url sync so a variant is shareable and reload-stable ----- */
+      function readUrl() {
+        const p = new URLSearchParams(location.search);
+        if (VARIANTS[p.get("variant")]) state.variant = p.get("variant");
+        if (CAPS[p.get("cap")]) state.cap = p.get("cap");
+        if (MODES[p.get("mode")]) state.mode = p.get("mode");
+        if (SUGS[p.get("sug")]) state.sug = p.get("sug");
+      }
+      function writeUrl() {
+        const p = new URLSearchParams({
+          variant: state.variant,
+          cap: state.cap,
+          mode: state.mode,
+          sug: state.sug,
+        });
+        history.replaceState(null, "", location.pathname + "?" + p.toString());
+      }
+
+      /* ---------- copy (Colombian Spanish, usted) ---------- */
+      const t = {
+        trayTitle: () => (state.mode === "necesidad" ? "Lo que necesita" : "Lo que sabe hacer"),
+        cta: () => "Continuar",
+        emptyZero: () =>
+          state.mode === "necesidad"
+            ? "Escoja al menos 1 para poder publicar su necesidad."
+            : "Escoja al menos 1 para poder publicar su perfil.",
+        emptyOne: () =>
+          state.mode === "necesidad"
+            ? "Con 1 ya puede publicar. Entre más puntual sea, mejores personas le vamos a mostrar."
+            : "Con 1 ya puede publicar. Entre más habilidades escoja, en más búsquedas va a aparecer.",
+        capNote: () => {
+          const n = state.selected.length;
+          const max = maxFor();
+          if (state.cap === "contador") {
+            return n >= max ? `Llegó a ${max}. Quite una para añadir otra.` : null;
+          }
+          if (state.cap === "tope") {
+            return null; // nothing until you hit the wall; see state.blocked
+          }
+          // elegir
+          if (n >= max)
+            return `Estas son sus ${max}. Para añadir otra, quite la que menos le interese.`;
+          if (n >= max - 5)
+            return `Le quedan ${max - n}. Deje las que más quiera hacer, no todas las que aceptaría.`;
+          return null;
+        },
+        capBlocked: () => {
+          const max = maxFor();
+          if (state.cap === "tope") return `No puede añadir más de ${max}.`;
+          if (state.cap === "contador") return `Llegó a ${max}. Quite una para añadir otra.`;
+          return `Ya tiene ${max}. Quite la que menos le interese para añadir esta.`;
+        },
+      };
+
+      /* ==================================================================
+         SEARCH
+         ================================================================== */
+      function searchAll(q) {
+        const n = norm(q.trim());
+        if (!n) return { skills: [], oficios: [] };
+        const score = (hay) => (hay.startsWith(n) ? 0 : hay.includes(n) ? 1 : -1);
+        const skills = SKILLS.map((s) => ({ s, r: score(s.search) }))
+          .filter((x) => x.r >= 0)
+          .sort((a, b) => a.r - b.r || a.s.label.localeCompare(b.s.label))
+          .map((x) => x.s);
+        const oficios = DENOMINATIONS.map((d) => ({
+          d,
+          r: Math.min(
+            ...d.search
+              .map(score)
+              .filter((v) => v >= 0)
+              .concat([9]),
+          ),
+        }))
+          .filter((x) => x.r < 9)
+          .sort((a, b) => a.r - b.r || a.d.name.localeCompare(b.d.name))
+          .map((x) => x.d);
+        return { skills, oficios };
+      }
+
+      /* ==================================================================
+         MUTATIONS
+         ================================================================== */
+      const say = (msg) => {
+        document.getElementById("live").textContent = msg;
+      };
+
+      function add(skillSlug, opts = {}) {
+        if (state.selected.includes(skillSlug)) return true;
+        if (atCap()) {
+          state.blocked = t.capBlocked();
+          say(state.blocked);
+          render();
+          return false;
+        }
+        state.selected.push(skillSlug);
+        state.blocked = null;
+        if (!opts.silent)
+          say(`Añadida: ${BY_SLUG.get(skillSlug).label}. ${state.selected.length} de ${maxFor()}.`);
+        return true;
+      }
+      function remove(skillSlug) {
+        state.selected = state.selected.filter((s) => s !== skillSlug);
+        state.blocked = null;
+        say(`Quitada: ${BY_SLUG.get(skillSlug).label}. ${state.selected.length} de ${maxFor()}.`);
+      }
+      function toggle(skillSlug) {
+        if (state.selected.includes(skillSlug)) remove(skillSlug);
+        else add(skillSlug);
+        render();
+      }
+      function addBundle(den) {
+        let added = 0,
+          skipped = 0;
+        den.skills.forEach((label) => {
+          const s = BY_LABEL.get(label);
+          if (!s) return;
+          if (state.selected.includes(s.slug)) return;
+          if (atCap()) {
+            skipped++;
+            return;
+          }
+          state.selected.push(s.slug);
+          added++;
+        });
+        state.blocked = skipped ? t.capBlocked() : null;
+        say(
+          `${added} habilidades añadidas de ${den.name}.` +
+            (skipped ? ` ${skipped} no cupieron. ${t.capBlocked()}` : ""),
+        );
+      }
+
+      /* ==================================================================
+         RENDER HELPERS
+         ================================================================== */
+      const esc = (s) =>
+        String(s).replace(
+          /[&<>"']/g,
+          (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+        );
+
+      function counterHtml() {
+        const n = state.selected.length,
+          max = maxFor();
+        if (state.cap === "tope" && n < max) return "";
+        const warn = n >= max ? " counter--warn" : "";
+        return `<span class="counter${warn}">${n} de ${max}</span>`;
+      }
+
+      function trayHtml() {
+        const n = state.selected.length;
+        const chips = state.selected
+          .map((sl) => {
+            const s = BY_SLUG.get(sl);
+            return `<li><button class="chip chip--on" data-remove="${s.slug}" aria-label="Quitar ${esc(s.label)}">
+              ${esc(s.label)} <span class="chip__x" aria-hidden="true">&times;</span></button></li>`;
+          })
+          .join("");
+
+        let note = "";
+        if (n === 0) note = `<p class="note note--empty">${t.emptyZero()}</p>`;
+        else if (n === 1) note = `<p class="note note--soft">${t.emptyOne()}</p>`;
+        const capNote = t.capNote();
+        if (capNote) note += `<p class="note note--cap">${capNote}</p>`;
+        if (state.blocked && state.cap === "tope")
+          note += `<p class="note note--cap">${esc(state.blocked)}</p>`;
+
+        return `<section class="tray" aria-labelledby="trayTitle">
+          <div class="tray__head">
+            <h2 id="trayTitle">${t.trayTitle()}</h2>
+            ${counterHtml()}
+          </div>
+          ${n ? `<ul class="chips">${chips}</ul>` : ""}
+          ${note}
+        </section>`;
+      }
+
+      function sugPanelHtml(query) {
+        if (state.sugSent) {
+          const near = searchAll(state.sugSent).skills.slice(0, 3);
+          const nearHtml = near.length
+            ? `<ul class="chips">${near
+                .map(
+                  (s) =>
+                    `<li><button class="chip chip--plain" data-add="${s.slug}">${esc(s.label)}</button></li>`,
+                )
+                .join("")}</ul>`
+            : `<ul class="chips">${POPULAR.slice(0, 3)
+                .map((l) => BY_LABEL.get(l))
+                .map(
+                  (s) =>
+                    `<li><button class="chip chip--plain" data-add="${s.slug}">${esc(s.label)}</button></li>`,
+                )
+                .join("")}</ul>`;
+          return `<div class="sug">
+            <h3>Gracias. Lo leemos nosotros.</h3>
+            <p>No entra a su publicación y no se usa para buscarlo. Mientras tanto, escoja lo más
+            parecido que encuentre — así ya queda visible hoy.</p>
+            ${nearHtml}
+          </div>`;
+        }
+        if (!state.sugOpen) {
+          return `<div class="sug">
+            <h3>¿No encuentra lo que usted hace?</h3>
+            <p>Cuéntenos con sus palabras. Lo leemos nosotros.</p>
+            <button class="btn btn--ghost" data-sugopen="1">Cuéntenos qué sabe hacer</button>
+          </div>`;
+        }
+        return `<form class="sug" data-sugform="1">
+          <h3>Cuéntenos qué sabe hacer</h3>
+          <p>Lo leemos nosotros y puede que lo agreguemos más adelante. No entra a su publicación
+          y no se usa para buscarlo.</p>
+          <label class="visually-hidden" for="sugText">Escríbalo con sus palabras</label>
+          <textarea id="sugText" name="sugText" placeholder="Escríbalo con sus palabras">${esc(query || "")}</textarea>
+          <div style="display:flex;gap:var(--space-3);margin-top:var(--space-3)">
+            <button class="btn" type="submit">Enviar</button>
+            <button class="btn btn--ghost" type="button" data-sugclose="1">Cancelar</button>
+          </div>
+        </form>`;
+      }
+
+      /* ==================================================================
+         VARIANT A — search-first
+         ================================================================== */
+      function variantA() {
+        const q = state.query;
+        const res = searchAll(q);
+        const options = []
+          .concat(res.oficios.map((d) => ({ kind: "oficio", d })))
+          .concat(res.skills.map((s) => ({ kind: "skill", s })));
+        const showList = q.trim().length > 0;
+        const noHits = showList && options.length === 0;
+
+        const optHtml = options
+          .slice(0, 40)
+          .map((o, i) => {
+            const active = i === state.active ? ' aria-selected="true"' : ' aria-selected="false"';
+            if (o.kind === "oficio") {
+              const already = o.d.skills.filter((l) => {
+                const s = BY_LABEL.get(l);
+                return s && state.selected.includes(s.slug);
+              }).length;
+              return `<li class="opt opt--oficio" role="option" id="opt-${i}"${active} data-i="${i}" data-oficio="${o.d.slug}">
+                <span class="opt__mark" aria-hidden="true">+</span>
+                <span class="opt__label"><strong>${esc(o.d.name)}</strong>
+                  <span class="opt__group">añade ${o.d.skills.length} habilidades${already ? ` · ya tiene ${already}` : ""}</span>
+                </span>
+                <span class="tag">oficio</span>
+              </li>`;
+            }
+            const on = state.selected.includes(o.s.slug);
+            return `<li class="opt${on ? " opt--added" : ""}" role="option" id="opt-${i}"${active} data-i="${i}" data-add="${o.s.slug}">
+              <span class="opt__mark" aria-hidden="true">${on ? "✓" : "+"}</span>
+              <span class="opt__label">${esc(o.s.label)}
+                <span class="opt__group">${esc(o.s.group)}</span>
+              </span>
+            </li>`;
+          })
+          .join("");
+
+        const popularHtml = POPULAR.map((l) => BY_LABEL.get(l))
+          .filter(Boolean)
+          .map((s) => {
+            const on = state.selected.includes(s.slug);
+            return `<li><button class="chip${on ? " chip--on" : " chip--plain"}" data-toggle="${s.slug}" aria-pressed="${on}">${esc(s.label)}</button></li>`;
+          })
+          .join("");
+
+        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+
+        return `
+          <h1>${state.mode === "necesidad" ? "¿Qué necesita que le hagan?" : "¿Qué sabe hacer?"}</h1>
+          <p class="lede">${
+            state.mode === "necesidad"
+              ? "Escriba la tarea o el oficio. Escoja hasta 5."
+              : "Escriba lo que sabe hacer, o el oficio en el que ha trabajado. No necesita hoja de vida."
+          }</p>
+
+          <div class="field field--hero">
+            <label class="visually-hidden" for="q">Buscar habilidades y oficios</label>
+            <input id="q" type="text" role="combobox" autocomplete="off"
+              aria-expanded="${showList}" aria-controls="results" aria-autocomplete="list"
+              ${state.active >= 0 ? `aria-activedescendant="opt-${state.active}"` : ""}
+              placeholder="Ej.: cocinar, moto, aseo, mesero…" value="${esc(q)}" />
+          </div>
+
+          ${
+            showList
+              ? options.length
+                ? `<ul class="listbox" id="results" role="listbox" aria-label="Resultados">${optHtml}</ul>`
+                : `<p class="note note--empty" id="results">No encontramos «${esc(q)}». Pruebe con otra palabra — o cuéntenos.</p>`
+              : `<div id="results" hidden></div>
+                 <p class="note" style="margin-top:var(--space-5)">O empiece por aquí</p>
+                 <ul class="chips" style="margin-top:var(--space-2)">${popularHtml}</ul>
+                 <p style="margin-top:var(--space-4)"><button class="btn--link" data-openbrowse="1">Ver todas las categorías</button></p>`
+          }
+
+          ${state.browseOpen && !showList ? browsePanel() : ""}
+          ${trayHtml()}
+          ${showSug ? sugPanelHtml(q) : ""}
+          <div class="stickybar">
+            <span class="counter">${state.selected.length} de ${maxFor()}</span>
+            <button class="btn" ${state.selected.length === 0 ? "disabled" : ""}>${t.cta()}</button>
+          </div>`;
+      }
+
+      function browsePanel() {
+        return `<div class="card" style="margin-top:var(--space-5);padding:var(--space-4)">
+          <div style="display:flex;justify-content:space-between;align-items:center;gap:var(--space-3)">
+            <h2>Categorías</h2>
+            <button class="btn--link" data-closebrowse="1">Cerrar</button>
+          </div>
+          ${groupsHtml()}
+        </div>`;
+      }
+
+      /* ==================================================================
+         VARIANT B — browse-by-Group first
+         ================================================================== */
+      function groupsHtml() {
+        return `<div class="grouplist">${GROUPS.map((g) => {
+          const open = state.openGroup === g.slug;
+          const picked = g.skills.filter((l) => {
+            const s = BY_LABEL.get(l);
+            return s && state.selected.includes(s.slug);
+          }).length;
+          const body = open
+            ? `<div class="group__body" id="grp-${g.slug}">
+                <div class="checks">
+                  ${g.skills
+                    .map((l) => {
+                      const s = BY_LABEL.get(l);
+                      const on = state.selected.includes(s.slug);
+                      const dis = !on && atCap() && state.cap === "tope" ? "disabled" : "";
+                      return `<label class="check">
+                        <input type="checkbox" data-toggle="${s.slug}" ${on ? "checked" : ""} ${dis} />
+                        <span>${esc(s.label)}</span>
+                      </label>`;
+                    })
+                    .join("")}
+                </div>
+                ${
+                  state.sug === "siempre"
+                    ? `<p style="margin-top:var(--space-3)"><button class="btn--link" data-sugopen="1">¿No está lo suyo en esta categoría?</button></p>`
+                    : ""
+                }
+              </div>`
+            : "";
+          return `<section class="card">
+            <button class="group__head" data-group="${g.slug}" aria-expanded="${open}" aria-controls="grp-${g.slug}">
+              <span>${esc(g.name)}</span>
+              ${picked ? `<span class="group__picked">${picked}</span>` : ""}
+              <span class="group__count">${g.skills.length}</span>
+              <span class="group__chev" aria-hidden="true">${open ? "▲" : "▼"}</span>
+            </button>
+            ${body}
+          </section>`;
+        }).join("")}</div>`;
+      }
+
+      function variantB() {
+        const q = state.query;
+        const res = searchAll(q);
+        const showList = q.trim().length > 0;
+        const noHits = showList && res.skills.length + res.oficios.length === 0;
+        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+
+        const optHtml = res.skills
+          .slice(0, 30)
+          .map((s, i) => {
+            const on = state.selected.includes(s.slug);
+            return `<li class="opt${on ? " opt--added" : ""}" role="option" id="opt-${i}" aria-selected="${i === state.active}" data-i="${i}" data-add="${s.slug}">
+              <span class="opt__mark" aria-hidden="true">${on ? "✓" : "+"}</span>
+              <span class="opt__label">${esc(s.label)}<span class="opt__group">${esc(s.group)}</span></span>
+            </li>`;
+          })
+          .join("");
+
+        return `
+          <h1>${state.mode === "necesidad" ? "¿Qué necesita que le hagan?" : "Escoja lo que sabe hacer"}</h1>
+          <p class="lede">${
+            state.mode === "necesidad"
+              ? "Abra una categoría y marque hasta 5 cosas."
+              : "Abra una categoría y marque todo lo que esté dispuesto a hacer. No tiene que haberlo hecho por un sueldo."
+          }</p>
+
+          <div class="field">
+            <label class="visually-hidden" for="q">Buscar dentro de las categorías</label>
+            <input id="q" type="text" role="combobox" autocomplete="off"
+              aria-expanded="${showList}" aria-controls="results" aria-autocomplete="list"
+              ${state.active >= 0 ? `aria-activedescendant="opt-${state.active}"` : ""}
+              placeholder="¿Busca algo puntual?" value="${esc(q)}" />
+          </div>
+
+          ${
+            showList
+              ? res.skills.length
+                ? `<ul class="listbox" id="results" role="listbox" aria-label="Resultados">${optHtml}</ul>`
+                : `<p class="note note--empty" id="results">No encontramos «${esc(q)}».</p>`
+              : `<div id="results" hidden></div><div style="margin-top:var(--space-5)">${groupsHtml()}</div>`
+          }
+
+          ${trayHtml()}
+          ${showSug ? sugPanelHtml(q) : ""}
+          <div class="stickybar">
+            <span class="counter">${state.selected.length} de ${maxFor()}</span>
+            <button class="btn" ${state.selected.length === 0 ? "disabled" : ""}>${t.cta()}</button>
+          </div>`;
+      }
+
+      /* ==================================================================
+         VARIANT C — denomination-first, with a mandatory edit step
+         ================================================================== */
+      function variantC() {
+        if (state.step === 1) return variantCStep1();
+        return variantCStep2();
+      }
+
+      function variantCStep1() {
+        const q = state.query;
+        const res = searchAll(q);
+        const showList = q.trim().length > 0;
+        const noHits = showList && res.oficios.length === 0;
+        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+
+        const optHtml = res.oficios
+          .slice(0, 25)
+          .map((d, i) => {
+            const on = state.oficios.includes(d.slug);
+            return `<li class="opt" role="option" id="opt-${i}" aria-selected="${i === state.active}" data-i="${i}" data-pickoficio="${d.slug}">
+              <span class="opt__mark" aria-hidden="true">${on ? "✓" : "+"}</span>
+              <span class="opt__label"><strong>${esc(d.name)}</strong>
+                <span class="opt__group">${d.skills.length} habilidades sugeridas</span></span>
+            </li>`;
+          })
+          .join("");
+
+        const tiles = COMMON_OFICIOS.map((name) => DENOMINATIONS.find((d) => d.name === name))
+          .filter(Boolean)
+          .map((d) => {
+            const on = state.oficios.includes(d.slug);
+            return `<li><button class="tile${on ? " tile--on" : ""}" data-pickoficio="${d.slug}" aria-pressed="${on}">
+              ${esc(d.name)}<small>${d.skills.length} habilidades</small></button></li>`;
+          })
+          .join("");
+
+        return `
+          <h1>${state.mode === "necesidad" ? "¿A quién necesita?" : "¿En qué ha trabajado antes?"}</h1>
+          <p class="lede">${
+            state.mode === "necesidad"
+              ? "Escoja el oficio más parecido. En el siguiente paso ajusta lo que de verdad necesita."
+              : "Escoja hasta 3 oficios. Con eso le proponemos habilidades y usted las ajusta — nadie hace todo lo de una lista."
+          }</p>
+
+          <div class="field field--hero">
+            <label class="visually-hidden" for="q">Buscar un oficio</label>
+            <input id="q" type="text" role="combobox" autocomplete="off"
+              aria-expanded="${showList}" aria-controls="results" aria-autocomplete="list"
+              ${state.active >= 0 ? `aria-activedescendant="opt-${state.active}"` : ""}
+              placeholder="Ej.: mesero, niñera, albañil…" value="${esc(q)}" />
+          </div>
+
+          ${
+            showList
+              ? res.oficios.length
+                ? `<ul class="listbox" id="results" role="listbox" aria-label="Oficios">${optHtml}</ul>`
+                : `<p class="note note--empty" id="results">No encontramos el oficio «${esc(q)}».</p>`
+              : `<div id="results" hidden></div><ul class="tiles">${tiles}</ul>`
+          }
+
+          ${
+            state.oficios.length
+              ? `<div class="stickybar">
+                  <span class="counter">${state.oficios.length} oficio${state.oficios.length > 1 ? "s" : ""}</span>
+                  <button class="btn" data-tostep2="1">Ver las habilidades</button>
+                </div>`
+              : `<p style="margin-top:var(--space-6)">
+                  <button class="btn--link" data-nooficio="1">No tengo un oficio fijo — prefiero escoger yo</button>
+                </p>`
+          }
+          ${showSug ? sugPanelHtml(q) : ""}`;
+      }
+
+      function variantCStep2() {
+        const chosen = state.oficios
+          .map((s) => DENOMINATIONS.find((d) => d.slug === s))
+          .filter(Boolean);
+        const q = state.query;
+        const res = searchAll(q);
+        const showList = q.trim().length > 0;
+        const noHits = showList && res.skills.length === 0;
+        const showSug = state.sug === "siempre" || noHits || state.sugOpen || state.sugSent;
+
+        const bundles = chosen
+          .map((d) => {
+            const rows = d.skills
+              .map((l) => {
+                const s = BY_LABEL.get(l);
+                if (!s) return "";
+                const on = state.selected.includes(s.slug);
+                const dis = !on && atCap() && state.cap === "tope" ? "disabled" : "";
+                return `<label class="check">
+                  <input type="checkbox" data-toggle="${s.slug}" ${on ? "checked" : ""} ${dis} />
+                  <span>${esc(s.label)}</span>
+                </label>`;
+              })
+              .join("");
+            return `<div class="bundlehead"><h2>Lo que suele hacer un ${esc(d.name.toLowerCase())}</h2></div>
+              <div class="card" style="padding:var(--space-3) var(--space-4)"><div class="checks">${rows}</div></div>`;
+          })
+          .join("");
+
+        const extra = state.selected
+          .map((sl) => BY_SLUG.get(sl))
+          .filter((s) => !chosen.some((d) => d.skills.includes(s.label)));
+
+        const optHtml = res.skills
+          .slice(0, 25)
+          .map((s, i) => {
+            const on = state.selected.includes(s.slug);
+            return `<li class="opt${on ? " opt--added" : ""}" role="option" id="opt-${i}" aria-selected="${i === state.active}" data-i="${i}" data-add="${s.slug}">
+              <span class="opt__mark" aria-hidden="true">${on ? "✓" : "+"}</span>
+              <span class="opt__label">${esc(s.label)}<span class="opt__group">${esc(s.group)}</span></span>
+            </li>`;
+          })
+          .join("");
+
+        return `
+          <p class="stepnote" style="margin:0 0 var(--space-2)">Paso 2 de 2</p>
+          <h1>Quite lo que no haga</h1>
+          <p class="lede">Marcamos lo que suele hacer alguien en ese oficio. Usted sabe cuál sí y cuál
+          no — y puede añadir lo que hace por fuera del oficio.</p>
+
+          ${bundles}
+
+          <div class="bundlehead"><h2>Añada lo que también sabe hacer</h2></div>
+          <div class="field">
+            <label class="visually-hidden" for="q">Añadir otra habilidad</label>
+            <input id="q" type="text" role="combobox" autocomplete="off"
+              aria-expanded="${showList}" aria-controls="results" aria-autocomplete="list"
+              ${state.active >= 0 ? `aria-activedescendant="opt-${state.active}"` : ""}
+              placeholder="Ej.: manejo de caja, jardinería…" value="${esc(q)}" />
+          </div>
+          ${
+            showList
+              ? res.skills.length
+                ? `<ul class="listbox" id="results" role="listbox" aria-label="Resultados">${optHtml}</ul>`
+                : `<p class="note note--empty" id="results">No encontramos «${esc(q)}».</p>`
+              : `<div id="results" hidden></div>`
+          }
+          ${
+            extra.length
+              ? `<ul class="chips" style="margin-top:var(--space-3)">${extra
+                  .map(
+                    (s) =>
+                      `<li><button class="chip chip--on" data-remove="${s.slug}" aria-label="Quitar ${esc(s.label)}">${esc(s.label)} <span class="chip__x" aria-hidden="true">&times;</span></button></li>`,
+                  )
+                  .join("")}</ul>`
+              : ""
+          }
+
+          ${(() => {
+            const n = state.selected.length;
+            let note = "";
+            if (n === 0) note = `<p class="note note--empty">${t.emptyZero()}</p>`;
+            else if (n === 1) note = `<p class="note note--soft">${t.emptyOne()}</p>`;
+            const c = t.capNote();
+            if (c) note += `<p class="note note--cap">${c}</p>`;
+            if (state.blocked && state.cap === "tope")
+              note += `<p class="note note--cap">${esc(state.blocked)}</p>`;
+            return note;
+          })()}
+
+          ${showSug ? sugPanelHtml(q) : ""}
+
+          <div class="stickybar">
+            <span class="counter">${state.selected.length} de ${maxFor()}</span>
+            <span style="display:flex;gap:var(--space-3)">
+              <button class="btn btn--ghost" data-tostep1="1">Atrás</button>
+              <button class="btn" ${state.selected.length === 0 ? "disabled" : ""}>${t.cta()}</button>
+            </span>
+          </div>`;
+      }
+
+      /* ==================================================================
+         RENDER
+         ================================================================== */
+      const root = document.getElementById("root");
+
+      function render() {
+        const act = document.activeElement;
+        const keepId = act && act.id === "q" ? "q" : act && act.id === "sugText" ? "sugText" : null;
+        const caret = keepId ? act.selectionStart : null;
+
+        root.innerHTML =
+          state.variant === "A" ? variantA() : state.variant === "B" ? variantB() : variantC();
+
+        if (keepId) {
+          const el = document.getElementById(keepId);
+          if (el) {
+            el.focus();
+            try {
+              el.setSelectionRange(caret, caret);
+            } catch (e) {}
+          }
+        }
+
+        document.getElementById("stepnote").textContent =
+          state.variant === "C" && state.step === 2 ? "Paso 2 de 2" : "Paso 1 de 2";
+        renderSwitcher();
+        writeUrl();
+      }
+
+      /* ---------- switcher ---------- */
+      function seg(id, map, current, attr) {
+        return Object.entries(map)
+          .map(
+            ([k, label]) =>
+              `<button data-${attr}="${k}" aria-pressed="${k === current}">${label}</button>`,
+          )
+          .join("");
+      }
+      function renderSwitcher() {
+        document.getElementById("variantTitle").textContent =
+          state.variant + " — " + VARIANTS[state.variant];
+        document.getElementById("modeCtl").innerHTML = seg("mode", MODES, state.mode, "setmode");
+        document.getElementById("capCtl").innerHTML = seg("cap", CAPS, state.cap, "setcap");
+        document.getElementById("sugCtl").innerHTML = seg("sug", SUGS, state.sug, "setsug");
+        document.getElementById("stateDump").textContent =
+          `${state.selected.length}/${maxFor()} · ${SKILLS.length} habilidades · ${DENOMINATIONS.length} oficios`;
+      }
+
+      /* ==================================================================
+         EVENTS
+         ================================================================== */
+      root.addEventListener("click", (e) => {
+        const el = e.target.closest(
+          "[data-add],[data-remove],[data-toggle],[data-oficio],[data-pickoficio],[data-group],[data-openbrowse],[data-closebrowse],[data-sugopen],[data-sugclose],[data-tostep2],[data-tostep1],[data-nooficio]",
+        );
+        if (!el) return;
+        const d = el.dataset;
+
+        if (el.tagName === "INPUT" && el.type === "checkbox") return; // handled on change
+
+        if (d.add) {
+          add(d.add);
+          render();
+        } else if (d.remove) {
+          remove(d.remove);
+          render();
+        } else if (d.toggle) {
+          toggle(d.toggle);
+        } else if (d.oficio) {
+          const den = DENOMINATIONS.find((x) => x.slug === d.oficio);
+          addBundle(den);
+          state.query = "";
+          state.active = -1;
+          render();
+        } else if (d.pickoficio) {
+          const has = state.oficios.includes(d.pickoficio);
+          if (has) state.oficios = state.oficios.filter((s) => s !== d.pickoficio);
+          else if (state.oficios.length < 3) state.oficios.push(d.pickoficio);
+          state.query = "";
+          state.active = -1;
+          render();
+        } else if (d.group) {
+          state.openGroup = state.openGroup === d.group ? null : d.group;
+          render();
+        } else if (d.openbrowse) {
+          state.browseOpen = true;
+          state.openGroup = GROUPS[0].slug;
+          render();
+        } else if (d.closebrowse) {
+          state.browseOpen = false;
+          state.openGroup = null;
+          render();
+        } else if (d.sugopen) {
+          state.sugOpen = true;
+          state.sugSent = null;
+          render();
+        } else if (d.sugclose) {
+          state.sugOpen = false;
+          render();
+        } else if (d.tostep2) {
+          state.oficios.forEach((s) => addBundle(DENOMINATIONS.find((x) => x.slug === s)));
+          state.step = 2;
+          state.query = "";
+          render();
+        } else if (d.tostep1) {
+          state.step = 1;
+          state.query = "";
+          render();
+        } else if (d.nooficio) {
+          state.variant = "B";
+          render();
+          say("Cambiamos a escoger por categorías.");
+        }
+      });
+
+      root.addEventListener("change", (e) => {
+        if (e.target.matches('input[type="checkbox"][data-toggle]')) {
+          toggle(e.target.dataset.toggle);
+        }
+      });
+
+      root.addEventListener("input", (e) => {
+        if (e.target.id === "q") {
+          state.query = e.target.value;
+          state.active = -1;
+          state.blocked = null;
+          render();
+          const r = document.getElementById("results");
+          const n = r && r.tagName === "UL" ? r.children.length : 0;
+          say(n ? `${n} resultados` : state.query.trim() ? "Sin resultados" : "");
+        }
+      });
+
+      root.addEventListener("submit", (e) => {
+        if (e.target.matches("[data-sugform]")) {
+          e.preventDefault();
+          const v = e.target.querySelector("#sugText").value.trim();
+          state.sugSent = v || state.query;
+          state.sugOpen = false;
+          render();
+          say("Enviado. Lo leemos nosotros.");
+        }
+      });
+
+      root.addEventListener("keydown", (e) => {
+        if (e.target.id !== "q") return;
+        const list = document.getElementById("results");
+        const opts = list && list.tagName === "UL" ? [...list.children] : [];
+        if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+          if (!opts.length) return;
+          e.preventDefault();
+          state.active =
+            e.key === "ArrowDown"
+              ? (state.active + 1) % opts.length
+              : (state.active - 1 + opts.length) % opts.length;
+          render();
+          const active = document.getElementById("opt-" + state.active);
+          if (active) active.scrollIntoView({ block: "nearest" });
+          if (active) say(active.textContent.trim());
+        } else if (e.key === "Enter") {
+          if (state.active < 0 || !opts.length) return;
+          e.preventDefault();
+          opts[state.active].click();
+        } else if (e.key === "Escape") {
+          state.query = "";
+          state.active = -1;
+          render();
+        }
+      });
+
+      /* ---------- switcher events ---------- */
+      const order = Object.keys(VARIANTS);
+      function cycle(delta) {
+        const i = order.indexOf(state.variant);
+        state.variant = order[(i + delta + order.length) % order.length];
+        state.query = "";
+        state.active = -1;
+        state.step = 1;
+        state.browseOpen = false;
+        state.blocked = null;
+        render();
+      }
+      document.getElementById("prev").onclick = () => cycle(-1);
+      document.getElementById("next").onclick = () => cycle(1);
+      document.getElementById("reset").onclick = () => {
+        state.selected = [];
+        state.oficios = [];
+        state.query = "";
+        state.step = 1;
+        state.openGroup = null;
+        state.browseOpen = false;
+        state.sugOpen = false;
+        state.sugSent = null;
+        state.blocked = null;
+        render();
+      };
+      document.querySelector(".switcher").addEventListener("click", (e) => {
+        const d = e.target.dataset || {};
+        if (d.setmode) {
+          state.mode = d.setmode;
+          state.selected = state.selected.slice(0, maxFor());
+          state.blocked = null;
+        } else if (d.setcap) {
+          state.cap = d.setcap;
+          state.blocked = null;
+        } else if (d.setsug) {
+          state.sug = d.setsug;
+        } else return;
+        render();
+      });
+
+      document.addEventListener("keydown", (e) => {
+        const tag = (document.activeElement || {}).tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || document.activeElement.isContentEditable)
+          return;
+        if (e.key === "ArrowLeft") cycle(-1);
+        if (e.key === "ArrowRight") cycle(1);
+      });
+
+      readUrl();
+      render();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Resolves #30. **ADR-0023** — 0021 went to the erasure session and 0022/0024 to the environments session.

Additive only: 3,096 lines added, none removed. Merges clean onto `dev` (verified with `git merge-tree` against `1be7650`).

## The decision

**Search-first.** One hero box — *"¿Qué sabes hacer?"* — over Skills and Denominations in the same result list. Browsing by Skill Group survives as a secondary path; the Denomination survives *inside* search; neither is the opening move.

**Browse-by-Group loses on what a Group *is*.** ADR-0012 built Skill Groups as scaffolding *"never an input to anything"* and *"not the second level the vocabulary deliberately lacks"*. Leading with fourteen of them has a person read them as **categories of person**, pick the one matching the job they lost, and never open the other thirteen — rebuilding the occupation tier out of labels that were never meant to mean anything.

**Denomination-first loses on one sentence:** it makes *"what were you employed as"* the first question the product asks. ADR-0012 exists because *"a hotel receptionist can do many things she was never employed to do"*, and a downstream edit step cannot undo a frame the first screen sets. Its own *"no tengo un oficio fijo"* escape is the proof — a first screen whose honest answer for many people is *"none of these"* sorts the audience.

**Search wins** because `mesero` still returns `Mesero · añade 6 habilidades` next to the individual Skills. The person who thinks in job titles keeps ADR-0012's shortcut; the person who thinks in tasks never meets one. Neither is asked which they are.

Cost named rather than hidden: **search demands you know a word** — mitigated by an authored Colombian vocabulary, ~14,762 entry points instead of ~300, common Skills as chips on an empty box, and ADR-0014's zero-result counter making the cost *measured* rather than assumed.

## The rest

- **The Denomination bundle adds straight to the tray**, with one editing note. Forced review rejected as a modal detour; silent add rejected as ADR-0012's *"accepted unedited"* failure. **The ADR says plainly this is weaker than a forced edit** — what replaces compulsion is that the chips are already on screen.
- **The cap of 20 is `choose`** — silent below 15, then *"deja las que más quieras hacer, no todas las que aceptarías"*. The only treatment carrying ADR-0012's reasoning into the copy; a counter frames 20 as a quota from the first tap, which is the behaviour the cap exists to prevent.
- **The Skill Suggestion is unconditional.** Behind a failed search it reads as an error state and never hears from the person who searched an approximate word and settled. Two unrelaxable rules: never promise the term (`@repo/catalog` is read-only at runtime), never dead-end.
- **A completion meter ships, and its shape is the decision** — not a percentage of 20, which tells someone with four real skills they are 20% of a person, but a bar marking the **floor**: *"Con 1 ya puedes publicar · 20 es el máximo"*. **Supersedes `NEXTJS_HANDOFF.md`'s `CompletionMeter`**: progress may be shown, completeness may not be scored.
- **Near-empty**: 0 blocks plainly, exactly 1 gets one **non-escalating** note, 2+ silence.

## Deliberately not decided

**The Need picker → #35.** The prototype shows the picker works for a Need *mechanically* and nothing more. The hirer thinks in job titles — the one case where Denomination-first is obviously right, *and* where ADR-0012 least wants a title framing the object and UAESPE Res. 129 art. 5 bites. Deciding it from the worker's screen would be deciding it wrong.

## Also in this PR

**ADR-0001 amended** for a reason unrelated to the picker: **a prototype's own controls are English**, only the copy inside the prototyped surface is Spanish. Spanish chrome grows Spanish state keys (`state.cap === "elegir"`) — the two-language codebase ADR-0001 exists to prevent, arriving through a file nobody thought counted.

**`CONTEXT.md`** gains an **address rule** (UI copy is `tú`; `usted` tried and overruled, `vos` never a candidate) and amends **Denomination** and **Skill Suggestion**.

**The prototype** at `docs/design/skill-picker-prototype/` is throwaway and kept as the primary source — all three variants and every toggle, since the losing options are the evidence for the winner. Open `index.html`; no build. Its 256 fixture terms in 14 Groups and 57 Denominations are sample data sized to ADR-0012's target so the alternatives could be judged at real density, and are **not the seed**.

## Reviewer notes

- **Accessibility is specified, not verified.** Real WAI-ARIA combobox, one polite live region over adds/removes/counts/refusals, real checkboxes, 40px targets, reduced motion. Not cleared: unvirtualised result list, no roving tabindex in the accordion, no screen-reader pass — and ADR-0017 puts browser E2E out of v1, so there is no automated guard. Recorded in the map's fog beside the unguarded consent path.
- **One discrepancy noticed while reading, not fixed here:** ADR-0009 still says *"three required consent boxes and two optional ones"* at `/signup`; ADR-0016 dropped `suggestions` from the Purpose set, making it four boxes. ADR-0016 records the amendment, so ADR-0009's prose is the stale side. Left for whoever touches ADR-0009 next rather than edited from this branch.