### PR TITLE
Four consent boxes, not five: ADR-0016's amendment reaches the ADRs it amended

### DIFF
--- a/docs/adr/0007-consent-as-versioned-per-purpose-evidence.md
+++ b/docs/adr/0007-consent-as-versioned-per-purpose-evidence.md
@@ -17,18 +17,25 @@ than in a table. There were seven; **ADR-0010 added `photo` as the eighth**.
 > mechanism is unchanged, and deliberately so: ADR-0008 dropped `pgEnum` precisely so that "the day
 > an eighth _finalidad_ appears" would need no `ALTER TYPE`. It needs none.
 
-| `Purpose`                | Required?             | Consented at                      |
-| ------------------------ | --------------------- | --------------------------------- |
-| `account`                | **yes**               | signup                            |
-| `transactional_messages` | **yes**               | signup                            |
-| `safety`                 | **yes**               | signup                            |
-| `suggestions`            | no                    | signup                            |
-| `news`                   | no                    | signup                            |
-| `publish`                | no                    | first publish                     |
-| `disclose_contact`       | no, and per-offer     | send _and_ acceptance — see below |
-| `photo`                  | **never** — see below | photo upload                      |
+> **Amended by ADR-0016 — `suggestions` leaves the v1 set.** The suggestions surface is not gated on
+> that Purpose and v1 sends no digest, so consenting to it would describe a _finalidad_ nobody
+> pursues. It stays in the table marked `v1.1` rather than being deleted, because the same
+> `text({ enum })` decision lets it return without a migration; what its return costs is a new
+> Disclosure version and a re-consent prompt for everyone who signed up before it. `/signup`
+> therefore asks **four** boxes, not five.
 
-Five unticked checkboxes at `/signup`, never an "accept all" control. The SIC's _Formatos modelo_
+| `Purpose`                | Required?                | Consented at                      |
+| ------------------------ | ------------------------ | --------------------------------- |
+| `account`                | **yes**                  | signup                            |
+| `transactional_messages` | **yes**                  | signup                            |
+| `safety`                 | **yes**                  | signup                            |
+| `news`                   | no                       | signup                            |
+| `publish`                | no                       | first publish                     |
+| `disclose_contact`       | no, and per-offer        | send _and_ acceptance — see below |
+| `photo`                  | **never** — see below    | photo upload                      |
+| `suggestions`            | **not in v1** — ADR-0016 | — (signup, when it returns)       |
+
+Four unticked checkboxes at `/signup`, never an "accept all" control. The SIC's _Formatos modelo_
 (2022) requires each finalidad to be separately selectable, and D.1377 art. 7 forbids treating
 silence as consent — so nothing is pre-ticked and nothing is bundled.
 
@@ -200,7 +207,7 @@ in the same instant — the record is the evidence that we honoured it.
 
 | Revoking                                      | Effect                                                                                                                                                        |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `suggestions`, `news`                         | Sends stop. Nothing else.                                                                                                                                     |
+| `news`                                        | Sends stop. Nothing else.                                                                                                                                     |
 | `publish`                                     | All publications unpublish; drafts survive; new publishing blocked.                                                                                           |
 | `disclose_contact`                            | Future acceptances blocked. **Past disclosures cannot be recalled**, and the UI says so — the recipient is an independent Responsable holding their own copy. |
 | `account`, `transactional_messages`, `safety` | Not a toggle. Routed as **an erasure request**, with confirmation copy that says so plainly rather than quietly failing.                                      |
@@ -250,7 +257,7 @@ So on the OAuth path the order is user-then-person, but **no `users` row ever ex
 consent** — which is what this section was protecting. One form, one submit survives intact: the
 submit is simply the button that begins the redirect.
 
-**The form grows.** ADR-0009 puts full name and `date_of_birth` on `/signup` alongside the five
+**The form grows.** ADR-0009 puts full name and `date_of_birth` on `/signup` alongside the four
 checkboxes, for every credential, and rules out prefilling the name from the provider profile —
 holding that profile pending consent would itself be _tratamiento_. The name is always authored by
 the person.

