### PR TITLE
Trust presentation, three ways: the prototype behind ADR-0026 (#12)

### DIFF
--- a/docs/design/trust-presentation-prototype/README.md
+++ b/docs/design/trust-presentation-prototype/README.md
@@ -1,0 +1,302 @@
+# Prototype — trust presentation between strangers (#12)
+
+**Throwaway.** One self-contained HTML file. Double-click `index.html`, or:
+
+```sh
+open docs/design/trust-presentation-prototype/index.html
+```
+
+No build, no server, no dependencies. Nothing here is production code, and none of the fixture data
+in it is real.
+
+> Three variants of **where the trust work lives**, rendered across every surface at once — the two
+> Walls, the Public View beside the signed-in profile, the public Need card, the coincidencias, the
+> Offer, the Contact Exchange and the safety states — switchable via `?variant=`, plus three
+> question toggles (`?proof=`, `?pay=`, `?scam=`) and two inspection toggles (`?photo=`,
+> `?setting=`).
+
+**No verdict yet.** This is the artefact to react to; the ADR is written after.
+
+## The finding that shapes all three variants
+
+The ticket asks what signals exist at all. Worked through against the ADRs, **there are no
+per-person trust signals in v1, and every candidate fails for a reason already on the record**:
+
+| Candidate                     | Verdict                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Confirmed contact details** | **Not a signal — a constant.** ADR-0009 gates publishing and sending on a verified email, so every Publication and every Offer sender already has one. A badge everyone holds distinguishes nobody. It is a fact about the _platform_, statable once.                                                                                              |
+| **Photo reviewed by a human** | **True, and unusable per profile.** ADR-0010 pre-moderates every image, so "foto revisada" is real — but attaching it to a profile makes a profile without a Photo second-class, which rule 1 forbids and this ticket inherits twice (ADR-0010, ADR-0011).                                                                                         |
+| **Offer history**             | **Refused, and not merely deferred.** ADR-0015 already says an unverifiable outcome shown as trust is worse than none. An _accepted_ count is verifiable but means only "exchanged contact details N times", and ADR-0015 names the real cost: the moment reputation accrues, re-registration stops being cheap and **ADR-0009 must be reopened**. |
+| **Report history**            | **Never.** It is a third party's personal data, it is disclosed to nobody but the reported Person (ADR-0013 as amended by ADR-0020), and "0 reportes" is a badge everyone wears until the day they do not.                                                                                                                                         |
+| **Account age**               | **Available, weak, and the only one left.** `persons.created_at` is honest and cheap. At launch everybody is new, and a fraudster ages an account for free. It is included in variant B precisely so its emptiness is visible.                                                                                                                     |
+| **Honestly nothing**          | **This is the answer.**                                                                                                                                                                                                                                                                                                                            |
+
+So the design question is not _which badge_. It is **where an honest account of the mechanism
+goes**, given that the product has one and only one true thing to say: what it does, what it does
+not do, and what cannot be undone. That is the axis the three variants disagree about.
+
+The motif that falls out of it is a **ledger, not a stamp** — two columns, _Lo que sabemos_ / _Lo
+que no sabemos_. A badge asserts; a ledger accounts. A product with nothing to assert should not be
+reaching for the vocabulary of assertion.
+
+## The three variants
+
+Flip with the arrows in the black bar, the `←`/`→` keys, or `?variant=A|B|C`.
+
+| Key   | Name               | Where the trust work lives                                                                                      | The bet                                                                                   |
+| ----- | ------------------ | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **A** | House rules        | One standing account of the mechanism — a band on the landing page, a page behind it, a link from every surface | Trust comes from a coherent, honest explanation read once, not from repetition            |
+| **B** | Per-object ledger  | A ledger attached to **every** profile, Need card, suggestion and Offer                                         | Honesty at the point of judgment beats a page nobody opens                                |
+| **C** | Only in the moment | Nothing standing at all. Everything at the Offer and the Contact Exchange                                       | A warning is only read where ignoring it costs something; everywhere else it is wallpaper |
+
+The variant names are **English**, like every other control — ADR-0001 as amended by #30. In the
+product these surfaces are _reglas_, _ficha_ and _propuesta_; in the black bar they are
+instrumentation and get deleted with it.
+
+They disagree about more than placement:
+
+- **What an unauthenticated visitor is told.** A gives them the whole mechanism before they scroll.
+  B gives them one line per card. C gives them nothing, and the Wall is left to carry it alone.
+- **Whether the same sentence repeats.** B says _"Encuentra no comprobó nada de esto"_ perhaps
+  fifteen times on one screen. A says it once. C never says it outside an Offer.
+- **Where the advance-fee warning is structural rather than optional.** In C it is not a toggle —
+  the Offer interruption is the variant.
+
+### Each one has a visible flaw, and the file is built to show it
+
+**B walks into ADR-0010 and the file makes it obvious.** Flip `Photo · without`. The ledger's _Lo
+que sabemos_ column loses a row — _"Una persona revisó esta foto"_ — so a Person with no Photo
+literally has less known about them, printed beside the person who has one. That is
+_second-class rendering_ arriving through a component that was trying to be honest. It is fixable
+only by deleting the row for everybody, at which point B's ledger is three "no" and two "yes" on
+every card and reads as an accusation. **Treat this as B's disqualifying defect unless you disagree
+with it.**
+
+**C loses the argument ADR-0010 already won.** That ADR's case for having faces at all is that _"a
+faceless directory of names and skills reads as a scam"_ in a market where this work is really
+arranged over WhatsApp. C's public surfaces claim nothing whatsoever, so the person deciding
+whether this platform is real gets no answer. Flip to C with `proof=none` and look at the landing
+page as a stranger.
+
+**A's flaw is the one the ticket named in advance** — _"a help page nobody opens"_. A is only
+defensible if its landing band carries the whole load and the page behind it is a reference, not the
+mechanism. Judge the band, not the page.
+
+## The toggles
+
+Two rows in the black bar: **Questions** are decisions #12 owes an answer to; **Inspect** are ways
+of looking at the same design.
+
+### `?proof=` — what replaces `TrustProof`'s "Empresas verificadas"
+
+| Value       | What it says                                                                                                                                                   |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limits`    | Three limits: _Aquí no pasa plata_ · _No verificamos a nadie_ · _Tus datos de contacto son tuyos_. A trust proof made of what we do **not** do.                |
+| `mechanism` | Three mechanics: _Usar Encuentra no cuesta nada_ · _Una persona revisa cada foto_ · _El teléfono se comparte al aceptar_. Same honesty, phrased as capability. |
+| `none`      | No band. One line — _"Cada perfil de abajo lo escribió la persona misma."_ — and the Wall is the proof.                                                        |
+
+`limits` is the direct inversion of the dead promise and it is the bravest. `mechanism` says the
+same true things without opening on a negative, which matters on the one screen whose job is to make
+someone stay. **The second `mechanism` item is a trap worth noticing**: _"una persona revisa cada
+foto"_ is true and is a platform fact, but read on a landing page it can be heard as _"Encuentra
+revisa a la gente"_. If that reading is live, the item has to go, and `mechanism` drops to two.
+
+### `?pay=` — how off-platform payment is said
+
+| Value    | Behaviour                                                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `plain`  | Stated on the landing page and in the Offer: _"si algo sale mal con el pago, nosotros no podemos devolvértela."_                     |
+| `warned` | Adds _"Nadie de Encuentra te va a pedir plata nunca."_ — an impersonation control, and the first sentence here that raises an alarm. |
+| `quiet`  | Only inside the Offer. The public surfaces never mention money at all.                                                               |
+
+The hard part is that the honest sentence is a **disclaimer of protection**, and disclaimers read as
+danger. The drafting rule used throughout: **state the limit, never the risk.** _"No podemos
+devolvértela"_ is a fact about us; _"te pueden estafar"_ is a warning about them, and the second one
+is what frightens people away from a product that has done nothing wrong.
+
+Against `warned`: it is the only line in the set that describes an attack. For it: impersonating the
+platform is the cheapest advance-fee approach there is, and the sentence costs nine words.
+
+### `?scam=` — where the advance-fee and equipment-purchase warning lands
+
+| Value      | Behaviour                                                                        |
+| ---------- | -------------------------------------------------------------------------------- |
+| `offer`    | Inside the Offer, above the answer buttons. Read before a decision, by everyone. |
+| `exchange` | At the Contact Exchange, beside ADR-0013's Work Setting guidance.                |
+| `both`     | Both places.                                                                     |
+
+The ticket's own framing — _"inside the offer flow, not on a help page nobody opens"_ — argues for
+`offer`, and there is a second reason: at the **exchange** the decision is already made and the
+contact details have already crossed. A warning that arrives after the irreversible step is a
+record that we said something, not a control.
+
+The argument for `exchange` is ADR-0013's: undifferentiated safety copy shown everywhere is
+wallpaper, and the Work Setting guidance is already there and is already differentiated. `both`
+risks exactly the wallpaper that ADR ruled against.
+
+### `?photo=` — inspection, not a question
+
+Renders the featured Person **with** or **without** a Photo across every surface. The Walls and the
+coincidencias stay mixed regardless, because the grid is where the contrast is sharpest — the
+constraint #12 inherited from ADR-0014's comment on this ticket.
+
+**The layout position this file takes:** a Person with no Photo does not get an empty circle, a grey
+silhouette, or initials in a disc. The card **re-flows** and the name takes the leading position at
+a larger size. A placeholder is a hole where a face should be, and a hole is a penalty rendered in
+CSS; a name set larger is not. This is a position, not a default — say so if it reads as its own
+kind of odd.
+
+### `?setting=` — inspection, all five Work Settings
+
+ADR-0013 makes Work Setting select the safety guidance at the Contact Exchange, so all five have to
+be readable. Flip it and read the Contact Exchange section. `hirer_home` is the one the ADR
+prioritises and the one whose copy is hardest — it must be useful without implying that Encuentra
+has vetted anywhere anyone goes.
+
+## What dies in `NEXTJS_HANDOFF.md`
+
+The ticket asks for "Empresas verificadas" and **anything else in the prototype that implies vetted
+employers**. The full list, so it is deleted once rather than found later:
+
+| Artefact                                                      | Why it dies                                                                                               |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `TrustProof` item **"Empresas verificadas"**                  | False. There are no companies and nothing is verified.                                                    |
+| `TrustProof` item **"Postularte es gratis"**                  | There is no _postulación_ — `CONTEXT.md` bans the word. The true sentence is that nothing costs anything. |
+| `TrustProof` item **"Respuestas en un solo lugar"**           | Survives in substance as the Offers surface, but it promises a reply. Nothing promises a reply.           |
+| `CompanyBadge`                                                | No company accounts exist.                                                                                |
+| `Job.company.verified: boolean`                               | The data contract's verification flag. Nothing sets it and nothing could.                                 |
+| `Job` / `Application` types, `ApplicationStage`               | ADR-0015: the four-stage timeline is **dead, not adapted**.                                               |
+| `ApplicationTimeline`, `NextStepCard`, `/mis-postulaciones`   | Same.                                                                                                     |
+| `/empleos`, `/empleos/[slug]`, `ApplyPanel`, `JobCard`        | Superseded IA. Routes are `/search/work` and `/search/people` (ADR-0014).                                 |
+| Content rule _"State «verificada» only after a real process"_ | Retire the escape hatch with the badge. There will be no such process in v1.                              |
+| `SafetyNotice` "no-fee policy"                                | Survives as **content**, not as a page: the fee statement moves into the Offer.                           |
+| `/ayuda/busqueda-segura`                                      | Kept only as a reference; it must never be where a warning first appears.                                 |
+
+**What survives, unchanged and still binding**: the design tokens, the component primitives, the
+motion rules, the content rules about never implying a guarantee of employment and never using
+disaster imagery, and the whole accessibility bar. This prototype uses the tokens verbatim.
+
+## The Public View / signed-in difference, stated
+
+Rendered side by side in section 2, because this is the sub-question most likely to be answered
+wrongly by instinct.
+
+|                                             | Public View               | Signed in                |
+| ------------------------------------------- | ------------------------- | ------------------------ |
+| Full name                                   | yes                       | yes                      |
+| Photo                                       | only if opted in publicly | if uploaded and approved |
+| Place                                       | **department only**       | exact Municipality       |
+| Skills                                      | yes                       | yes                      |
+| Availability, Need detail, Self-description | no                        | yes                      |
+| **What is claimed about the person**        | **nothing**               | **nothing**              |
+
+**The last row is the decision.** The boundary ADR-0011 drew is about _enumerability_, not
+credibility. Signing in buys you more fields about the same unvetted stranger, and **no copy on
+either side of the line may imply that an account buys a vetted person.** The public view therefore
+carries one sentence that is easy to get wrong and is written to be right:
+
+> _Con una cuenta ves el municipio y el detalle de lo que publicó. No ves nada más sobre si es de
+> fiar: eso no lo tenemos._
+
+## Language
+
+**The prototype's controls are English. Only the copy inside the surfaces is Spanish.**
+
+The black bar and its labels, the **variant names**, the top banner, the board's section headers
+(`1 · Landing and the two Walls`), the **frame labels** on each surface (`Public View · signed out`),
+the state readout and every search-param value are instrumentation — they get deleted when this
+prototype is captured, so no string in them will reach a user. Everything a person in the design
+would read is Spanish. This is ADR-0001 as amended by #30, and the trap it closes is Spanish chrome
+growing Spanish state keys behind it.
+
+Two cases needed a call:
+
+- **Frame labels name product surfaces**, and a surface name is close to domain vocabulary. They are
+  chrome because they are navigation _through the board_, which is not a thing that exists in the
+  product. So `Contact Exchange · accepted`, not `Intercambio de datos · aceptada` — and `CONTEXT.md`
+  already gives every one of those concepts an English name for exactly this reason.
+- **English commentary that has to sit inside a Spanish surface** — the note on variant C's band, the
+  404's "deliberately incurious", the hint-vs-refusal labels — is rendered in the dark monospace
+  `.chromenote` style rather than the product's own muted text, so it cannot be mistaken for design.
+
+## Voice
+
+Following the sketch in `docs/design/skill-picker-prototype/README.md` — Everyman, Directness **5**,
+Warmth **4**, Sophistication **1**, `tú`, no gender agreement with the reader. Two rules this
+surface adds, because safety copy is where a voice usually breaks:
+
+- **State the limit, never the risk.** _"Encuentra no puede devolverte la plata"_ over _"te pueden
+  estafar"_. The first is a fact about us and is calm; the second is a warning about a stranger the
+  reader is about to meet, and it is the sentence that makes a product feel dangerous.
+- **Never claim a reach we do not have.** ADR-0013 forbids any copy suggesting we can retrieve
+  contact details already exchanged. Hence the Contact Exchange's _"ya no te va a poder escribir
+  **por Encuentra** — pero ya tiene tu número"_, and the Block dialog's version of the same
+  sentence.
+
+**Never:** _verificado_, _confiable_, _seguro_ about a person; _empresa_, _empleador_; any word
+implying we will find you work; _víctima_, _damnificado_, _ayuda_, _apoyo_ about the person; a
+promise of an outcome on a Report.
+
+## Accessibility
+
+The bar from `NEXTJS_HANDOFF.md` binds. Present here: no meaning carried by colour alone — every
+notice has a text kicker naming what it is, and the ledger's two columns are labelled rather than
+tinted; 44px minimum targets; a 2px `--color-brand-500` focus ring; real radio inputs in the report
+form with real labels; the switcher announced through a polite live region; `prefers-reduced-motion`
+honoured; hover motion behind `(hover: hover) and (pointer: fine)`; tabular figures on the pay
+amount; `:active { transform: scale(.97) }` on every button.
+
+**Not cleared here**: nothing has been through a screen reader, the board is a long single column at
+390px rather than a designed mobile layout, and the coloured discs standing in for photographs carry
+`role="img"` with a generic label because there is no real image to describe. Treat the a11y as
+_demonstrated pattern_, not _verified conformance_.
+
+## Departures from the named skills
+
+- **`/prototype` UI branch wants a route.** This is a single HTML file instead, for the same reason
+  `skill-picker-prototype` and `first-run-prototype` are: `apps/web` is still the bare
+  `create-turbo` scaffold, so sub-shape A has no host page and sub-shape B would mean standing up
+  half the app. The repo's own convention is a single-file prototype.
+- **UI.md wants variants that "disagree about structure", and one section here does not vary.** The
+  safety states (section 7/8) are identical across A, B and C, because they are copy decisions
+  rather than placement decisions — the ticket asks for _"the wording, in Spanish, of every
+  safety-relevant state"_ and the wording does not depend on where the trust band lives. They are
+  rendered once, in all three.
+- **The board is not a flow.** UI.md's variants usually replace a page; here each variant re-renders
+  **seven surfaces at once**, because the ticket's real question is consistency _across_ surfaces
+  and a one-page variant cannot show it.
+- **`shadcn` could not be loaded as a skill.** `npx shadcn info` refuses at the monorepo root; run
+  with `-c packages/design-system` it reports the project: style `base-vega`, Base UI underneath,
+  Tailwind v4, lucide, preset `b1sRmB0Rk`. That is recorded here because it is what a real
+  implementation will build against — but this file is plain CSS on the handoff tokens, so nothing
+  from the registry is used.
+- **`brand-voice` was not run as specified.** It produces a full voice guide from an intake
+  interview, which is its own effort and sits past this map's destination. The sketch above extends
+  the one `skill-picker-prototype` established, which is the lightweight path that skill permits
+  when no guide exists.
+- **`emil-design-eng` and `userinterface-wiki` bound the motion and the layout, not the copy.** What
+  they contributed: `ease-out` with the handoff's custom curve, press feedback at 140ms, no
+  animation on the keyboard-driven variant switch, transitions rather than keyframes, tabular
+  figures on the pay amount, minimum target size, and proximity grouping in the ledger. Neither has
+  a rule about safety copy, which is most of this ticket.
+- **`frontend-design` asks for a distinctive palette and type system; the brief pins both.** The
+  handoff's tokens are recorded as still binding, and that skill's own rule is that the brief wins.
+  The freedom spent instead is structural: the **ledger** motif, and the surfaces board.
+
+## Open calls this prototype takes without being asked to
+
+Flag any of these that are wrong — they are positions, not defaults.
+
+1. **No per-person trust signal ships in v1, including account age.** Variant B renders it to make
+   the case visible, not because it should ship.
+2. **A profile with no Photo gets no placeholder at all**, and the name grows instead.
+3. **"Correo verificado" is never shown to anyone.** Everyone has one; it distinguishes nobody.
+4. **The pay statement lives in the Offer even when it also lives on the landing page.** The
+   landing page is read by a visitor; the Offer is read by the person about to say yes.
+5. **The Report acknowledgement routes to Block in its last sentence.** ADR-0013's whole argument
+   for refusing automatic moderation is that Block is instant, so the acknowledgement is where that
+   has to be said.
+6. **The 404 for an absent profile is deliberately incurious** — no "may have been removed", which
+   would leak what a 403 leaks.
+7. **The advance-fee copy names equipment purchase explicitly** rather than folding it into "asking
+   for money". _"Cómprate tú el uniforme y arrancamos"_ is not heard as being asked for money.

--- a/docs/design/trust-presentation-prototype/README.md
+++ b/docs/design/trust-presentation-prototype/README.md
@@ -328,11 +328,16 @@ _demonstrated pattern_, not _verified conformance_.
 - **The board is not a flow.** UI.md's variants usually replace a page; here each variant re-renders
   **seven surfaces at once**, because the ticket's real question is consistency _across_ surfaces
   and a one-page variant cannot show it.
-- **`shadcn` could not be loaded as a skill.** `npx shadcn info` refuses at the monorepo root; run
-  with `-c packages/design-system` it reports the project: style `base-vega`, Base UI underneath,
-  Tailwind v4, lucide, preset `b1sRmB0Rk`. That is recorded here because it is what a real
-  implementation will build against — but this file is plain CSS on the handoff tokens, so nothing
-  from the registry is used.
+- **`shadcn` could not be loaded as a skill**, and the map is right that the old excuse is stale.
+  `npx shadcn info` refuses at the monorepo root; with `-c packages/design-system` it reports style
+  `base-vega`, Base UI underneath, Tailwind v4, lucide, preset `b1sRmB0Rk`. So the package **does**
+  exist now, and #30's and #35's _"there is nothing for it to act on"_ no longer holds. What holds
+  instead is narrower and still binding: `@repo/design-system` ships **one component** (`button.tsx`)
+  as un-built React source, and a single static HTML file opened over `file://` cannot consume React
+  source. The departure is the **single-file format**, not the absence of a design system — and the
+  format is itself forced, because `apps/web` has no host page for UI.md's preferred sub-shape A.
+- **The handoff's tokens and the design system's tokens are not the same tokens, and this file uses
+  the handoff's.** See below — it is a conflict this ticket surfaced and does not own.
 - **`brand-voice` was not run as specified.** It produces a full voice guide from an intake
   interview, which is its own effort and sits past this map's destination. The sketch above extends
   the one `skill-picker-prototype` established, which is the lightweight path that skill permits
@@ -345,6 +350,33 @@ _demonstrated pattern_, not _verified conformance_.
 - **`frontend-design` asks for a distinctive palette and type system; the brief pins both.** The
   handoff's tokens are recorded as still binding, and that skill's own rule is that the brief wins.
   The freedom spent instead is structural: the **ledger** motif, and the surfaces board.
+
+## A conflict this ticket surfaced and does not own
+
+**The map records `NEXTJS_HANDOFF.md`'s design tokens as _still binding_ after the pivot. The design
+system that has since landed disagrees with them.**
+
+|                 | `NEXTJS_HANDOFF.md` (map says binding) | `@repo/design-system` (what shipped)      |
+| --------------- | -------------------------------------- | ----------------------------------------- |
+| Brand / primary | `#2457e6` — a blue                     | `oklch(0.52 0.105 223.128)` — a cyan/teal |
+| Body face       | Manrope                                | Inter                                     |
+| Heading face    | Manrope                                | Figtree                                   |
+| Mono            | DM Mono                                | Geist Mono                                |
+| Radius          | `0.3125 / 0.5 / 0.75rem`               | `--radius: 0.625rem`                      |
+
+Those are two different visual identities. The preset arrived with `feat(design-system): tailwind,
+shadcn on base ui, and @repo/ui retired`, and **no ADR reconciles it with the handoff** — ADR-0018
+and ADR-0019 are the linter and the formatter, and ADR-0006 names the package without choosing its
+palette.
+
+This file uses the **handoff** tokens, for three reasons: the map names them as binding, the two
+earlier prototypes use them so a reader can compare across all three, and #12 is a question about
+_what the product says_, not about what colour it says it in. Every decision in ADR-0026 is copy,
+placement or layout, and **none of them moves if the palette changes.**
+
+But an implementer building the landing band will ask which one is real, and there is no written
+answer. Sharp enough to be a ticket rather than fog: _which palette and typeface pair does the
+product ship?_ Noted on the map.
 
 ## Calls this prototype took without being asked to
 

--- a/docs/design/trust-presentation-prototype/README.md
+++ b/docs/design/trust-presentation-prototype/README.md
@@ -15,7 +15,35 @@ in it is real.
 > question toggles (`?proof=`, `?pay=`, `?scam=`) and two inspection toggles (`?photo=`,
 > `?setting=`).
 
-**No verdict yet.** This is the artefact to react to; the ADR is written after.
+## Verdict
+
+**#12 is decided — ADR-0026.** The file still carries every variant and every toggle, because the
+losing options are the evidence for the winner. The defaults on load are now the decisions:
+`?variant=C&proof=mechanism&pay=warned&scam=both`.
+
+| Question                             | Answer                                                                                                                                                                                                           |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| What signals exist                   | **None per person.** Every candidate fails on something already decided — see the table below. Nothing is attached to a profile, a Need card or a suggestion.                                                    |
+| Where the trust work lives           | **C — at the moment.** The Offer and the Contact Exchange carry it, because those are the only two places where ignoring it costs something.                                                                     |
+| What replaces "Empresas verificadas" | **A three-item band, phrased as mechanism**, on the landing page and nowhere else. C's own `proof=none` lost: the ticket says TrustProof must be _replaced_, and nothing else public sets the money expectation. |
+| Off-platform payment                 | **`warned`** — stated in the Offer, including _"Nadie de Encuentra te va a pedir plata nunca."_ The band says using Encuentra is free, which makes impersonating Encuentra the cheapest approach there is.       |
+| The advance-fee warning              | **Twice, and never the same words.** The Offer asks whether to say yes at all; the Exchange covers the cost that appears _after_ acceptance, which the Offer could not.                                          |
+| A profile with no Photo              | **No placeholder at all.** No silhouette, no initials disc. The card re-flows and the name grows.                                                                                                                |
+
+### The one that moved after the first pass
+
+**The landing band came back, against variant C's own answer.** C is right that a warning is only
+read where ignoring it costs something, and right that per-object trust copy is noise — but it
+over-reached into the one public surface that is not judging a person: the landing page, which is
+where a false promise used to live and therefore where a true statement has to.
+
+That change forced a second one. `mechanism`'s middle item was _"Una persona revisa cada foto ·
+antes de que aparezca"_, and dropping the `limits` band took _"No verificamos a nadie"_ off the
+product entirely — leaving the only public claim sounding like vetting. The item now names its own
+limit and carries the load the dropped band was carrying:
+
+> **Una persona revisa cada foto.** Antes de que aparezca. Solo la foto: no comprobamos nada más de
+> nadie.
 
 ## The finding that shapes all three variants
 
@@ -82,6 +110,13 @@ page as a stranger.
 defensible if its landing band carries the whole load and the page behind it is a reference, not the
 mechanism. Judge the band, not the page.
 
+**How C's flaw was actually closed.** C won, so its defect had to be answered rather than accepted:
+the landing band stays. What C gives up is everything _else_ standing — the ledger on a profile, the
+line under a Need card, the disclaimer on a suggestion — and that is the part of A and B that was
+never earning its keep, because none of those surfaces is where anybody decides anything. **The
+distinction the decision turns on is not "standing versus situated". It is whether the surface is
+judging a person.** The landing page is not; a profile is.
+
 ## The toggles
 
 Two rows in the black bar: **Questions** are decisions #12 owes an answer to; **Inspect** are ways
@@ -89,33 +124,50 @@ of looking at the same design.
 
 ### `?proof=` — what replaces `TrustProof`'s "Empresas verificadas"
 
-| Value       | What it says                                                                                                                                                   |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `limits`    | Three limits: _Aquí no pasa plata_ · _No verificamos a nadie_ · _Tus datos de contacto son tuyos_. A trust proof made of what we do **not** do.                |
-| `mechanism` | Three mechanics: _Usar Encuentra no cuesta nada_ · _Una persona revisa cada foto_ · _El teléfono se comparte al aceptar_. Same honesty, phrased as capability. |
-| `none`      | No band. One line — _"Cada perfil de abajo lo escribió la persona misma."_ — and the Wall is the proof.                                                        |
+| Value       | What it says                                                                                                                                                                |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limits`    | Three limits: _Aquí no pasa plata_ · _No verificamos a nadie_ · _Tus datos de contacto son tuyos_. A trust proof made of what we do **not** do.                             |
+| `mechanism` | **Decided.** Three mechanics: _Usar Encuentra no cuesta nada_ · _Una persona revisa cada foto_ · _El teléfono se comparte al aceptar_. Same honesty, phrased as capability. |
+| `none`      | No band. One line — _"Cada perfil de abajo lo escribió la persona misma."_ — and the Wall is the proof.                                                                     |
 
-`limits` is the direct inversion of the dead promise and it is the bravest. `mechanism` says the
-same true things without opening on a negative, which matters on the one screen whose job is to make
-someone stay. **The second `mechanism` item is a trap worth noticing**: _"una persona revisa cada
-foto"_ is true and is a platform fact, but read on a landing page it can be heard as _"Encuentra
-revisa a la gente"_. If that reading is live, the item has to go, and `mechanism` drops to two.
+`limits` is the direct inversion of the dead promise and it is the bravest. `mechanism` won because
+it says the same true things without opening on three negatives, on the one screen whose job is to
+make someone stay.
+
+**The trap in `mechanism`'s middle item was live, and closing it changed the copy.** _"Una persona
+revisa cada foto"_ is true and is a platform fact, but on a landing page it can be heard as
+_"Encuentra revisa a la gente"_ — and dropping `limits` removed _"No verificamos a nadie"_ from the
+public product entirely, so nothing was left to contradict the misreading. The item now carries its
+own limit, which is what the losing band was carrying:
+
+> **Una persona revisa cada foto.** Antes de que aparezca. Solo la foto: no comprobamos nada más de
+> nadie.
+
+The alternative was dropping the item and shipping a band of two. Rejected: the photo review is the
+single true operational fact this platform has, and a product with almost nothing to say should not
+throw away the one thing it can.
 
 ### `?pay=` — how off-platform payment is said
 
-| Value    | Behaviour                                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `plain`  | Stated on the landing page and in the Offer: _"si algo sale mal con el pago, nosotros no podemos devolvértela."_                     |
-| `warned` | Adds _"Nadie de Encuentra te va a pedir plata nunca."_ — an impersonation control, and the first sentence here that raises an alarm. |
-| `quiet`  | Only inside the Offer. The public surfaces never mention money at all.                                                               |
+| Value    | Behaviour                                                                                                                                        |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `plain`  | Stated on the landing page and in the Offer: _"si algo sale mal con el pago, nosotros no podemos devolvértela."_                                 |
+| `warned` | **Decided.** Adds _"Nadie de Encuentra te va a pedir plata nunca."_ — an impersonation control, and the only sentence here that names an attack. |
+| `quiet`  | Only inside the Offer. The public surfaces never mention money at all.                                                                           |
+
+Under variant C the pay statement lives **in the Offer**, wherever the toggle sits — the band's
+first item sets the free-to-use expectation, and the limit on what we can recover belongs where
+somebody is about to accept a figure.
 
 The hard part is that the honest sentence is a **disclaimer of protection**, and disclaimers read as
 danger. The drafting rule used throughout: **state the limit, never the risk.** _"No podemos
 devolvértela"_ is a fact about us; _"te pueden estafar"_ is a warning about them, and the second one
 is what frightens people away from a product that has done nothing wrong.
 
-Against `warned`: it is the only line in the set that describes an attack. For it: impersonating the
-platform is the cheapest advance-fee approach there is, and the sentence costs nine words.
+Against `warned`: it is the only line in the set that describes an attack. For it, and why it won:
+the band now says using Encuentra is free, which makes **impersonating Encuentra** the cheapest
+advance-fee approach available — the sentence closes a hole the band itself opens, and it costs nine
+words.
 
 ### `?scam=` — where the advance-fee and equipment-purchase warning lands
 
@@ -123,16 +175,27 @@ platform is the cheapest advance-fee approach there is, and the sentence costs n
 | ---------- | -------------------------------------------------------------------------------- |
 | `offer`    | Inside the Offer, above the answer buttons. Read before a decision, by everyone. |
 | `exchange` | At the Contact Exchange, beside ADR-0013's Work Setting guidance.                |
-| `both`     | Both places.                                                                     |
+| `both`     | **Decided** — both places, with **different words in each**.                     |
 
 The ticket's own framing — _"inside the offer flow, not on a help page nobody opens"_ — argues for
 `offer`, and there is a second reason: at the **exchange** the decision is already made and the
-contact details have already crossed. A warning that arrives after the irreversible step is a
-record that we said something, not a control.
+contact details have already crossed, so a warning arriving there is a record that we said
+something rather than a control.
 
-The argument for `exchange` is ADR-0013's: undifferentiated safety copy shown everywhere is
-wallpaper, and the Work Setting guidance is already there and is already differentiated. `both`
-risks exactly the wallpaper that ADR ruled against.
+**What rescues `both` is that the two moments are not warning about the same thing.** ADR-0013 ruled
+against undifferentiated safety copy, and repeating one block verbatim is exactly that — which is
+what this file did on `scam=both` before #12 was decided. Split, each earns its place:
+
+- **In the Offer — the decision gate.** _"Nadie debería pedirte plata para darte trabajo."_ Uniform,
+  materials, course, trámites, and being asked to buy something yourself named as the same thing.
+  The question it serves is whether to say yes at all.
+- **At the Exchange — what the Offer could not cover, because it had not happened yet.** The terms
+  are now fixed and the platform can no longer see anything, so the live vector is a cost that
+  appears _after_ acceptance: _"Si aparece un costo que no estaba en la propuesta, no estaba en el
+  trato."_ Plus the instruction to fix the pay date by message before starting.
+
+The second one is the reason `both` beats `offer`. An advance-fee approach that survives the Offer
+screen does so precisely by not being in the Offer.
 
 ### `?photo=` — inspection, not a question
 
@@ -283,16 +346,17 @@ _demonstrated pattern_, not _verified conformance_.
   handoff's tokens are recorded as still binding, and that skill's own rule is that the brief wins.
   The freedom spent instead is structural: the **ledger** motif, and the surfaces board.
 
-## Open calls this prototype takes without being asked to
+## Calls this prototype took without being asked to
 
-Flag any of these that are wrong — they are positions, not defaults.
+All of these went into ADR-0026 unchanged. They were positions when the file was written, and none
+was overturned on review.
 
 1. **No per-person trust signal ships in v1, including account age.** Variant B renders it to make
    the case visible, not because it should ship.
 2. **A profile with no Photo gets no placeholder at all**, and the name grows instead.
 3. **"Correo verificado" is never shown to anyone.** Everyone has one; it distinguishes nobody.
-4. **The pay statement lives in the Offer even when it also lives on the landing page.** The
-   landing page is read by a visitor; the Offer is read by the person about to say yes.
+4. **The pay statement lives in the Offer**, not on the surface a visitor is browsing. The landing
+   page is read by a visitor; the Offer is read by the person about to say yes.
 5. **The Report acknowledgement routes to Block in its last sentence.** ADR-0013's whole argument
    for refusing automatic moderation is that Block is instant, so the acknowledgement is where that
    has to be said.

--- a/docs/design/trust-presentation-prototype/index.html
+++ b/docs/design/trust-presentation-prototype/index.html
@@ -730,7 +730,10 @@
         },
         C: {
           name: "C — Only in the moment",
-          gist: "Nothing standing. All the weight goes to the Offer and the Contact Exchange.",
+          gist:
+            "Nothing on any profile, Need card or suggestion. A landing band, then all the weight " +
+            "at the Offer and the Contact Exchange.",
+          decided: true,
         },
       };
 
@@ -773,11 +776,13 @@
         },
       };
 
+      /* The defaults on load are #12's decisions. Every variant and toggle
+         survives, because the losing options are the evidence for the winner. */
       const DEFAULTS = {
-        variant: "A",
-        proof: "limits",
-        pay: "plain",
-        scam: "offer",
+        variant: "C",
+        proof: "mechanism",
+        pay: "warned",
+        scam: "both",
         photo: "on",
         setting: "business",
       };
@@ -942,8 +947,11 @@
             d: "Ni publicar, ni buscar, ni mandar una propuesta.",
           },
           {
+            // Rewritten after #12 was decided. "Una persona revisa cada foto" alone
+            // can be heard as "Encuentra revisa a la gente", so the item names its
+            // own limit — and that limit is what the dropped `limits` band carried.
             t: "Una persona revisa cada foto.",
-            d: "Antes de que aparezca. Poner foto es opcional y no cambia nada más.",
+            d: "Antes de que aparezca. Solo la foto: no comprobamos nada más de nadie.",
           },
           {
             t: "El teléfono se comparte al aceptar.",
@@ -961,7 +969,12 @@
         quiet: "El pago lo acuerdan ustedes dos. Encuentra no cobra, no paga y no guarda plata.",
       };
 
-      function scamBlock() {
+      /* Two warnings at two moments, and they may never be the same words.
+         The Offer one is the decision gate: should you say yes at all.
+         The Exchange one covers what the Offer could not, because it had not
+         happened yet — a cost that appears after acceptance, once the terms
+         are fixed and the platform can no longer see anything. */
+      function scamBlockOffer() {
         return `
           <div class="notice warn">
             <span class="kicker">Antes de responder</span>
@@ -970,6 +983,18 @@
             Que te pidan comprar algo tú para empezar es la misma cosa dicha de otra forma.</p>
             <p style="margin:0">Si te la piden, repórtalo. No pierdes nada por reportar y no le
             avisamos a nadie que lo hiciste.</p>
+          </div>`;
+      }
+
+      function scamBlockExchange() {
+        return `
+          <div class="notice warn">
+            <span class="kicker">Cuando acuerden el pago</span>
+            <h4>Lo que aceptaste es lo que quedó escrito: $90.000 por día.</h4>
+            <p>Acuerden por mensaje qué día se paga, antes de empezar. Esa conversación ya es de
+            ustedes: Encuentra no la ve y no guarda nada de ella.</p>
+            <p style="margin:0"><strong>Si aparece un costo que no estaba en la propuesta, no estaba
+            en el trato.</strong></p>
           </div>`;
       }
 
@@ -1041,9 +1066,13 @@
         } else {
           band = `<div class="proofnote">Cada perfil de abajo lo escribió la persona misma.</div>`;
         }
-        if (S.variant === "C" && S.proof !== "none") {
-          band += `<div class="chromenote">Variant C renders this band only because you asked for
-            it. Its own answer is <code>proof=none</code>.</div>`;
+        // C keeps the band by decision: "Empresas verificadas" must be REPLACED, not
+        // deleted, and this is the only surface a person meets before signing up.
+        // What C drops is everything attached to a profile, a card or a suggestion.
+        if (S.proof === "none") {
+          band += `<div class="chromenote">Losing option. #12 kept the band — the ticket says
+            TrustProof must be <em>replaced</em>, and with no band nothing public sets the money
+            expectation before signup.</div>`;
         }
         const payHere =
           S.pay !== "quiet" && S.variant !== "C"
@@ -1222,7 +1251,7 @@
         const set = SETTINGS[S.setting];
         const hasPhoto = S.photo === "on";
         const warn =
-          S.scam === "offer" || S.scam === "both" || S.variant === "C" ? scamBlock() : "";
+          S.scam === "offer" || S.scam === "both" || S.variant === "C" ? scamBlockOffer() : "";
         return frame(
           "Offers received · pending",
           "the moment a decision is made",
@@ -1279,7 +1308,7 @@
       /* ---- 6. The Contact Exchange ---------------------------------------- */
       function sExchange() {
         const set = SETTINGS[S.setting];
-        const warn = S.scam === "exchange" || S.scam === "both" ? scamBlock() : "";
+        const warn = S.scam === "exchange" || S.scam === "both" ? scamBlockExchange() : "";
         return frame(
           "Contact Exchange · accepted",
           "guidance keyed to Work Setting",
@@ -1492,7 +1521,7 @@
         parts.push(`<section class="surface">
           <header>
             <h2>${v.name}</h2>
-            <span class="tag">variant ${S.variant}</span>
+            <span class="tag">${v.decided ? "decided" : "variant " + S.variant}</span>
             <span class="note">${v.gist}</span>
           </header>
         </section>`);

--- a/docs/design/trust-presentation-prototype/index.html
+++ b/docs/design/trust-presentation-prototype/index.html
@@ -1,0 +1,1640 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>PROTOTIPO — Confianza entre desconocidos (Encuentra, #12)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=DM+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ------------------------------------------------------------------
+         THROWAWAY PROTOTYPE — ticket #12, wayfinder map #1.
+
+         Three variants of where trust presentation LIVES, rendered across
+         every surface at once (wall, public view, signed-in profile, public
+         Need card, coincidencias, the Offer, the Contact Exchange, and the
+         safety states), switchable via ?variant=, plus three question
+         toggles (?proof=, ?pay=, ?scam=) and two inspection toggles
+         (?photo=, ?setting=).
+
+         Tokens copied verbatim from apps/landing/NEXTJS_HANDOFF.md, which
+         the map records as STILL BINDING after the pivot. Everything else
+         in that document that implies a vetted employer is dead — see the
+         README.
+
+         Not production code. No tests, no error handling, no abstractions.
+         The photograph is a coloured disc: the question here is the layout
+         around it, never the face inside it.
+         ------------------------------------------------------------------ */
+      :root {
+        --color-brand-500: #2457e6;
+        --color-brand-700: #172d70;
+        --color-ink: #172747;
+        --color-text-muted: #62708a;
+        --color-surface: #ffffff;
+        --color-page: #f7f9ff;
+        --color-surface-brand: #e8efff;
+        --color-border: #dce2ef;
+        --color-success: #387e65;
+        --color-success-surface: #e6f6ed;
+        --color-warning: #946016;
+        --color-warning-surface: #fff1c7;
+        --color-danger: #c53b5d;
+        --color-danger-surface: #fff5f7;
+
+        --font-sans: "Manrope", ui-sans-serif, system-ui, sans-serif;
+        --font-mono: "DM Mono", ui-monospace, monospace;
+        --text-2xs: 0.5rem;
+        --text-xs: 0.625rem;
+        --text-sm: 0.75rem;
+        --text-md: 0.875rem;
+        --text-lg: 1.125rem;
+        --text-display: clamp(1.75rem, 4vw, 2.5rem);
+
+        --space-1: 0.25rem;
+        --space-2: 0.5rem;
+        --space-3: 0.75rem;
+        --space-4: 1rem;
+        --space-5: 1.25rem;
+        --space-6: 1.5rem;
+        --space-8: 2rem;
+        --space-10: 2.5rem;
+        --space-12: 3rem;
+        --radius-sm: 0.3125rem;
+        --radius-md: 0.5rem;
+        --radius-lg: 0.75rem;
+        --shadow-card: 0 8px 19px rgb(38 74 150 / 8%);
+        --shadow-search: 0 13px 30px rgb(42 65 127 / 15%);
+        --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+      html {
+        -webkit-text-size-adjust: 100%;
+      }
+      body {
+        margin: 0;
+        background: var(--color-page);
+        color: var(--color-ink);
+        font-family: var(--font-sans);
+        font-size: 1rem;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+        padding-bottom: 240px; /* room for the switcher */
+      }
+      :focus-visible {
+        outline: 2px solid var(--color-brand-500);
+        outline-offset: 2px;
+        border-radius: var(--radius-sm);
+      }
+      p {
+        margin: 0 0 var(--space-3);
+      }
+      h1,
+      h2,
+      h3,
+      h4 {
+        margin: 0 0 var(--space-3);
+        letter-spacing: -0.045em;
+        line-height: 1.2;
+      }
+      a {
+        color: var(--color-brand-500);
+      }
+
+      /* ================= prototype chrome (English, deleted on capture) === */
+      .protobanner {
+        background: var(--color-ink);
+        color: #fff;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        padding: var(--space-3) var(--space-5);
+        text-align: center;
+      }
+      .protobanner b {
+        color: #8fb0ff;
+      }
+      .board {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: var(--space-8) var(--space-5) var(--space-12);
+      }
+      .surface {
+        margin-bottom: var(--space-12);
+      }
+      .surface > header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: var(--space-3);
+        border-top: 2px solid var(--color-ink);
+        padding-top: var(--space-3);
+        margin-bottom: var(--space-5);
+      }
+      .surface > header h2 {
+        font-family: var(--font-mono);
+        font-size: var(--text-md);
+        font-weight: 500;
+        margin: 0;
+        letter-spacing: 0;
+      }
+      .surface > header .note {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+      }
+      .tag {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        background: var(--color-ink);
+        color: #fff;
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+      }
+      .tag.muted {
+        background: var(--color-border);
+        color: var(--color-text-muted);
+      }
+      .cols {
+        display: grid;
+        gap: var(--space-5);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      /* ================= product surfaces (Spanish — the design) ========== */
+      .frame {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-card);
+        overflow: hidden;
+      }
+      .frame > .pad {
+        padding: var(--space-6);
+      }
+      .framelabel {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        padding: var(--space-2) var(--space-4);
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-page);
+        display: flex;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+
+      .topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-4) var(--space-5);
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-surface);
+      }
+      .wordmark {
+        font-weight: 800;
+        letter-spacing: -0.06em;
+        font-size: var(--text-lg);
+      }
+      .wordmark span {
+        color: var(--color-brand-500);
+      }
+
+      .hero {
+        padding: var(--space-10) var(--space-6) var(--space-8);
+        text-align: center;
+      }
+      .hero h1 {
+        font-size: var(--text-display);
+        letter-spacing: -0.07em;
+        margin-bottom: var(--space-4);
+      }
+      .hero p.lede {
+        color: var(--color-text-muted);
+        max-width: 46ch;
+        margin: 0 auto var(--space-5);
+      }
+
+      /* --- the ledger: the recurring motif. An account, never a stamp. --- */
+      .ledger {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1px;
+        background: var(--color-border);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
+      .ledger > div {
+        background: var(--color-surface);
+        padding: var(--space-4);
+      }
+      .ledger h4 {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--color-text-muted);
+        margin-bottom: var(--space-3);
+        letter-spacing: 0;
+      }
+      .ledger ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        font-size: var(--text-md);
+      }
+      .ledger li {
+        padding: var(--space-2) 0;
+        border-top: 1px solid var(--color-border);
+      }
+      .ledger li:first-child {
+        border-top: 0;
+      }
+      .ledger .none {
+        border-left: 3px solid var(--color-ink);
+        padding-left: var(--space-3);
+        margin-left: calc(var(--space-3) * -1);
+      }
+      @media (max-width: 560px) {
+        .ledger {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      /* --- the trust band that replaces TrustProof --- */
+      .proofband {
+        display: grid;
+        gap: var(--space-5);
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        padding: var(--space-6);
+        border-top: 1px solid var(--color-border);
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-page);
+      }
+      .proofitem strong {
+        display: block;
+        font-size: var(--text-lg);
+        letter-spacing: -0.045em;
+        margin-bottom: var(--space-1);
+      }
+      .proofitem span {
+        color: var(--color-text-muted);
+        font-size: var(--text-md);
+      }
+      .proofnote {
+        padding: var(--space-4) var(--space-6);
+        color: var(--color-text-muted);
+        font-size: var(--text-md);
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      /* --- person / publication cards --- */
+      .wall {
+        padding: var(--space-6);
+      }
+      .wall + .wall {
+        border-top: 1px solid var(--color-border);
+      }
+      .wall > h3 {
+        font-size: var(--text-lg);
+      }
+      .wall > p.sub {
+        color: var(--color-text-muted);
+        font-size: var(--text-md);
+      }
+      .grid {
+        display: grid;
+        gap: var(--space-4);
+        grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+      }
+      .pcard {
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        background: var(--color-surface);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        transition:
+          transform 160ms var(--ease-out),
+          box-shadow 160ms var(--ease-out);
+      }
+      @media (hover: hover) and (pointer: fine) {
+        .pcard:hover {
+          transform: translateY(-2px);
+          box-shadow: var(--shadow-card);
+        }
+      }
+      .pcard .name {
+        font-weight: 700;
+        letter-spacing: -0.04em;
+        font-size: var(--text-lg);
+      }
+      /* A Person with no Photo does not get an empty circle. The card
+         re-flows and the name takes the leading position at the same
+         weight — ADR-0010's never-second-class rule, as layout. */
+      .pcard.nophoto .name {
+        font-size: 1.3rem;
+        line-height: 1.15;
+      }
+      .disc {
+        width: 56px;
+        height: 56px;
+        border-radius: 999px;
+        background: linear-gradient(140deg, #b9c9ef, #7f97cd);
+        flex: none;
+      }
+      .disc.lg {
+        width: 84px;
+        height: 84px;
+      }
+      .meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+      }
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-1);
+      }
+      .chip {
+        font-size: var(--text-sm);
+        background: var(--color-surface-brand);
+        color: var(--color-brand-700);
+        border-radius: 999px;
+        padding: 2px 10px;
+      }
+      .chip.plain {
+        background: var(--color-page);
+        color: var(--color-text-muted);
+        border: 1px solid var(--color-border);
+      }
+      .disclaim {
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        border-top: 1px dashed var(--color-border);
+        padding-top: var(--space-2);
+        margin-top: auto;
+      }
+
+      .profilehead {
+        display: flex;
+        gap: var(--space-4);
+        align-items: flex-start;
+        margin-bottom: var(--space-5);
+      }
+      .profilehead h3 {
+        font-size: 1.5rem;
+        margin-bottom: var(--space-1);
+      }
+      .prose {
+        font-size: var(--text-md);
+        color: var(--color-ink);
+        background: var(--color-page);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+      }
+      .fieldrow {
+        display: flex;
+        gap: var(--space-3);
+        padding: var(--space-2) 0;
+        border-top: 1px solid var(--color-border);
+        font-size: var(--text-md);
+      }
+      .fieldrow dt {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        min-width: 130px;
+      }
+      .fieldrow dd {
+        margin: 0;
+      }
+
+      /* --- notices: never colour alone, always a text label --- */
+      .notice {
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        font-size: var(--text-md);
+        border: 1px solid var(--color-border);
+        background: var(--color-page);
+      }
+      .notice h4 {
+        font-size: var(--text-md);
+        margin-bottom: var(--space-2);
+      }
+      .notice .kicker {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        display: block;
+        margin-bottom: var(--space-2);
+      }
+      .notice.warn {
+        background: var(--color-warning-surface);
+        border-color: #e3c680;
+      }
+      .notice.warn .kicker {
+        color: var(--color-warning);
+      }
+      .notice.good {
+        background: var(--color-success-surface);
+        border-color: #a9d4bf;
+      }
+      .notice.good .kicker {
+        color: var(--color-success);
+      }
+      .notice.stop {
+        background: var(--color-danger-surface);
+        border-color: #eab5c3;
+      }
+      .notice.stop .kicker {
+        color: var(--color-danger);
+      }
+      .notice ul {
+        margin: var(--space-2) 0 0;
+        padding-left: 1.1em;
+      }
+      .notice li {
+        margin-bottom: var(--space-1);
+      }
+
+      .btn {
+        font: inherit;
+        font-weight: 600;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-brand-500);
+        background: var(--color-brand-500);
+        color: #fff;
+        cursor: pointer;
+        transition: transform 140ms var(--ease-out);
+      }
+      .btn:active {
+        transform: scale(0.97);
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--color-brand-700);
+      }
+      .btn.quiet {
+        background: transparent;
+        border-color: var(--color-border);
+        color: var(--color-ink);
+      }
+      .btn.danger {
+        background: transparent;
+        border-color: var(--color-danger);
+        color: var(--color-danger);
+      }
+      .btnrow {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-top: var(--space-4);
+      }
+      .linky {
+        background: none;
+        border: 0;
+        font: inherit;
+        color: var(--color-brand-500);
+        text-decoration: underline;
+        cursor: pointer;
+        padding: var(--space-1) 0;
+      }
+
+      .terms {
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
+      .terms dl {
+        margin: 0;
+        padding: 0 var(--space-4) var(--space-3);
+      }
+      .terms .pay {
+        font-family: var(--font-mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 1.4rem;
+        letter-spacing: -0.03em;
+      }
+      .paydir {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--color-text-muted);
+        padding: var(--space-3) var(--space-4);
+        border-top: 1px solid var(--color-border);
+        background: var(--color-page);
+      }
+
+      .statebox {
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-surface);
+        overflow: hidden;
+      }
+      .statebox > h4 {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--color-text-muted);
+        margin: 0;
+        padding: var(--space-2) var(--space-4);
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-page);
+      }
+      .statebox > .body {
+        padding: var(--space-4);
+      }
+      .reasonlist {
+        list-style: none;
+        margin: var(--space-2) 0 0;
+        padding: 0;
+        font-size: var(--text-md);
+      }
+      .reasonlist li {
+        padding: var(--space-2) 0;
+        border-top: 1px solid var(--color-border);
+        display: flex;
+        gap: var(--space-3);
+        align-items: baseline;
+      }
+      .reasonlist input {
+        accent-color: var(--color-brand-500);
+        width: 18px;
+        height: 18px;
+      }
+
+      /* ================= the switcher (English chrome) ==================== */
+      .switcher {
+        position: fixed;
+        left: 50%;
+        bottom: var(--space-4);
+        transform: translateX(-50%);
+        width: min(1120px, calc(100vw - 24px));
+        background: #0d1526;
+        color: #e8eefc;
+        border-radius: var(--radius-lg);
+        box-shadow: 0 18px 44px rgb(9 16 32 / 45%);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        z-index: 50;
+      }
+      .switcher .row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-3) var(--space-4);
+      }
+      .switcher .row + .row {
+        border-top: 1px solid #22304d;
+      }
+      .switcher .rowlabel {
+        color: #7f93bb;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: var(--text-xs);
+        min-width: 66px;
+      }
+      .switcher button {
+        font: inherit;
+        background: #1b2740;
+        color: #e8eefc;
+        border: 1px solid #2b3a5c;
+        border-radius: var(--radius-sm);
+        min-height: 32px;
+        padding: 0 10px;
+        cursor: pointer;
+        transition: transform 140ms var(--ease-out);
+      }
+      .switcher button:active {
+        transform: scale(0.97);
+      }
+      .switcher button[aria-pressed="true"] {
+        background: #3b6fff;
+        border-color: #3b6fff;
+        color: #fff;
+      }
+      .switcher .arrow {
+        width: 34px;
+        padding: 0;
+      }
+      .switcher .vname {
+        min-width: 210px;
+        color: #fff;
+      }
+      .switcher .group {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .switcher .group > span {
+        color: #7f93bb;
+      }
+      .switcher .readout {
+        color: #7f93bb;
+        margin-left: auto;
+      }
+
+      /* English instrumentation sitting inside a Spanish surface. Marked so it
+         is visibly not part of the design being judged. Deleted on capture. */
+      .chromenote {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: #7f93bb;
+        background: #0d1526;
+        padding: var(--space-3) var(--space-5);
+      }
+      .chromenote code {
+        color: #8fb0ff;
+      }
+      p.chromenote {
+        margin: var(--space-3) 0 0;
+        border-radius: var(--radius-sm);
+      }
+
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          transition-duration: 1ms !important;
+        }
+        .pcard:hover {
+          transform: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="protobanner">
+      PROTOTYPE · ticket #12 — trust presentation between strangers. Three variants of
+      <b>where the trust work lives</b>, rendered across every surface at once. Chrome is English;
+      the surfaces are Spanish. The photograph is a coloured disc on purpose.
+    </div>
+
+    <main id="board" class="board"></main>
+
+    <div class="switcher" role="region" aria-label="Prototype variant switcher">
+      <div class="row">
+        <span class="rowlabel">Variant</span>
+        <button class="arrow" id="prev" aria-label="Previous variant">←</button>
+        <span class="vname" id="vname"></span>
+        <button class="arrow" id="next" aria-label="Next variant">→</button>
+        <span class="readout" id="readout"></span>
+      </div>
+      <div class="row" id="questions">
+        <span class="rowlabel">Questions</span>
+      </div>
+      <div class="row" id="inspect">
+        <span class="rowlabel">Inspect</span>
+        <button id="reset" style="margin-left: auto">Reset</button>
+      </div>
+    </div>
+
+    <p aria-live="polite" class="visually-hidden" id="live"></p>
+
+    <script>
+      /* =================================================================
+         State. Every axis is a URL search param so a view is shareable.
+         ================================================================= */
+      const VARIANTS = {
+        A: {
+          name: "A — House rules",
+          gist: "One standing account of the mechanism, stated once and reachable everywhere.",
+        },
+        B: {
+          name: "B — Per-object ledger",
+          gist: "Every profile, card and offer carries its own ledger of what we know and do not.",
+        },
+        C: {
+          name: "C — Only in the moment",
+          gist: "Nothing standing. All the weight goes to the Offer and the Contact Exchange.",
+        },
+      };
+
+      const AXES = {
+        proof: {
+          label: "Proof",
+          row: "questions",
+          values: ["limits", "mechanism", "none"],
+          labels: { limits: "limits", mechanism: "mechanism", none: "none" },
+        },
+        pay: {
+          label: "Pay",
+          row: "questions",
+          values: ["plain", "warned", "quiet"],
+          labels: { plain: "plain", warned: "warned", quiet: "offer only" },
+        },
+        scam: {
+          label: "Scam warning",
+          row: "questions",
+          values: ["offer", "exchange", "both"],
+          labels: { offer: "in the offer", exchange: "at the exchange", both: "both" },
+        },
+        photo: {
+          label: "Photo",
+          row: "inspect",
+          values: ["on", "off"],
+          labels: { on: "with", off: "without" },
+        },
+        setting: {
+          label: "Work Setting",
+          row: "inspect",
+          values: ["hirer_home", "worker_home", "business", "public", "remote"],
+          labels: {
+            hirer_home: "hirer home",
+            worker_home: "worker home",
+            business: "business",
+            public: "public/varied",
+            remote: "remote",
+          },
+        },
+      };
+
+      const DEFAULTS = {
+        variant: "A",
+        proof: "limits",
+        pay: "plain",
+        scam: "offer",
+        photo: "on",
+        setting: "business",
+      };
+
+      const S = { ...DEFAULTS };
+
+      function readUrl() {
+        const q = new URLSearchParams(location.search);
+        if (VARIANTS[q.get("variant")]) S.variant = q.get("variant");
+        for (const [k, axis] of Object.entries(AXES)) {
+          if (axis.values.includes(q.get(k))) S[k] = q.get(k);
+        }
+      }
+      function writeUrl() {
+        const q = new URLSearchParams();
+        q.set("variant", S.variant);
+        for (const k of Object.keys(AXES)) q.set(k, S[k]);
+        history.replaceState(null, "", "?" + q.toString());
+      }
+
+      /* =================================================================
+         Fixtures. Not the vocabulary, not the seed, not real people.
+         ================================================================= */
+      const PERSON = {
+        name: "Luz Marina Ocampo",
+        dept: "Risaralda",
+        muni: "Dosquebradas",
+        since: "agosto de 2026",
+        remote: false,
+        skills: [
+          "atención al cliente",
+          "manejo de caja",
+          "cocina casera",
+          "aseo de locales",
+          "cuidado de niños",
+        ],
+        about:
+          "Trabajé ocho años en un restaurante en el centro y también he cuidado niños de la familia. Puedo empezar de una y trabajo fines de semana.",
+      };
+
+      const WALL_PEOPLE = [
+        {
+          name: "Luz Marina Ocampo",
+          dept: "Risaralda",
+          skills: ["cocina casera", "manejo de caja"],
+          photo: true,
+        },
+        {
+          name: "Jhon Freddy Cardona",
+          dept: "Risaralda",
+          skills: ["conducción de motocicleta"],
+          photo: false,
+        },
+        {
+          name: "Yeimy Alexandra Gil",
+          dept: "Risaralda",
+          skills: ["aseo de locales", "lavandería"],
+          photo: true,
+        },
+        {
+          name: "Óscar Iván Betancur",
+          dept: "Risaralda",
+          skills: ["albañilería", "pintura"],
+          photo: false,
+        },
+      ];
+
+      const WALL_NEEDS = [
+        {
+          title: "Ayuda en la cocina los fines de semana",
+          author: "Carolina Restrepo",
+          dept: "Risaralda",
+          skills: ["cocina casera", "aseo de locales"],
+          setting: "En un negocio o local",
+          commitment: "Fijo · sábados y domingos",
+        },
+        {
+          title: "Alguien que cuide a mi mamá dos tardes",
+          author: "Diego Alonso Marín",
+          dept: "Risaralda",
+          skills: ["cuidado de adultos mayores"],
+          setting: "En la casa de quien contrata",
+          commitment: "Fijo · martes y jueves",
+        },
+        {
+          title: "Digitar facturas desde la casa",
+          author: "Sandra Milena Toro",
+          dept: "Bogotá D.C.",
+          skills: ["digitación", "manejo de Excel"],
+          setting: "Remoto",
+          commitment: "Por una vez · una semana",
+        },
+      ];
+
+      const SENDER = {
+        name: "Andrés Villegas",
+        dept: "Risaralda",
+        since: "julio de 2026",
+      };
+
+      const SETTINGS = {
+        hirer_home: {
+          es: "En la casa de quien contrata",
+          guide: [
+            "Vas a ir a la casa de alguien que no conoces.",
+            "Cuéntale a alguien de confianza a dónde vas y a qué hora piensas salir.",
+            "Si al llegar algo no te cuadra, te puedes ir. No le debes una explicación a nadie.",
+          ],
+        },
+        worker_home: {
+          es: "En tu casa",
+          guide: [
+            "Alguien que no conoces va a ir a tu casa.",
+            "Puedes proponer una hora en la que no estés a solas.",
+            "No tienes que dar la dirección exacta hasta que acuerden el día.",
+          ],
+        },
+        business: {
+          es: "En un negocio o local",
+          guide: [
+            "Pregunta la dirección exacta y el nombre del negocio antes de ir.",
+            "Encuentra no conoce ese negocio ni lo ha visitado.",
+          ],
+        },
+        public: {
+          es: "En la calle o en varios sitios",
+          guide: [
+            "Acuerden un punto conocido para verse la primera vez.",
+            "Si el trabajo implica cargar plata o mercancía ajena, acuérdenlo por escrito antes.",
+          ],
+        },
+        remote: {
+          es: "Remoto",
+          guide: [
+            "Nadie necesita que pagues nada por adelantado para trabajar desde tu casa.",
+            "No mandes fotos de la cédula ni datos bancarios para “inscribirte”. Eso no existe.",
+          ],
+        },
+      };
+
+      /* =================================================================
+         Copy blocks that more than one surface uses.
+         ================================================================= */
+      const PROOF = {
+        limits: [
+          {
+            t: "Aquí no pasa plata.",
+            d: "Encuentra no cobra, no paga y no guarda nada. El pago lo arreglan ustedes dos.",
+          },
+          {
+            t: "No verificamos a nadie.",
+            d: "Ni a quien busca trabajo ni a quien contrata. Lo que lees lo escribió esa persona.",
+          },
+          {
+            t: "Tus datos de contacto son tuyos.",
+            d: "Solo se comparten cuando aceptas una propuesta. Antes, no.",
+          },
+        ],
+        mechanism: [
+          {
+            t: "Usar Encuentra no cuesta nada.",
+            d: "Ni publicar, ni buscar, ni mandar una propuesta.",
+          },
+          {
+            t: "Una persona revisa cada foto.",
+            d: "Antes de que aparezca. Poner foto es opcional y no cambia nada más.",
+          },
+          {
+            t: "El teléfono se comparte al aceptar.",
+            d: "Tú decides cuándo, propuesta por propuesta.",
+          },
+        ],
+        none: null,
+      };
+
+      const PAY_LINE = {
+        plain:
+          "El pago lo acuerdan ustedes dos. Encuentra no cobra, no paga y no guarda plata: si algo sale mal con el pago, nosotros no podemos devolvértela.",
+        warned:
+          "El pago lo acuerdan ustedes dos. Encuentra no cobra, no paga y no guarda plata: si algo sale mal con el pago, nosotros no podemos devolvértela. Nadie de Encuentra te va a pedir plata nunca.",
+        quiet: "El pago lo acuerdan ustedes dos. Encuentra no cobra, no paga y no guarda plata.",
+      };
+
+      function scamBlock() {
+        return `
+          <div class="notice warn">
+            <span class="kicker">Antes de responder</span>
+            <h4>Nadie debería pedirte plata para darte trabajo.</h4>
+            <p>Ni para el uniforme, ni para los materiales, ni para el curso, ni para los trámites.
+            Que te pidan comprar algo tú para empezar es la misma cosa dicha de otra forma.</p>
+            <p style="margin:0">Si te la piden, repórtalo. No pierdes nada por reportar y no le
+            avisamos a nadie que lo hiciste.</p>
+          </div>`;
+      }
+
+      function payDirection() {
+        return `<div class="paydir">En una propuesta la plata solo va en una dirección: de quien
+          contrata a quien trabaja. No hay forma de escribir lo contrario.</div>`;
+      }
+
+      /* =================================================================
+         Ledger — variant B's motif, and the shape of every honest answer.
+         ================================================================= */
+      function ledger(hasPhoto, opts = {}) {
+        const know = [`Tiene cuenta desde ${opts.since || PERSON.since}`, "Correo verificado"];
+        if (hasPhoto) know.push("Una persona revisó esta foto");
+        const dont = [
+          "No comprobamos quién es",
+          "No sabemos si ha hecho este trabajo antes",
+          "No sabemos si le han pagado",
+        ];
+        return `
+          <div class="ledger">
+            <div>
+              <h4>Lo que sabemos</h4>
+              <ul>${know.map((k) => `<li>${k}</li>`).join("")}</ul>
+            </div>
+            <div>
+              <h4>Lo que no sabemos</h4>
+              <ul>${dont.map((k) => `<li class="none">${k}</li>`).join("")}</ul>
+            </div>
+          </div>`;
+      }
+
+      const FLATLINE = "Encuentra no comprobó nada de esto. Lo escribió esa persona.";
+
+      /* =================================================================
+         Surface renderers
+         ================================================================= */
+      function personCard(p, opts = {}) {
+        const nophoto = !p.photo;
+        return `
+          <article class="pcard ${nophoto ? "nophoto" : ""}">
+            ${p.photo ? '<div class="disc" role="img" aria-label="Foto de la persona"></div>' : ""}
+            <div class="name">${p.name}</div>
+            <div class="meta">${p.dept}</div>
+            <div class="chips">${p.skills.map((s) => `<span class="chip">${s}</span>`).join("")}</div>
+            ${opts.disclaim ? `<div class="disclaim">${opts.disclaim}</div>` : ""}
+          </article>`;
+      }
+
+      function needCard(n, opts = {}) {
+        return `
+          <article class="pcard">
+            <div class="name" style="font-size:var(--text-lg)">${n.title}</div>
+            <div class="meta">${n.dept} · ${n.setting} · ${n.commitment}</div>
+            <div class="chips">${n.skills.map((s) => `<span class="chip">${s}</span>`).join("")}</div>
+            <div class="meta">Publicado por <a href="#">${n.author}</a></div>
+            ${opts.disclaim ? `<div class="disclaim">${opts.disclaim}</div>` : ""}
+          </article>`;
+      }
+
+      /* ---- 1. Landing: the band that replaces TrustProof, plus the Walls -- */
+      function sLanding() {
+        const items = PROOF[S.proof];
+        let band = "";
+        if (items) {
+          band = `<div class="proofband">${items
+            .map((i) => `<div class="proofitem"><strong>${i.t}</strong><span>${i.d}</span></div>`)
+            .join("")}</div>`;
+        } else {
+          band = `<div class="proofnote">Cada perfil de abajo lo escribió la persona misma.</div>`;
+        }
+        if (S.variant === "C" && S.proof !== "none") {
+          band += `<div class="chromenote">Variant C renders this band only because you asked for
+            it. Its own answer is <code>proof=none</code>.</div>`;
+        }
+        const payHere =
+          S.pay !== "quiet" && S.variant !== "C"
+            ? `<div class="proofnote">${PAY_LINE[S.pay]}</div>`
+            : "";
+
+        const disc = S.variant === "B" ? FLATLINE : "";
+
+        return frame(
+          "Landing · signed out",
+          "public · indexable",
+          `
+          <div class="topbar">
+            <div class="wordmark">Encuen<span>tra</span></div>
+            <div><button class="btn quiet">Entrar</button></div>
+          </div>
+          <div class="hero">
+            <h1>Aquí dices qué sabes hacer, y alguien te contrata.</h1>
+            <p class="lede">Encuentra no consigue trabajo por nadie. Te pone donde te pueden
+            encontrar.</p>
+            <button class="btn">Crear mi cuenta</button>
+          </div>
+          ${band}
+          ${payHere}
+          <div class="wall">
+            <h3>Personas que ya están aquí</h3>
+            <p class="sub">Cambian cada día. Esto no es la lista completa y no se puede buscar sin
+            cuenta.</p>
+            <div class="grid">${WALL_PEOPLE.map((p) => personCard(p, { disclaim: disc })).join("")}</div>
+          </div>
+          <div class="wall">
+            <h3>Trabajos que alguien necesita</h3>
+            <p class="sub">Estos sí los puedes buscar sin cuenta.</p>
+            <div class="grid">${WALL_NEEDS.slice(0, 3)
+              .map((n) => needCard(n, { disclaim: disc }))
+              .join("")}</div>
+          </div>
+          ${
+            S.variant === "A"
+              ? `<div class="proofnote"><a href="#reglas">Cómo funciona Encuentra</a> — qué
+                 revisamos, qué no, y qué pasa con tus datos.</div>`
+              : ""
+          }
+        `,
+        );
+      }
+
+      /* ---- 2. Public View next to the signed-in profile ------------------ */
+      function sProfiles() {
+        const hasPhoto = S.photo === "on";
+        const pub = `
+          ${
+            hasPhoto
+              ? `<div class="profilehead"><div class="disc lg" role="img" aria-label="Foto"></div>
+                 <div><h3>${PERSON.name}</h3><div class="meta">${PERSON.dept}</div></div></div>`
+              : `<div class="profilehead"><div><h3 style="font-size:1.9rem">${PERSON.name}</h3>
+                 <div class="meta">${PERSON.dept}</div></div></div>`
+          }
+          <div class="chips" style="margin-bottom:var(--space-4)">
+            ${PERSON.skills.map((s) => `<span class="chip">${s}</span>`).join("")}
+          </div>
+          ${S.variant === "B" ? ledger(hasPhoto) : ""}
+          ${
+            S.variant === "A"
+              ? `<p class="meta" style="margin-top:var(--space-4)"><a href="#reglas">Encuentra no
+                 verifica a nadie — cómo funciona</a></p>`
+              : ""
+          }
+          <div class="btnrow"><button class="btn">Entrar para mandarle una propuesta</button></div>
+          <p class="meta" style="margin-top:var(--space-3)">Con una cuenta ves el municipio y el
+          detalle de lo que publicó. No ves nada más sobre si es de fiar: eso no lo tenemos.</p>
+        `;
+
+        const priv = `
+          ${
+            hasPhoto
+              ? `<div class="profilehead"><div class="disc lg" role="img" aria-label="Foto"></div>
+                 <div><h3>${PERSON.name}</h3><div class="meta">${PERSON.muni}, ${PERSON.dept}</div></div></div>`
+              : `<div class="profilehead"><div><h3 style="font-size:1.9rem">${PERSON.name}</h3>
+                 <div class="meta">${PERSON.muni}, ${PERSON.dept}</div></div></div>`
+          }
+          <div class="chips" style="margin-bottom:var(--space-4)">
+            ${PERSON.skills.map((s) => `<span class="chip">${s}</span>`).join("")}
+          </div>
+          <div class="prose"><strong>Sobre mí.</strong> ${PERSON.about}</div>
+          <dl style="margin:var(--space-4) 0 0">
+            <div class="fieldrow"><dt>Disponible</dt><dd>Fines de semana y festivos</dd></div>
+            <div class="fieldrow"><dt>Trabajo remoto</dt><dd>No</dd></div>
+            <div class="fieldrow"><dt>Municipio</dt><dd>${PERSON.muni}</dd></div>
+          </dl>
+          ${S.variant === "B" ? `<div style="margin-top:var(--space-4)">${ledger(hasPhoto)}</div>` : ""}
+          <div class="btnrow">
+            <button class="btn">Mandarle una propuesta</button>
+            <button class="btn quiet">Bloquear</button>
+            <button class="btn quiet">Reportar</button>
+          </div>
+        `;
+
+        return `
+          <section class="surface">
+            <header>
+              <h2>2 · Public View vs the signed-in profile</h2>
+              <span class="tag muted">what each one CLAIMS</span>
+              <span class="note">The difference is fields, never credibility. Neither side may
+              imply that signing in buys you a vetted person.</span>
+            </header>
+            <div class="cols">
+              ${frame("Public View · signed out", "noindex · rotatable link", `<div class="pad">${pub}</div>`)}
+              ${frame("Capability Profile · signed in", "session required", `<div class="pad">${priv}</div>`)}
+            </div>
+          </section>`;
+      }
+
+      /* ---- 3. Public Need card (ADR-0014's contents) ---------------------- */
+      function sNeed() {
+        const n = WALL_NEEDS[0];
+        return frame(
+          "/search/work · signed out",
+          "noindex · results are a query, not content",
+          `<div class="pad">
+            <h3>${n.title}</h3>
+            <dl style="margin:0 0 var(--space-4)">
+              <div class="fieldrow"><dt>Dónde</dt><dd>${n.dept} · ${n.setting}</dd></div>
+              <div class="fieldrow"><dt>Dedicación</dt><dd>${n.commitment}</dd></div>
+              <div class="fieldrow"><dt>Habilidades</dt><dd>${n.skills.join(", ")}</dd></div>
+              <div class="fieldrow"><dt>Publicado por</dt><dd><a href="#">${n.author}</a></dd></div>
+            </dl>
+            <div class="prose">Necesito quien me ayude en la cocina sábados y domingos en el local
+            del centro. No hace falta experiencia, yo enseño.</div>
+            ${
+              S.variant === "B"
+                ? `<p class="disclaim" style="margin-top:var(--space-4)">${FLATLINE}</p>`
+                : ""
+            }
+            <div class="btnrow"><button class="btn">Entrar para responder</button></div>
+            <p class="meta" style="margin-top:var(--space-3)">El pago y las condiciones no van en la
+            necesidad: van en la propuesta que se mandan.</p>
+          </div>`,
+        );
+      }
+
+      /* ---- 4. Coincidencias ---------------------------------------------- */
+      function sSuggestions() {
+        const cards = [
+          { ...WALL_NEEDS[0], why: "Pide 3 de las 5 habilidades de tu perfil · Risaralda" },
+          { ...WALL_NEEDS[2], why: "Pide 1 de las 5 habilidades de tu perfil · acepta remoto" },
+          { ...WALL_NEEDS[1], why: "Pide 1 de las 5 habilidades de tu perfil · Risaralda" },
+        ];
+        return frame(
+          "Signed-in home · suggestions",
+          "the signed-in home IS this surface",
+          `<div class="pad">
+            <h3>Coincidencias</h3>
+            <p class="meta">Trabajos que encajan con lo que sabes hacer. Nadie te está buscando por
+            esto: es una búsqueda que no escribiste.</p>
+            <div class="grid" style="margin-top:var(--space-4)">
+              ${cards
+                .map(
+                  (c) => `
+                <article class="pcard">
+                  <div class="meta">${c.why}</div>
+                  <div class="name" style="font-size:var(--text-lg)">${c.title}</div>
+                  <div class="meta">${c.dept} · ${c.setting}</div>
+                  <div class="chips">${c.skills.map((s) => `<span class="chip">${s}</span>`).join("")}</div>
+                  ${S.variant === "B" ? `<div class="disclaim">${FLATLINE}</div>` : ""}
+                </article>`,
+                )
+                .join("")}
+            </div>
+          </div>`,
+        );
+      }
+
+      /* ---- 5. The Offer, received, pending -------------------------------- */
+      function sOffer() {
+        const set = SETTINGS[S.setting];
+        const hasPhoto = S.photo === "on";
+        const warn =
+          S.scam === "offer" || S.scam === "both" || S.variant === "C" ? scamBlock() : "";
+        return frame(
+          "Offers received · pending",
+          "the moment a decision is made",
+          `<div class="pad">
+            <div class="profilehead">
+              ${hasPhoto ? '<div class="disc" role="img" aria-label="Foto"></div>' : ""}
+              <div>
+                <h3 style="${hasPhoto ? "" : "font-size:1.6rem"}">${SENDER.name}</h3>
+                <div class="meta">${SENDER.dept} · <a href="#">ver su perfil público</a></div>
+              </div>
+            </div>
+
+            ${S.variant === "B" ? ledger(hasPhoto, { since: SENDER.since }) : ""}
+            ${
+              S.variant === "A"
+                ? `<p class="meta"><a href="#reglas">Encuentra no verifica a nadie — cómo
+                   funciona</a></p>`
+                : ""
+            }
+
+            <div class="terms" style="margin-top:var(--space-4)">
+              <div class="framelabel"><span>Lo que te propone</span><span>No se puede cambiar</span></div>
+              <div class="pad" style="padding-bottom:0">
+                <p>Ayudar en la cocina del local los sábados y domingos, de 8 a 4. No necesitas
+                experiencia.</p>
+              </div>
+              <dl>
+                <div class="fieldrow"><dt>Dónde</dt><dd>${set.es} · Pereira</dd></div>
+                <div class="fieldrow"><dt>Dedicación</dt><dd>Fijo · sábados y domingos, 8 horas</dd></div>
+                <div class="fieldrow"><dt>Empieza</dt><dd>Lo antes posible</dd></div>
+                <div class="fieldrow"><dt>Pago</dt><dd class="pay">$90.000 por día</dd></div>
+              </dl>
+              ${payDirection()}
+            </div>
+
+            <p class="meta" style="margin-top:var(--space-4)">${
+              S.pay === "quiet" ? PAY_LINE.quiet : PAY_LINE[S.pay]
+            }</p>
+
+            ${warn}
+
+            <div class="btnrow">
+              <button class="btn">Aceptar</button>
+              <button class="btn quiet">No, gracias</button>
+              <button class="btn quiet">Bloquear</button>
+              <button class="btn quiet">Reportar</button>
+            </div>
+            <p class="meta" style="margin-top:var(--space-3)">Si aceptas, se intercambian los datos
+            de contacto de los dos. Tienes 14 días para contestar; si no contestas, se vence sola.</p>
+          </div>`,
+        );
+      }
+
+      /* ---- 6. The Contact Exchange ---------------------------------------- */
+      function sExchange() {
+        const set = SETTINGS[S.setting];
+        const warn = S.scam === "exchange" || S.scam === "both" ? scamBlock() : "";
+        return frame(
+          "Contact Exchange · accepted",
+          "guidance keyed to Work Setting",
+          `<div class="pad">
+            <div class="notice good">
+              <span class="kicker">Aceptaste</span>
+              <h4>Ya tienen los datos del otro.</h4>
+              <p style="margin:0">Andrés ya puede ver tu teléfono y tu correo, y tú los de él.
+              Encuentra no sabe nada de lo que pase de aquí en adelante.</p>
+            </div>
+
+            <dl style="margin:var(--space-5) 0">
+              <div class="fieldrow"><dt>Teléfono</dt><dd>316 000 00 00</dd></div>
+              <div class="fieldrow"><dt>Correo</dt><dd>andres.villegas@ejemplo.com</dd></div>
+            </dl>
+
+            <div class="notice">
+              <span class="kicker">Este trabajo es: ${set.es.toLowerCase()}</span>
+              <ul style="margin-top:0">${set.guide.map((g) => `<li>${g}</li>`).join("")}</ul>
+            </div>
+
+            ${warn}
+
+            <div class="notice stop" style="margin-top:var(--space-4)">
+              <span class="kicker">Esto no se puede deshacer</span>
+              <p style="margin:0">Si más adelante lo bloqueas, no te va a poder escribir
+              <em>por Encuentra</em> — pero ya tiene tu número y eso no se lo podemos quitar.</p>
+            </div>
+
+            <p class="meta" style="margin-top:var(--space-4)">${PAY_LINE[S.pay === "quiet" ? "quiet" : S.pay]}</p>
+          </div>`,
+        );
+      }
+
+      /* ---- 7. The safety states, as rendered components ------------------- */
+      function sStates() {
+        const boxes = [
+          [
+            "Block",
+            `<h4>Bloquear a ${SENDER.name}</h4>
+             <p>No va a poder escribirte ni mandarte propuestas por Encuentra, y no se van a ver el
+             uno al otro en las búsquedas.</p>
+             <p><strong>No le avisamos.</strong> Si ya intercambiaron datos, esto no le quita tu
+             número.</p>
+             <div class="btnrow"><button class="btn danger">Bloquear</button>
+             <button class="btn quiet">Cancelar</button></div>`,
+          ],
+          [
+            "Report — reason codes",
+            `<h4>Reportar a ${SENDER.name}</h4>
+             <p class="meta">Escoge lo que pasó. Lo leemos nosotros.</p>
+             <ul class="reasonlist">
+               ${[
+                 "Me pidió plata para darme el trabajo",
+                 "Me sacó de Encuentra antes de aceptar",
+                 "No es quien dice ser",
+                 "No es un trabajo de verdad",
+                 "Me acosó o me amenazó",
+                 "Me discriminó",
+                 "El trabajo es ilegal o peligroso",
+                 "Parece menor de edad",
+                 "Manda lo mismo a todo el mundo",
+                 "Otra cosa",
+               ]
+                 .map(
+                   (r, i) =>
+                     `<li><input type="radio" name="rep" id="rep${i}" /><label for="rep${i}">${r}</label></li>`,
+                 )
+                 .join("")}
+             </ul>`,
+          ],
+          [
+            "Report — acknowledgement",
+            `<div class="notice">
+               <span class="kicker">Recibido</span>
+               <p>Gracias. Lo leemos nosotros.</p>
+               <p>No te vamos a contar qué pasó después: no podemos hablarte de la cuenta de otra
+               persona.</p>
+               <p style="margin:0">Si quieres que deje de escribirte ya mismo, bloquéala. Eso no
+               espera a nadie.</p>
+             </div>`,
+          ],
+          [
+            "Counterparty suspended",
+            `<div class="notice">
+               <span class="kicker">Esta propuesta se cerró</span>
+               <p style="margin:0">Esta cuenta ya no está disponible.</p>
+             </div>
+             <p class="chromenote">Nothing here says a moderation action happened. It reads the
+             same for a deleted account.</p>`,
+          ],
+          [
+            "Returning from Pause",
+            `<div class="notice">
+               <span class="kicker">Mientras no estabas</span>
+               <p style="margin:0">Llegaron 2 propuestas mientras estabas en pausa. Contéstalas o
+               descártalas.</p>
+             </div>`,
+          ],
+          [
+            "Absent public profile",
+            `<h4>Esta página ya no existe.</h4>
+             <p style="margin:0">Puedes buscar trabajos publicados sin cuenta.</p>
+             <p class="chromenote">Deliberately incurious: paused, rotated and deleted are
+             indistinguishable. 404, never 403.</p>`,
+          ],
+          [
+            "Photo pending review",
+            `<div class="notice">
+               <span class="kicker">Tu foto</span>
+               <p>La está revisando una persona. Suele tardar menos de 3 días.</p>
+               <p style="margin:0">Mientras tanto tu perfil funciona igual: sales en las búsquedas,
+               te pueden mandar propuestas y tú puedes mandar.</p>
+             </div>`,
+          ],
+          [
+            "Contact details typed into prose",
+            `<p class="chromenote">Hint, shown before anyone types</p>
+             <div class="notice" style="margin-top:var(--space-3)"><p style="margin:0">Tus datos de
+             contacto se comparten cuando alguien acepta una propuesta. No los pongas aquí.</p></div>
+             <p class="chromenote">Refusal on save</p>
+             <div class="notice stop"><p style="margin:0">Eso parece un teléfono. Tus datos se
+             comparten cuando aceptas una propuesta, no antes.</p></div>`,
+          ],
+          [
+            "Sin publicar",
+            `<div class="notice">
+               <span class="kicker">Tu perfil</span>
+               <h4>Está guardado, sin publicar.</h4>
+               <p>Nadie te puede encontrar mientras esté sin publicar.</p>
+               <div class="btnrow"><button class="btn">Terminar y publicar</button></div>
+             </div>`,
+          ],
+          [
+            "The line every route out ends on",
+            `<p style="font-size:var(--text-lg);letter-spacing:-0.04em;margin:0">Encuentra no
+             consigue trabajo por nadie. Te pone donde te pueden encontrar.</p>`,
+          ],
+        ];
+        return `<div class="cols">${boxes
+          .map(([t, b]) => `<div class="statebox"><h4>${t}</h4><div class="body">${b}</div></div>`)
+          .join("")}</div>`;
+      }
+
+      /* ---- A's standing rules panel --------------------------------------- */
+      function sRules() {
+        return frame(
+          "Standing rules page",
+          "variant A only · one standing account of the mechanism",
+          `<div class="pad" id="reglas">
+            <h2 style="font-size:1.5rem">Cómo funciona Encuentra</h2>
+            <h3>Qué hacemos y qué no</h3>
+            <div class="ledger" style="margin-bottom:var(--space-5)">
+              <div>
+                <h4>Lo que sí hacemos</h4>
+                <ul>
+                  <li>Revisamos cada foto antes de que aparezca</li>
+                  <li>Guardamos lo que se escriben en una propuesta</li>
+                  <li>Leemos todos los reportes</li>
+                  <li>Podemos cerrarle la cuenta a alguien</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Lo que no hacemos</h4>
+                <ul>
+                  <li class="none">No comprobamos quién es nadie</li>
+                  <li class="none">No sabemos si alguien hizo bien un trabajo</li>
+                  <li class="none">No sabemos si a alguien le pagaron</li>
+                  <li class="none">No movemos plata y no salimos de fiadores</li>
+                </ul>
+              </div>
+            </div>
+            <h3>La plata</h3>
+            <p>${PAY_LINE.plain}</p>
+            <h3>Tus datos de contacto</h3>
+            <p>Tu teléfono y tu correo no salen en ninguna parte. Se comparten solo cuando aceptas
+            una propuesta, y ahí se comparten los de los dos.</p>
+            <h3>Si algo sale mal</h3>
+            <p>Bloquear es inmediato y no le avisamos a nadie. Reportar lo leemos nosotros, pero no
+            te podemos contar qué pasó con la cuenta de otra persona.</p>
+          </div>`,
+        );
+      }
+
+      /* =================================================================
+         Frame + board assembly
+         ================================================================= */
+      function frame(label, right, inner) {
+        return `<div class="frame">
+          <div class="framelabel"><span>${label}</span><span>${right}</span></div>
+          ${inner}
+        </div>`;
+      }
+
+      function section(n, title, tag, note, body) {
+        return `<section class="surface">
+          <header>
+            <h2>${n} · ${title}</h2>
+            ${tag ? `<span class="tag muted">${tag}</span>` : ""}
+            ${note ? `<span class="note">${note}</span>` : ""}
+          </header>
+          ${body}
+        </section>`;
+      }
+
+      function render() {
+        const v = VARIANTS[S.variant];
+        const parts = [];
+
+        parts.push(`<section class="surface">
+          <header>
+            <h2>${v.name}</h2>
+            <span class="tag">variant ${S.variant}</span>
+            <span class="note">${v.gist}</span>
+          </header>
+        </section>`);
+
+        parts.push(
+          section(
+            1,
+            "Landing and the two Walls",
+            "replaces TrustProof",
+            '"Empresas verificadas" is gone. What stands in its place is the ?proof= axis.',
+            sLanding(),
+          ),
+        );
+        parts.push(sProfiles());
+        parts.push(
+          section(
+            3,
+            "Public Need card",
+            "the work, not the author",
+            "Name only, no photo — ADR-0014, inherited by this ticket.",
+            sNeed(),
+          ),
+        );
+        parts.push(
+          section(
+            4,
+            "Suggestions",
+            "explanation always on the card",
+            "Never behind a disclosure control.",
+            sSuggestions(),
+          ),
+        );
+        parts.push(
+          section(
+            5,
+            "The Offer, pending",
+            "where the decision is",
+            "Identity before acceptance; contact details only at it.",
+            sOffer(),
+          ),
+        );
+        parts.push(
+          section(
+            6,
+            "The Contact Exchange",
+            "irreversible",
+            "Guidance is chosen by Work Setting — flip it in the black bar.",
+            sExchange(),
+          ),
+        );
+        if (S.variant === "A") {
+          parts.push(
+            section(
+              7,
+              "The standing rules page",
+              "variant A only",
+              "The standing page everything else links to. Its risk: nobody opens it.",
+              sRules(),
+            ),
+          );
+        }
+        parts.push(
+          section(
+            S.variant === "A" ? 8 : 7,
+            "Every safety-relevant state, in Spanish",
+            "same in all three variants",
+            "These are copy decisions, not layout ones — they do not vary by variant.",
+            sStates(),
+          ),
+        );
+
+        document.getElementById("board").innerHTML = parts.join("");
+        paintSwitcher();
+        writeUrl();
+      }
+
+      /* =================================================================
+         Switcher
+         ================================================================= */
+      function paintSwitcher() {
+        document.getElementById("vname").textContent = VARIANTS[S.variant].name;
+        document.getElementById("readout").textContent =
+          `?variant=${S.variant}&proof=${S.proof}&pay=${S.pay}&scam=${S.scam}&photo=${S.photo}&setting=${S.setting}`;
+
+        for (const rowId of ["questions", "inspect"]) {
+          const row = document.getElementById(rowId);
+          row.querySelectorAll(".group").forEach((g) => g.remove());
+        }
+        for (const [key, axis] of Object.entries(AXES)) {
+          const row = document.getElementById(axis.row);
+          const g = document.createElement("span");
+          g.className = "group";
+          g.innerHTML =
+            `<span>${axis.label}</span>` +
+            axis.values
+              .map(
+                (val) =>
+                  `<button data-axis="${key}" data-val="${val}" aria-pressed="${S[key] === val}">${axis.labels[val]}</button>`,
+              )
+              .join("");
+          const resetBtn = row.querySelector("#reset");
+          if (resetBtn) row.insertBefore(g, resetBtn);
+          else row.appendChild(g);
+        }
+        document.querySelectorAll("[data-axis]").forEach((b) => {
+          b.addEventListener("click", () => {
+            S[b.dataset.axis] = b.dataset.val;
+            render();
+            announce(`${AXES[b.dataset.axis].label}: ${b.dataset.val}`);
+          });
+        });
+      }
+
+      function cycle(dir) {
+        const keys = Object.keys(VARIANTS);
+        const i = keys.indexOf(S.variant);
+        S.variant = keys[(i + dir + keys.length) % keys.length];
+        render();
+        announce(VARIANTS[S.variant].name);
+      }
+
+      function announce(msg) {
+        document.getElementById("live").textContent = msg;
+      }
+
+      document.getElementById("prev").addEventListener("click", () => cycle(-1));
+      document.getElementById("next").addEventListener("click", () => cycle(1));
+      document.getElementById("reset").addEventListener("click", () => {
+        Object.assign(S, DEFAULTS);
+        render();
+        announce("Reset");
+      });
+
+      addEventListener("keydown", (e) => {
+        const t = e.target;
+        if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return;
+        if (e.key === "ArrowLeft") cycle(-1);
+        if (e.key === "ArrowRight") cycle(1);
+      });
+
+      readUrl();
+      render();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Companion to #56, which carries **ADR-0026**. This is the artefact the decision came out of. Resolves nothing on its own; #12 is already closed.

Additive only: 2,067 lines added, none removed, two new files under `docs/design/`. Docs only.

```sh
open docs/design/trust-presentation-prototype/index.html
```

No build, no server, no dependencies.

## What it is

Three variants of **where the trust work lives**, each re-rendering **seven surfaces at once** — the two Walls, the Public View beside the signed-in profile, the public Need card, the coincidencias, the Offer, the Contact Exchange, and every safety state. `?variant=A|B|C`, three question toggles (`?proof=`, `?pay=`, `?scam=`) and two inspection toggles (`?photo=`, `?setting=`).

**The board is the departure from `/prototype`'s UI branch that matters.** UI.md's variants normally replace a page; #12's real question is consistency *across* surfaces, and a one-page variant cannot show it. The Spanish sentence about payment has to be the same sentence in the Offer and at the Exchange, and the only way to see that is to render both at once.

The defaults on load are the decisions: `?variant=C&proof=mechanism&pay=warned&scam=both`.

## Why keep it rather than delete the losers

**One variant was disqualified by a defect that only exists on screen**, and the ADR cites the file for it. Flip `?variant=B&photo=off`:

The per-object ledger's *Lo que sabemos* column can truthfully carry *"una persona revisó esta foto"* — a row that exists only for people who uploaded one. Rendered beside someone who did, a Person with no Photo has visibly less known about them. Delete the row for everybody and it becomes three "no" and two "yes" printed next to every human on the platform. **There is no third version**, and that is not obvious from the prose — it is obvious from the two cards side by side.

Same for variant C's own `proof=none`: the argument that a public surface claiming nothing *"reads as a scam"* is ADR-0010's, and it is much easier to agree with while looking at the landing page than while reading the sentence.

## What moved after the first pass

- **The landing band came back**, against the winning variant's own answer — #12 requires `TrustProof` to be *replaced*, not deleted, and nothing else public sets the money expectation before signup.
- **`mechanism`'s middle item was rewritten**, because dropping the limits-phrased band took *"no verificamos a nadie"* off the product and left the only public claim sounding like vetting. It now carries its own limit: *"Solo la foto: no comprobamos nada más de nadie."*
- **`scam=both` stopped rendering one block twice.** ADR-0013 ruled against undifferentiated safety copy, so the two moments now say different things — the Offer is the decision gate, the Exchange covers the cost that appears *after* acceptance.

## Departures, and one that was stale

- **A single HTML file rather than a route.** `apps/web` is still the bare scaffold, so UI.md's preferred sub-shape A has no host page.
- **`shadcn` could not be loaded as a skill** — its CLI refuses at a monorepo root; `-c packages/design-system` works and reports style `base-vega`, Base UI, Tailwind v4, preset `b1sRmB0Rk`. **The map is right that the old excuse is stale**: `@repo/design-system` exists now, so #30's and #35's *"there is nothing for it to act on"* no longer holds. What holds instead is narrower — the package ships **one component** (`button.tsx`) as un-built React source, and a `file://` page cannot consume React. The departure is the format, which `apps/web` forces anyway.
- **`brand-voice` sketched rather than run**, extending the sketch `skill-picker-prototype` established. Two rules this surface adds: **state the limit, never the risk**, and **never claim a reach we do not have**.
- **The safety states do not vary by variant.** They are copy decisions, not placement ones, so they render identically in all three rather than being triplicated.

## Worth knowing before merging

**Checking the stale-shadcn note surfaced a conflict, now ticketed as #54.** The map's Notes record `NEXTJS_HANDOFF.md`'s design tokens as *still binding*; `@repo/design-system` shipped the shadcn `vega` preset instead — a cyan primary against the handoff's blue, Inter and Figtree against Manrope, Geist Mono against DM Mono, a different radius scale. No ADR reconciles them.

**This file uses the handoff tokens**, because the map names them binding and because the two earlier prototypes use them, so all three can be read against each other. Every decision in ADR-0026 is copy, placement or layout, so **none of them moves if the palette changes** — but a reviewer should know the colours here may not be the product's.

## Reviewer notes

- **Chrome is English, surfaces are Spanish** — ADR-0001 as amended by #30, including the variant names and the frame labels (`Contact Exchange · accepted`, not `Intercambio de datos · aceptada`). English commentary that has to sit *inside* a Spanish surface renders in a dark monospace `.chromenote` style so it cannot be mistaken for design.
- **The photograph is a coloured disc on purpose.** The question is the layout around it, never the face inside it — and `?photo=off` is how the no-placeholder rule is judged.
- **The fixture data is not the vocabulary and not the seed.** Names, skills and amounts are layout fixtures.
- **Accessibility is a demonstrated pattern, not verified conformance.** No meaning by colour alone (every notice carries a text kicker; the ledger's columns are labelled rather than tinted), 44px targets, real radio inputs with labels, a polite live region on the switcher, `prefers-reduced-motion` honoured, hover behind `(hover: hover) and (pointer: fine)`, tabular figures on the pay amount. Nothing has been through a screen reader.

`oxfmt --check` clean — note that oxfmt **does** format HTML, so `index.html` is formatted output rather than hand-wrapped.