--- a/docs/adr/0009-sign-in-credentials-and-account-recovery.md
+++ b/docs/adr/0009-sign-in-credentials-and-account-recovery.md
@@ -51,7 +51,7 @@ The provider list is named in the _aviso de privacidad_.
 
 ## Consent precedes the redirect
 
-ADR-0007 put five unticked consent boxes on `/signup` and wrote the `persons` row **before** the
+ADR-0007 put four unticked consent boxes on `/signup` and wrote the `persons` row **before** the
 Better Auth `users` row, in one form with one submit. OAuth inverts that order: Better Auth creates
 the user inside `GET /api/auth/callback/:id`, where there is no form payload.
 
@@ -84,7 +84,12 @@ its sequence changes, and only for OAuth. The password path is unchanged.
 
 ## One signup form for everyone
 
-`/signup` asks for full name, date of birth, three required consent boxes and two optional ones — and
+> **The box count follows ADR-0016.** This ADR was written when `suggestions` was a Purpose consented
+> at signup. ADR-0016 dropped it from the v1 set, so the form carries **four** consent boxes, not
+> five. The required three are unchanged and nothing else in this ADR moves — it is the same form,
+> one row shorter.
+
+`/signup` asks for full name, date of birth, three required consent boxes and one optional one — and
 _then_ offers Google, Facebook or a password. **Social login saves you a password and gives us a
 pre-verified email. It does not shorten the form.**
 
@@ -207,7 +212,7 @@ signups cost **$50.87** — eight times the entire remaining budget.
 ## What this binds
 
 - **ADR-0007 is amended**: `persons` is created in `user.create.after` on the OAuth path, consent
-  proven by the pending-signup record. Its five checkboxes are joined on `/signup` by full name and
+  proven by the pending-signup record. Its four checkboxes are joined on `/signup` by full name and
   date of birth, all carried server-side across the redirect.
 - **#15** inherits the persisted-rate-limiter flag, and owns the fact that the in-memory default is a
   no-op behind more than one machine.

--- a/docs/adr/0017-testing-at-two-seams.md
+++ b/docs/adr/0017-testing-at-two-seams.md
@@ -248,7 +248,7 @@ React components. Server Action adapters. Async Server Components — ADR-0006 r
 Anything concurrent, which PGlite makes impossible rather than merely unfunded.
 
 **And browser end-to-end testing, including Playwright.** This was reconsidered during #16 specifically
-for the signup flow, where ADR-0007's five consent boxes become art. 9 evidence and ADR-0009 layered a
+for the signup flow, where ADR-0007's four consent boxes become art. 9 evidence and ADR-0009 layered a
 server-side Pending Signup and an OAuth redirect underneath — the one path where a silent breakage is a
 compliance failure rather than a bug, and the one path Vitest structurally cannot reach. It is still out
 of v1. **The gap is named rather than left silent: the consent-evidence path has no automated guard**,


### PR DESCRIPTION
Found while reviewing #30's branch, and wider than the line that surfaced it.

ADR-0016 dropped `suggestions` from the v1 Purpose set and **recorded the amendment on its own side only**. Three ADRs went on counting five.

- **ADR-0007** is the source. `suggestions` moves to the bottom of the purpose table marked **not in v1** rather than being deleted — ADR-0008's `text({ enum })` is what lets it return without a migration, so deleting the row would misrepresent what bringing it back costs (a new Disclosure version and a re-consent prompt, not an `ALTER TYPE`). Its revocation-table row goes with it, both checkbox counts drop to four, and an `Amended by ADR-0016` note lands in the same blockquote style ADR-0010 already uses in that file.
- **ADR-0009** is the one that would have misled an implementer first: *"three required consent boxes and two optional ones"*. The **required three are unchanged**; the optional two are now one. The other two stale counts in that file are fixed too, with a short note at *One signup form for everyone* saying where the count comes from. #35 reads this ADR for the first screen of the first run.
- **ADR-0017** counted the same boxes while naming the consent-evidence path that browser testing does not guard.

`CONTEXT.md` was already correct on `dev` — ADR-0016 did apply that half of its own amendment.

`oxfmt --check` clean. Docs only; no code, no schema, no migration.
