### PR TITLE
The photo refusal notice: ADR-0027 and the prototype behind it (#29)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -200,7 +200,9 @@ _Avoid_: Avatar, Image, Picture, Attachment, Upload, File
 The operator's decision on whether a Photo may appear. Every Photo waits for one, and no one but its
 owner sees it until it is approved — but nothing else waits: the Person publishes, is matched, and
 sends and receives Offers meanwhile. A refusal has a reason drawn from a fixed vocabulary, and the
-image itself is destroyed; the record that it happened is not.
+image itself is destroyed; the record that it happened is not. It judges the **image and never the
+account**: every reason names something about the photograph, and a doubt about the person behind it
+is a Report rather than a refusal, so a Review has two exits and only one of them touches the Photo.
 _Spanish (UI)_: revisión de la foto
 _Avoid_: Approval, Moderation (which is the wider #13 concern, not this one step), Verification
 

--- a/docs/adr/0010-profile-photos-as-consented-sensitive-data.md
+++ b/docs/adr/0010-profile-photos-as-consented-sensitive-data.md
@@ -230,7 +230,11 @@ authorisation simply ended.
 - **#12 inherits a rule**: a profile without a photograph must never render as second-class. Rule 1 is
   worthless if the UI makes the absence a visible penalty.
 - **#13 inherits** the reason-code vocabulary, the evidentiary rejection row, and the optional
-  classifier as a queue pre-filter.
+  classifier as a queue pre-filter. **Superseded by ADR-0027**: ADR-0013 declined the vocabulary,
+  recording only that it stays separate from its own Report codes, so nobody held it. It is authored
+  in ADR-0027 **copy-first** — the Spanish sentence first, the code derived from it — because a list
+  written for an operator's queue translates into exactly the sentence this ADR's rejection rule
+  exists to avoid. The evidentiary row and the classifier pre-filter are unaffected and still #28's.
 - **#10 and #20 inherit** rules 3 and 4 as hard constraints.
 - **Admin tooling is now a launch requirement**, not a #13 dependency — pre-moderation does not
   function without a review surface.

--- a/docs/adr/0015-the-offer-as-an-immutable-snapshot.md
+++ b/docs/adr/0015-the-offer-as-an-immutable-snapshot.md
@@ -210,6 +210,11 @@ reading status straight off `offers`, plus email. A notification system earns it
 stop being 1:1 with a domain row (a Report resolved, a Photo approved, a Skill Suggestion answered),
 and that is a decision to make with real events in hand.
 
+> **Tested by ADR-0027 and the condition is not met.** A Photo approved or refused is exactly 1:1
+> with the Photo row, which already carries the state a notification would announce — so a
+> `notifications` table would be the denormalised copy this section rejects. What that ADR needs is
+> the outbox below, unchanged. One event off this list; a Skill Suggestion answered is still open.
+
 This adds **`seen_at`** to the Offer, for the recipient's own unread count, with a hard rule:
 **`seen_at` is never shown to the sender.** No read receipts. _"Seen three days ago, no answer"_ is a
 pressure tactic aimed at the person with the least power in the exchange, and it tells a harasser

--- a/docs/adr/0026-there-is-no-badge-to-earn.md
+++ b/docs/adr/0026-there-is-no-badge-to-earn.md
@@ -192,6 +192,12 @@ Initials in a disc are the same statement in a friendlier font. A name set large
 substitute for a photograph and does not read as one; it reads as a card that was designed for a
 name.
 
+> **Boundary, added by ADR-0027.** This rule governs surfaces where a Person is being **shown to
+> somebody else** — a profile, a card, a search result, a suggestion. It does not reach the owner's
+> own Photo screen, where ADR-0027 sets the refusal inside a photo-shaped frame deliberately: there
+> the rectangle is the object under discussion rather than a person's missing face, and naming it is
+> the point. The two must never be quoted at each other.
+
 ## The safety-relevant states, in Spanish
 
 | State                         | Copy                                                                                                                                                                                                          |

--- a/docs/adr/0027-a-refused-photo-is-told-what-to-change.md
+++ b/docs/adr/0027-a-refused-photo-is-told-what-to-change.md
@@ -1,0 +1,338 @@
+# A refused Photo is told what to change, and the email carries only the half that is true of everyone
+
+ADR-0010 made **re-upload the appeal** — there is no separate appeals process in v1 — and destroys the
+rejected bytes immediately. The whole mechanism therefore rests on a message: the person has to learn
+the Photo was refused and come back. Nobody had designed that message, and it is the one place this
+product tells someone their face was rejected, against a standing rule that Encuentra preserves
+_dignity, agency and income_ and never charity or disaster imagery.
+
+_"Tu foto fue rechazada"_ fails that on its own, and each softening fails differently: _"lamentamos
+informarte"_ is an institution clearing its throat, _"no cumple nuestras normas comunitarias"_ sends
+the reader looking for the rule they broke, _"¡Ups! Algo salió mal"_ is a product being cute about
+somebody's face.
+
+This ADR decides the vocabulary, the channel, the re-upload path, the approval case, the repeat case
+and the timeout case. Prototyped at `docs/design/photo-refusal-prototype/` on
+`prototype/photo-refusal-notice`, four email variants against three app surfaces.
+
+## The vocabulary is authored copy-first, and that is what makes the tone problem tractable
+
+ADR-0010 fixes that a refusal carries a code from a fixed vocabulary and forbids operator prose. It
+never says what the codes are, and its consequences hand them to #13 — which then declined them,
+recording only that they stay a **separate vocabulary** from its own Report codes. So nobody had
+written them.
+
+**They are authored here, sentence first, code second**, reversing the direction ADR-0010 implied.
+A list authored for an operator's queue — `INVALID`, `POLICY_VIOLATION`, `LOW_QUALITY` — translates
+into exactly the sentence this ADR exists to avoid, and by the time it is being translated the
+translation is the only lever left.
+
+Written the other way round, the finding falls out immediately: **almost every real cause is a fact
+about the image, not a judgment of the person.** A photograph of a cédula, a landscape, two people, a
+phone number across the frame, a face too dark to make out — in five of six cases there is nothing to
+say about the human being at all. So every code names **a property of the photo and the change that
+fixes it**, and the sentence _"tu foto fue rechazada"_ never has to be written.
+
+| Code               | The diagnosis (in the session)                                                                                                                                         | The imperative (in the email)                               |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `face_not_visible` | _No se te ve la cara._ Puede que esté muy oscura, muy lejos o movida. Con que se te vea de frente basta: no tiene que ser bonita ni profesional.                       | _Que se te vea la cara, de frente y con buena luz._         |
+| `no_person`        | _En la foto no hay nadie._ Va una foto tuya, no de tu negocio, tu herramienta ni tu logo. La cara sirve para que quien te va a contratar sepa con quién está hablando. | _Va tu cara, no tu negocio ni tu logo._                     |
+| `other_people`     | _Sale alguien más en la foto._ Solo podemos mostrar tu cara: la otra persona no nos dio permiso para mostrar la suya.                                                  | _Tiene que salir una sola persona: tú._                     |
+| `document`         | _Es la foto de un documento._ No recibimos cédulas, diplomas ni hojas de vida. Esa la borramos apenas la vimos y no queda copia. Aquí va una foto tuya y ya.           | _Aquí solo va una foto tuya: nada de cédulas ni papeles._   |
+| `contact_visible`  | _Se ve un número de teléfono en la foto._ Tus datos de contacto se comparten cuando alguien acepta una propuesta, no antes.                                            | _Sin números de teléfono ni correos escritos en la imagen._ |
+| `not_for_work`     | _No podemos mostrar esta foto en un perfil de trabajo._ Pon otra donde se te vea la cara.                                                                              | _Que se te vea la cara, de frente y con buena luz._         |
+
+Codes are English `snake_case` per ADR-0001 as amended, and remain the separate vocabulary ADR-0013
+requires. Four carry a decision rather than a translation:
+
+- **`face_not_visible` says the photo does not have to be good.** _"No tiene que ser bonita ni
+  profesional"_ exists because the most likely second attempt after a quality refusal is **no second
+  attempt at all** — somebody concluding they have no photograph good enough. A refusal that reads as
+  a standard is the one that loses the Photo permanently, and rule 1 forbids us to cost anybody
+  anything for not having one.
+- **`document` says the bytes are already gone**, in the same breath as the refusal. Photographing a
+  cédula and sending it to a website is the most frightening thing on this list, and ADR-0010 makes
+  the reassurance true rather than soothing.
+- **`contact_visible` repeats the mechanic and never the format.** ADR-0026's rule for the prose
+  refusal, applied to an image instead of a text field.
+- **`not_for_work` is the only one that does not say what to change, and that is the design.** It
+  states what **we** cannot do, never what the image is — ADR-0026's _state the limit, never the
+  risk_, pointed at a person rather than at a stranger. It does not characterise, cite a rule or
+  moralise, and **ADR-0010 gives the operator no free text to elaborate with**, which is the clause
+  that makes the line survivable rather than merely polite.
+
+### Two codes are deliberately absent
+
+An operator will sometimes think _this is a stock photo_ or _this person looks under 18_. Neither is a
+photo-refusal code, because **they are judgments about an account rather than about an image**, and
+ADR-0013 already owns both as Report codes with an operator queue behind them. Refusing the Photo
+under a nearby code would be a lie, and this vocabulary cannot afford one: **there is no
+operator-only layer — the person is always shown the same code the operator picked.**
+
+So **the photo queue judges photos and the safety queue judges accounts.** Where no image-level code
+is true, the Photo is approved and the account is handled under ADR-0013 — which is the right outcome
+anyway, since suppressing one image does nothing about somebody who is not who they say they are.
+
+## The email carries the imperative, and the diagnosis stays in the session
+
+The channel question looked like a straight choice and was not.
+
+Putting the reason in the email is what reaches the person who never opens the site again, and the
+whole mechanism is "the person comes back". But **the reason then outlives the photograph**: a
+sentence about somebody's face, in clear text, in a mailbox that may be shared, retained by a third
+party, and outside every erasure adapter we have — while ADR-0010 destroys the image itself within
+seconds. Withholding the reason answers that and costs a hop, and **every hop between the refusal and
+the re-upload is a place the Photo is lost for good**.
+
+**The resolution came from reading the vocabulary rather than the channel.** Each message already
+contains two halves: a **diagnosis**, which is a proposition about the reader, and an **imperative**,
+which is a rule true of everybody on the platform. The imperative carries the same operational
+information to the one person who knows what they uploaded, and nothing at all to anyone else.
+
+So the email names the outcome, says plainly that a human looked, and carries **only the imperative**.
+The diagnosis lives in the session. Nothing that persists in a mailbox is a statement about the
+reader.
+
+> **Tu foto todavía no está en tu perfil.** Una persona la revisó y hay algo que cambiar.
+>
+> _Lo que sirve:_ **Aquí solo va una foto tuya: nada de cédulas ni papeles.**
+>
+> Tu perfil sigue igual: sales en las búsquedas y te pueden mandar propuestas. Lo único que falta es
+> la foto.
+
+**`not_for_work` and `face_not_visible` share one imperative, word for word, and that is the control
+rather than a collision.** The first idea was a per-code channel policy — five reasons travel, the
+sensitive one does not — and it is wrong for a reason this repo has already established twice:
+**differential treatment leaks the thing it protects.** A vaguer email for the sensitive code makes
+the vague email _mean_ that code, which is the failure ADR-0011 avoided by 404-ing rather than
+403-ing, and ADR-0015 avoided by making the suspended-counterparty string deliberately incurious.
+Collapsing the two imperatives is what stops the email being read backwards to the code.
+
+**The cost, named rather than hidden:** this protects the person whose inbox is shared at the expense
+of the person who only ever reads the email. Somebody refused under `not_for_work` receives the same
+words as somebody whose photo was dark, and if they never open the app they may re-upload against the
+wrong understanding. That is what makes the repeat rule below load-bearing rather than optional.
+
+**A standing constraint on the vocabulary, so the argument survives the next code added:**
+
+> **No reason code may enter this vocabulary unless its imperative half is a rule true of everyone on
+> the platform.**
+
+Without it, the sixth code somebody adds quietly reopens the whole question. It is testable against a
+single sentence, which is the only kind of rule worth writing here.
+
+**No email ever carries the image** — not the rejected one, not a thumbnail, not a link to one. The
+rejected bytes are gone before the message is composed, and an approved photograph does not need
+reprinting in a mailbox.
+
+## `transactional_messages` carries the send
+
+Not close, and recorded because the ticket asked.
+
+- **Ley 2300 art. 5 par. 2** permits requiring consent to messages _"estrictamente relacionados con el
+  bien o servicio adquirido"_, which is why ADR-0007 could make this Purpose required at all. The
+  outcome of a review the person themselves started is the paradigm case.
+- **`news` could not carry it.** `news` is optional, so somebody who declined it would never learn
+  their Photo was refused and would hold a permanently invisible Photo with no way to find out.
+- **The send is not gated on the `photo` Purpose.** That Purpose authorises _showing_ a Photo; this is
+  a service outcome. Gating it would mean revoking `photo` consent silently disables the only channel
+  that could confirm the deletion.
+
+The footer states this rather than offering a control that does nothing: _"Te escribimos porque es un
+mensaje del servicio, no publicidad. Estos no se pueden desactivar; los de novedades sí, en Tus
+datos."_
+
+## No notification system, and the outbox already exists
+
+ADR-0015 refused a `notifications` table and named the condition for revisiting it: _"a notification
+system earns its place when events stop being 1:1 with a domain row (a Report resolved, **a Photo
+approved**, a Skill Suggestion answered)"_.
+
+**This is the decision with that event in hand, and the condition is not met.** A Photo approval or
+refusal is exactly 1:1 with the Photo row, which already carries the state a notification would
+announce — so a `notifications` table would be the denormalised copy able to disagree that ADR-0015
+rejected. What this needs is what ADR-0015 already built: **an outbox row written inside the
+transaction and drained after commit**, so a rollback cannot leave a sent email describing a refusal
+that did not happen.
+
+That is the second entry on ADR-0015's list gone. The list is not empty — a Skill Suggestion answered
+is still out there — but it is now one event short of the argument.
+
+## The re-upload path restates the diagnosis, always
+
+The link lands on the Photo screen, and **the diagnosis is restated there in every case**. An email
+read on a bus and opened an hour later has lost its context, and under the channel decision above the
+email never carried the diagnosis in the first place.
+
+The screen carries, before any file is chosen, the guidance that prevents a second refusal — phrased
+as what works rather than as prohibitions, with the item matching the refusal emphasised:
+
+> Que se te vea la cara. · Que salgas tú, no tu negocio ni tu logo. · Que no salga nadie más. · Nada
+> de cédulas, diplomas ni papeles. · Sin números ni correos escritos en la imagen.
+
+**ADR-0025's three properties are inherited unchanged and are not preferences**: the two controls at
+equal visual weight, the cost of skipping stated, and the screen never placed last before publishing.
+A refusal does not suspend D.1377 art. 6 — if anything it is the moment the pressure to nudge is
+highest, because the Photo is now a thing the person has failed to supply twice.
+
+## The approval case is a message, and it is not a congratulation
+
+Silence is defensible — an approval is not news — but it leaves somebody who was shown _menos de 3
+días_ with no way to learn the answer except by coming back to check, and **ADR-0025's whole argument
+is that people do not come back.**
+
+> **Tu foto ya está en tu perfil.** Una persona la revisó. Ahora la ve quien entre a tu perfil.
+>
+> Si algún día la quieres quitar, se quita en un toque.
+
+Three things about it are decisions:
+
+- **It says a human looked.** This is the only moment that sentence can be said to a specific person
+  without cost. ADR-0026 forbids it on a profile precisely because attaching it there makes a profile
+  without a Photo carry visibly less — the second-class rendering ADR-0010 rule 1 bans. Said to the
+  owner about their own Photo, it penalises nobody.
+- **It does not celebrate.** No _¡Felicitaciones!_, no tick, no badge. ADR-0026 is titled _there is no
+  badge to earn_ and ADR-0025's ending already refuses to celebrate; an approval that reads as an
+  award teaches that the platform grades faces.
+- **It closes on how to remove it**, because ADR-0010 rule 5 holds that publication by the Titular is
+  never a licence. Revocation has to be one tap and it has to be visible at the moment consent has
+  just been vindicated.
+
+## The timeout case is a message with no new date
+
+ADR-0010 displays _menos de 3 días_ and forbids any automatic state transition, so a missed
+commitment is purely a copy problem.
+
+> **Tu foto sigue en revisión.** Dijimos que menos de 3 días y no cumplimos. No se perdió y no tienes
+> que hacer nada.
+
+**Silence cannot actually be silent**, which is what settles this: leaving _"suele tardar menos de 3
+días"_ on the pending card on day five is the product asserting something false, so even the quiet
+option requires editing that card. Once that edit is accepted, the person can already see we missed
+it and we still have not said so.
+
+**No new date.** A second promise we might also miss is worse than none — ADR-0013 refused a
+response-time commitment on Reports for the same reason, and ADR-0010 warns that a routinely missed
+three days is the signal to revisit pre-moderation rather than to weaken the escalation.
+
+## A repeat refusal gets sharper guidance, never a sterner tone and never a count
+
+ADR-0010 keeps an evidentiary row per refusal for #13's benefit. **This surface never reads it as a
+count.** What changes on a second refusal for the **same** code is that the guidance becomes more
+concrete:
+
+> Prueba de día, cerca de una ventana, con el teléfono a la altura de la cara. Sin gorra y sin gafas
+> oscuras.
+
+This treats a second refusal as **our failure to explain** rather than the person's failure to
+comply, and it is the only treatment that makes the next attempt more likely to work — which matters
+doubly under the channel decision, since the email-only reader is the one most likely to have
+misunderstood.
+
+**Escalation is refused outright.** _"Es la tercera foto que no podemos mostrar"_ is the platform
+keeping score against somebody's face; it threatens an account over the one Purpose that can never be
+required (ADR-0007); and ADR-0013 refused accumulation-triggered action across the whole product on
+the ground that it is a brigading weapon. Identical-forever was the purest reading of that ADR and
+loses only because repeating guidance that has already failed once is not restraint.
+
+## The refusal is a property of a rectangle, not of a person
+
+Stated here because otherwise it is decided by whoever writes the component.
+
+ADR-0010 destroys the rejected bytes within seconds, so **the photograph can never be shown back to
+its owner** — the message is about something neither party can see. The diagnosis is therefore set
+**inside a photo-proportioned frame with a mat inset**, in the space where the photo is not, and the
+same rectangle returns in outline on the upload screen as the place the new one goes. It carries the
+vocabulary's thesis structurally rather than in prose.
+
+**This is not the avatar placeholder ADR-0026 bans**, and the two must never be quoted at each other.
+That ban protects a **profile card**, where an empty disc beside a human being is a penalty rendered
+in CSS on behalf of somebody who declined to supply sensitive data. This is the person's own Photo
+screen, where the rectangle is the object under discussion and naming it is the point.
+
+**Nothing on the refusal path uses an alarm colour** — no red, no warning mark, no `danger` token. A
+refusal that looks like an error teaches the reader they did something wrong, and in five of six cases
+they did not. The frame was drawn dark in the first pass and rejected: on a message about somebody's
+face a black panel reads as mourning, one step from the disaster register the product exists to
+refuse.
+
+## The tone rule this generalises
+
+The dimensions everyone's instinct says to move when delivering bad news are exactly the ones that
+must not move. Against the voice fragments already scattered across `CONTEXT.md`, ADR-0023, ADR-0025
+and ADR-0026:
+
+> **Refusal: Energy 2 → 1, Optimism 3 → 2. Nothing else moves.**
+
+- **Warmth up produces pity**, which is the charity register the product exists to refuse. _"Sabemos
+  lo difícil que es"_ about a photograph is worse than the blunt version.
+- **Directness down produces euphemism**, and euphemism about a face reads as concealment. It also
+  fails operationally: somebody who cannot tell what to change does not re-upload, and re-upload is
+  the appeal.
+- **Confidence down produces _"creemos que quizás"_**, inviting an argument the product has no surface
+  to hold — there is no appeals process, only the upload button.
+
+Two additions to the Never list: **never the passive voice with the person's face as its object**
+(_"tu foto fue rechazada"_, _"fue revisada"_ — there is a human at both ends and the sentence should
+say which did what), and **never a rule the reader has to go and read** (no _"normas comunitarias"_,
+no link to a policy page; the refusal carries its own reason or it is a homework assignment).
+
+## Consequences
+
+- **ADR-0010's reason-code vocabulary is authored**, and its consequence handing them to #13 is
+  discharged — via #29 rather than #13, which had already declined them.
+- **ADR-0015 is extended, not amended**: a Photo approved is 1:1 with the Photo row, so it does not
+  meet that ADR's condition for a notification system, and its outbox carries these sends.
+- **ADR-0026 gains an explicit boundary**: the no-placeholder rule governs a profile card, not the
+  owner's own Photo screen.
+- **ADR-0007 is confirmed unchanged**: `transactional_messages` carries the send, `news` could not,
+  and nothing here is gated on the `photo` Purpose.
+- **`CONTEXT.md`'s Photo Review is amended** to name the vocabulary's two exits.
+- **#28 inherits a finished vocabulary and a queue with two exits** — refuse the image, or approve it
+  and raise an ADR-0013 matter about the account. It still owns how an operator picks a code, the
+  queue order, the access log and the 3-day alert.
+- **Nothing here has an automated guard**, and it joins the list ADR-0025 opened and ADR-0026
+  extended. Two items carry more than a usability cost: the equal-weight controls on the re-upload
+  screen are D.1377 art. 6 compliance living in a component tree, and **the standing constraint on the
+  vocabulary is enforced by nobody** — a seventh code whose imperative names the reader would reopen
+  the channel decision silently.
+- **A gap this ticket surfaced and does not own**: **no email of ours survives an erasure.** ADR-0021
+  hard-deletes the `persons` row and ADR-0010 has an object-store adapter, but a sent message is
+  outside every adapter. This is not a photo problem — ADR-0015's Offer notifications name a person
+  and a pay figure, revealing considerably more than _"no se te ve la cara"_ — so it belongs to the
+  notifications lane rather than here.
+
+## Rejected
+
+**An operator-convenience code list, translated afterwards.** The direction ADR-0010 implied, and the
+one that produces the sentence this ADR exists to avoid.
+
+**An operator-only layer of codes.** The person would be shown something other than what was decided
+about them, and a copy-first vocabulary cannot survive one lie.
+
+**`impersonation` and `underage` as photo codes.** Judgments about an account, already owned by
+ADR-0013, and suppressing one image does nothing about either.
+
+**The full diagnosis in the email.** Reaches the most people and leaves a proposition about somebody's
+face in a channel we can never reach.
+
+**A per-code channel policy.** Differential treatment leaks the thing it protects — the vague email
+becomes the signal.
+
+**No reason in the email at all.** Strictly safest, costs a hop, and the hop is where the Photo is
+lost.
+
+**Silence on approval.** Leaves the person who was promised three days with no way to learn the
+answer.
+
+**Silence on the missed three days.** Cannot be silent anyway, since the pending card has to stop
+asserting something false.
+
+**A new date when we miss the first one.** A second promise we might also miss.
+
+**Escalating copy on a repeat**, and a visible count of refusals. Keeping score against a face, over a
+Purpose that can never be required.
+
+**A congratulation on approval.** There is no badge to earn.
+
+**A dark frame, an alarm colour, or any warning mark on the refusal path.**

--- a/docs/design/photo-refusal-prototype/README.md
+++ b/docs/design/photo-refusal-prototype/README.md
@@ -8,10 +8,10 @@ open docs/design/photo-refusal-prototype/index.html
 
 No build, no server, no dependencies. Nothing here is production code.
 
-> Three variants of **where the news lives and what it asks of the reader**, rendered across all three
-> surfaces at once — the email as it lands, the signed-in home, and the screen the link opens —
-> switchable via `?variant=`, plus four question toggles (`?reason=`, `?approve=`, `?late=`,
-> `?repeat=`).
+> Two independent axes — `?variant=` is **what the email says**, `?home=` is **what the app shows** —
+> rendered across all three surfaces at once: the email as it lands, the signed-in home, and the
+> screen the link opens. Plus four question toggles (`?reason=`, `?approve=`, `?late=`, `?repeat=`).
+> Defaults on load are `variant=A&home=card`.
 
 **Not decided yet.** This file is the artifact to react to, not the answer. Everything below marked
 _position_ is a call the prototype takes so it can be argued with — say so if it is wrong.
@@ -95,25 +95,36 @@ anyway, since suppressing one image does nothing about a person who is not who t
 
 _This is a position, and it hands #28 a queue with two exits rather than one._
 
-## The three variants
+## Two axes, because the first pass wrongly made them one
 
-Flip with the arrows in the black bar, the `←`/`→` keys, or `?variant=A|B|C`.
+The file first shipped three variants that each bundled an email decision with an app decision. The
+first round of feedback broke that apart — _"I like A but the app should borrow concept B"_ — and it
+was right: **what the email says and what the app shows are independent decisions**, and binding them
+together hid the combination that is probably the answer. So:
 
-| Key   | Name                                | Where the news lives                                                                        | The bet                                                                                        |
-| ----- | ----------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **A** | Email carries it                    | Subject, reason, guidance and button all in the inbox; the app keeps one quiet line         | The inbox is where people actually are; someone who never opens the site again still learns    |
-| **B** | App carries it, email knocks        | Email says only that something is waiting; every word about the photo is inside the session | Nothing about a person's face may leave a channel we control and can delete                    |
-| **C** | No verdict, just an unfinished step | No refusal anywhere — no notice, no _"una persona la revisó"_, no event with a name         | A verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial |
+**`?variant=` — what the email says.** Flip with the arrows, the `←`/`→` keys, or `?variant=A|B|C`.
 
-They disagree about more than placement:
+| Key   | Name                     | The email                                                                   | The bet                                                                                        |
+| ----- | ------------------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **A** | Email carries the reason | Subject, reason, guidance and button, all in the inbox                      | The inbox is where people actually are; someone who never opens the site again still learns    |
+| **B** | Email only knocks        | Only that something is waiting — no reason, no detail                       | Nothing about a person's face may leave a channel we control and can delete                    |
+| **C** | No verdict anywhere      | The step is unfinished and here is what to change; nobody reviewed anything | A verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial |
 
-- **Whether the reason leaves our systems.** A puts a sentence about somebody's face into Gmail
-  forever. B puts nothing there. C puts the _fix_ there and never the verdict.
-- **Whether the word _revisó_ is ever said.** A and B say it; C says it nowhere.
-- **What the home surface is for.** In A it is a receipt, in B it is the record, in C it is
-  ADR-0025's _sin publicar_ card wearing a different hat.
+**`?home=` — what the app shows.**
 
-### Each has a visible flaw, and the file names it under the surfaces
+| Value  | The app surface                                                                            |
+| ------ | ------------------------------------------------------------------------------------------ |
+| `card` | The full card: the mount, the reason, what did not change, the action                      |
+| `line` | One quiet line inside the profile block — the email already did the work                   |
+| `step` | ADR-0025's _sin publicar_ card wearing a different hat: an unfinished step, and no verdict |
+
+The three original variants were `A+line`, `B+card` and `C+step`; those combinations still render.
+**The defaults on load are now `variant=A&home=card`** — A's email with B's card, which was neither
+variant as built. Combinations can be incoherent on purpose: `C+card` puts _"una persona la revisó"_
+on a screen whose email denies any review happened, and looking at that is the fastest way to see
+what C is actually buying.
+
+### Each email variant has a visible flaw, and the file names it under the surfaces
 
 **A's flaw is that the email outlives the photograph.** ADR-0010 destroys the rejected bytes within
 seconds of the refusal; the email describing them sits in a mailbox we cannot reach, possibly shared,
@@ -132,16 +143,51 @@ two), it is what ADR-0010's art. 12 disclosure promises will be said plainly, an
 _"te falta un paso"_ is the product deciding a Titular is better off not knowing what was done with
 their data.
 
-### Where I would land — a position, not a decision
+### Where this stands — `A+card`, with one argument left open
 
-**B's channel discipline with A's honesty, which is neither variant as built.** The email names the
-outcome and carries the fix but never the reason code — _"Tu foto todavía no está en tu perfil. Una
-persona la revisó y hay algo que cambiar. Entra y te decimos qué es."_ — and the reason lives only in
-the session. That keeps a sentence about someone's face out of a mailbox we cannot delete, while
-giving the email enough shape that it is not the vague knock B ships.
+`A+card` is the current default and the direction the dev picked: the email carries the reason so
+that someone who never returns still learns what happened, and the app carries the full card so the
+person who does return meets the whole thing rather than a footnote.
 
-It costs one extra hop for the person, which is the thing to argue about: every hop between the
-refusal and the re-upload is a place the Photo is lost for good.
+**The one live objection is A's flaw above**, and it is not small: the reason outlives the photograph.
+The middle position, if that lands harder than the reachability argument, is an email that names the
+outcome and the fix but never the reason code — _"Tu foto todavía no está en tu perfil. Una persona la
+revisó y hay algo que cambiar. Entra y te decimos qué es."_ — with the reason living only in the
+session. It costs one extra hop, and every hop between the refusal and the re-upload is a place the
+Photo is lost for good. **That is the trade to settle before the ADR.**
+
+## The design — one signature, and it is the reason it exists
+
+The first pass was, correctly, called raw. What it lacked was not decoration but a **subject**: the
+message is about a photograph that the reader cannot see and neither can we, because ADR-0010
+destroys the rejected bytes within seconds of the refusal.
+
+**So the absence is the object, and the reason is set inside the rectangle where the photo is not** —
+a photo-proportioned frame with a mat inset, holding the reason and nothing else. The same rectangle
+returns in outline on the upload screen as the place you put the new one. It runs across all three
+surfaces and carries the thesis of the vocabulary structurally rather than in prose: **the refusal is
+a property of that rectangle, never of the person holding it.**
+
+**The frame was drawn dark first, and that was wrong.** On a message about somebody's face a black
+panel reads as mourning, which is one step from the disaster register the product exists to refuse —
+and the frame is not improved by weight, only by being unmistakably a frame. The shape was the whole
+argument; the darkness was decoration wearing the argument's clothes. It is light now, on the brand
+tint, with the mat inset doing the work.
+
+Two things it is deliberately not:
+
+- **Not an avatar placeholder.** ADR-0026 bans those, and the ban is about a **profile card**, where
+  an empty disc beside a human being is a penalty rendered in CSS on behalf of somebody who declined
+  to supply sensitive data. This is the person's own photo screen, where the rectangle is the object
+  under discussion and naming it is the entire point. The two rules must not be quoted at each other.
+- **Not alarm.** No red, no warning triangle, no `--color-danger` anywhere on the refusal path — the
+  palette stays the standing brand blue and ink, and the only saturated colour on the surface is the
+  action.
+
+Everything else is restraint: one type scale with real weight contrast, a mono eyebrow that labels
+rather than decorates, and generous space. The email carries the same frame, which is a claim worth
+testing — it is a table cell with a background in a real client, and nothing here has been through
+one.
 
 ## The toggles
 
@@ -333,6 +379,13 @@ who has actually had a photo refused.
   surface at once rather than one page three ways.
 - **`brand-voice` was run in audit mode only**, by the choice recorded at the top of this section. Its
   intake, archetype selection and full guide were not run.
+- **`frontend-design` was added to this ticket's skills**, which named only `prototype` and
+  `brand-voice`. The first pass was called raw, and _"how does a refusal look without looking like an
+  alarm"_ is squarely its subject. It is worth recording that its brief and this one pull in opposite
+  directions: it asks for a distinctive identity and one justified aesthetic risk, and this repo
+  already has a binding palette, typeface and accessibility bar. So the palette was not touched, and
+  **the one risk it did prompt — the dark frame — was taken and then rejected**, which is the honest
+  outcome and is left in the record above rather than quietly reverted.
 - **`shadcn` was not loaded.** Its CLI refuses to run at a monorepo root and wants
   `-c packages/design-system`; there is one component in that package (`button.tsx`) and nothing on
   this screen needs it. Tokens are `NEXTJS_HANDOFF.md`'s, matching the sibling prototype — the design
@@ -355,3 +408,9 @@ Flag any of these that are wrong — they are positions, not defaults.
 7. **`face_not_visible` says the photo does not have to be good**, on the theory that the most common
    second attempt is no second attempt.
 8. **No email ever carries the image**, in any variant.
+9. **The reason is set inside a photo-shaped frame, and that is not the avatar placeholder ADR-0026
+   bans.** The ban protects a profile card from rendering somebody second-class; this is the person's
+   own photo screen, where the rectangle is the subject. Worth an explicit line in the ADR so the two
+   rules are never quoted at each other.
+10. **The refusal path uses no alarm colour at all** — no red, no warning mark. A refusal that looks
+    like an error teaches the reader they did something wrong, and in five of six cases they did not.

--- a/docs/design/photo-refusal-prototype/README.md
+++ b/docs/design/photo-refusal-prototype/README.md
@@ -1,0 +1,357 @@
+# Prototype — how a person learns their Photo was refused (#29)
+
+**Throwaway.** One self-contained HTML file. Double-click `index.html`, or:
+
+```sh
+open docs/design/photo-refusal-prototype/index.html
+```
+
+No build, no server, no dependencies. Nothing here is production code.
+
+> Three variants of **where the news lives and what it asks of the reader**, rendered across all three
+> surfaces at once — the email as it lands, the signed-in home, and the screen the link opens —
+> switchable via `?variant=`, plus four question toggles (`?reason=`, `?approve=`, `?late=`,
+> `?repeat=`).
+
+**Not decided yet.** This file is the artifact to react to, not the answer. Everything below marked
+_position_ is a call the prototype takes so it can be argued with — say so if it is wrong.
+
+## The question, and why it is a tone problem before it is a design problem
+
+ADR-0010 made **re-upload the appeal** — there is no separate appeals process — and destroys the
+rejected bytes immediately. That only works if the person learns their Photo was refused and is
+brought back to try again. It is also the one place this product tells someone their face was
+rejected, against a standing rule that the platform preserves **dignity, agency and income** and never
+charity or disaster imagery.
+
+_"Tu foto fue rechazada"_ fails that on its own, and every softening of it fails differently:
+_"lamentamos informarte"_ is an institution clearing its throat, _"no cumple nuestras normas
+comunitarias"_ makes the person go looking for the rule they broke, and _"¡Ups! Algo salió mal"_ is a
+product being cute about somebody's face.
+
+## The finding the vocabulary is built on
+
+**Almost every real cause is a fact about the image, not a judgment of the person.** A photograph of a
+cédula, a landscape, two people, a phone number written across the frame, a face too dark to see — in
+five of six cases there is nothing to say about the human being at all, only about the file.
+
+So the vocabulary is authored so that **every code names a property of the photo and the change that
+fixes it**, which means the sentence _"tu foto fue rechazada"_ never has to be written. The one case
+that genuinely is a judgment is isolated, and its copy is shaped by that isolation rather than by
+being averaged in with the other five.
+
+This is why #29 authors the vocabulary and #28 inherits it, rather than the reverse. A list authored
+for an operator's queue — `INVALID`, `POLICY_VIOLATION`, `LOW_QUALITY` — translates into exactly the
+sentence this ticket exists to avoid, and by then the translation is the only lever left.
+
+## The vocabulary — six codes, one message each
+
+Codes are English `snake_case` per ADR-0001 as amended, and stay a **separate vocabulary** from
+ADR-0013's Report codes, which that ADR requires. Every Spanish string is the design under review.
+
+| Code               | What the person reads                                                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `face_not_visible` | **No se te ve la cara.** Puede que esté muy oscura, muy lejos o movida. Con que se te vea de frente basta: no tiene que ser bonita ni profesional.                       |
+| `no_person`        | **En la foto no hay nadie.** Va una foto tuya, no de tu negocio, tu herramienta ni tu logo. La cara sirve para que quien te va a contratar sepa con quién está hablando. |
+| `other_people`     | **Sale alguien más en la foto.** Solo podemos mostrar tu cara: la otra persona no nos dio permiso para mostrar la suya.                                                  |
+| `document`         | **Es la foto de un documento.** No recibimos cédulas, diplomas ni hojas de vida. Esa la borramos apenas la vimos y no queda copia. Aquí va una foto tuya y ya.           |
+| `contact_visible`  | **Se ve un número de teléfono en la foto.** Tus datos de contacto se comparten cuando alguien acepta una propuesta, no antes.                                            |
+| `not_for_work`     | **No podemos mostrar esta foto en un perfil de trabajo.** Pon otra donde se te vea la cara.                                                                              |
+
+Four of these carry a decision rather than a translation.
+
+- **`face_not_visible` says the photo does not have to be good.** _"No tiene que ser bonita ni
+  profesional"_ is there because the most likely second attempt after a quality refusal is no second
+  attempt at all — someone concluding they do not have a photo that is good enough. The refusal that
+  reads as a standard is the one that loses the Photo permanently.
+- **`document` says the bytes are already gone**, in the same breath as the refusal. Photographing
+  your cédula and sending it to a website is the single most frightening thing on this list, and
+  ADR-0010 makes the reassurance true rather than soothing: the image is destroyed at refusal and no
+  copy survives.
+- **`contact_visible` repeats the mechanic and never the format.** That is ADR-0026's rule for the
+  prose refusal — _"tus datos se comparten cuando aceptas una propuesta"_, never _"formato
+  inválido"_ — applied to an image instead of a text field.
+- **`not_for_work` is the only one that does not say what to change, and that is the design.** It
+  states what **we** cannot do, never what the image is, which is ADR-0026's _state the limit, never
+  the risk_ pointed at a person rather than at a stranger. It does not characterise, it does not cite
+  a rule, it does not moralise, and **ADR-0010 gives the operator no free text to elaborate with** —
+  which is the clause that makes this line survivable rather than merely polite.
+
+### Two codes are deliberately absent, and where they go instead
+
+An operator will sometimes think _this is a stock photo_ or _this person looks under 18_. Neither is a
+photo-refusal code here, and the reason is structural rather than squeamish:
+
+- **They are judgments about an account, not about an image.** ADR-0013 already owns both —
+  `impersonation` and `underage` are Report codes there, with an operator queue and four operator
+  actions behind them.
+- **Refusing the Photo under a nearby code would be a lie**, and a copy-first vocabulary cannot
+  afford one: the person is told the true code the operator picked, always, with no operator-only
+  layer underneath.
+
+So: **the photo queue judges photos and the safety queue judges accounts.** If no image-level code is
+true, the Photo is approved and the account is handled under ADR-0013 — which is the right outcome
+anyway, since suppressing one image does nothing about a person who is not who they say they are.
+
+_This is a position, and it hands #28 a queue with two exits rather than one._
+
+## The three variants
+
+Flip with the arrows in the black bar, the `←`/`→` keys, or `?variant=A|B|C`.
+
+| Key   | Name                                | Where the news lives                                                                        | The bet                                                                                        |
+| ----- | ----------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **A** | Email carries it                    | Subject, reason, guidance and button all in the inbox; the app keeps one quiet line         | The inbox is where people actually are; someone who never opens the site again still learns    |
+| **B** | App carries it, email knocks        | Email says only that something is waiting; every word about the photo is inside the session | Nothing about a person's face may leave a channel we control and can delete                    |
+| **C** | No verdict, just an unfinished step | No refusal anywhere — no notice, no _"una persona la revisó"_, no event with a name         | A verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial |
+
+They disagree about more than placement:
+
+- **Whether the reason leaves our systems.** A puts a sentence about somebody's face into Gmail
+  forever. B puts nothing there. C puts the _fix_ there and never the verdict.
+- **Whether the word _revisó_ is ever said.** A and B say it; C says it nowhere.
+- **What the home surface is for.** In A it is a receipt, in B it is the record, in C it is
+  ADR-0025's _sin publicar_ card wearing a different hat.
+
+### Each has a visible flaw, and the file names it under the surfaces
+
+**A's flaw is that the email outlives the photograph.** ADR-0010 destroys the rejected bytes within
+seconds of the refusal; the email describing them sits in a mailbox we cannot reach, possibly shared,
+indexed by a third party, for years. Every other decision in that ADR treats a face as sensitive data
+whose lifetime we control, and this one hands a sentence about it to Google.
+
+**B's flaw is that its email is phishing-shaped.** _"Hay algo pendiente en tu perfil. Entra y te
+contamos"_ with a link is the exact form of the impersonation attack ADR-0026 spent its one
+attack-naming sentence closing — and it is the one message of ours a careful person is right to
+distrust. It also gets the lowest open rate of the three, which matters when the whole mechanism is
+"the person comes back".
+
+**C's flaw is that it is tactful about something the person has a right to know.** A human did look at
+this person's face. That is the single true operational fact the platform has (ADR-0026's band item
+two), it is what ADR-0010's art. 12 disclosure promises will be said plainly, and burying it under
+_"te falta un paso"_ is the product deciding a Titular is better off not knowing what was done with
+their data.
+
+### Where I would land — a position, not a decision
+
+**B's channel discipline with A's honesty, which is neither variant as built.** The email names the
+outcome and carries the fix but never the reason code — _"Tu foto todavía no está en tu perfil. Una
+persona la revisó y hay algo que cambiar. Entra y te decimos qué es."_ — and the reason lives only in
+the session. That keeps a sentence about someone's face out of a mailbox we cannot delete, while
+giving the email enough shape that it is not the vague knock B ships.
+
+It costs one extra hop for the person, which is the thing to argue about: every hop between the
+refusal and the re-upload is a place the Photo is lost for good.
+
+## The toggles
+
+### `?reason=` — which code is on screen
+
+Cycles the six. Drives the email, the home card, the landing screen and the repeat strips at once, so
+each message can be read in every position it will occupy.
+
+### `?approve=` — is silence right when a Photo is approved?
+
+| Value    | Behaviour                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------- |
+| `told`   | _"Tu foto ya está en tu perfil. Una persona la revisó."_ plus one line on how to remove it    |
+| `silent` | Nothing. The pending state stops being pending and whoever does not come back never finds out |
+
+_Position: `told`._ Three reasons. The person was shown _menos de 3 días_ and left waiting, so
+silence means the only way to learn the answer is to come back and check — and ADR-0025's whole
+argument is that people do not come back. It is the one moment where _"una persona la revisó"_ can be
+said to somebody without making a profile without a Photo carry visibly less, which is exactly why
+ADR-0026 forbids it everywhere else. And email is effectively free (#6).
+
+**It is not a congratulation.** No _¡Felicitaciones!_, no green tick, no badge — ADR-0026 titled
+itself _there is no badge to earn_, and ADR-0025's own ending refuses to celebrate. The closing line
+is how to take it down, because ADR-0010 rule 5 holds that publication is never a licence.
+
+### `?late=` — does anyone hear when we miss the 3 days?
+
+| Value    | Behaviour                                                                                        |
+| -------- | ------------------------------------------------------------------------------------------------ |
+| `told`   | _"Tu foto sigue en revisión. Dijimos que menos de 3 días y no cumplimos."_ — and **no new date** |
+| `silent` | No message; the pending card quietly stops claiming three days                                   |
+
+_Position: `told`._ ADR-0010 forbids any automatic transition, so a missed commitment is purely a copy
+problem — and note that even `silent` cannot be truly silent: leaving _"suele tardar menos de 3
+días"_ on screen on day five is the product asserting something false. Once you have accepted that
+edit, the person can already see we missed it and we still have not said so.
+
+**No new date is the load-bearing half.** A second promise we might also miss is worse than none, and
+ADR-0013 refused a response-time commitment on Reports for the same reason.
+
+### `?repeat=` — does the second refusal for the same reason read differently?
+
+| Value       | Behaviour                                                                                      |
+| ----------- | ---------------------------------------------------------------------------------------------- |
+| `sharper`   | Same message, plus more concrete guidance — _"prueba de día, cerca de una ventana, sin gorra"_ |
+| `same`      | Word-for-word identical, forever                                                               |
+| `escalates` | _"Es la tercera foto que no podemos mostrar…"_ and a threat to the account                     |
+
+_Position: `sharper`._ It treats a second refusal as **our** failure to explain rather than the
+person's failure to comply, and it is the only one of the three that makes the next attempt more
+likely to work. `same` is the purest reading of ADR-0013 — the evidentiary rows are for the operator
+and nothing accumulates where the person can see it — but it repeats guidance that has already failed
+once, which is not restraint, only stubbornness.
+
+**`escalates` is in the file to be looked at and rejected.** It is the platform keeping score against
+somebody's face; it threatens an account over the one Purpose that can never be required (ADR-0007);
+and ADR-0013 refused accumulation-triggered action for the entire product on the ground that it is a
+brigading weapon. The evidentiary row ADR-0010 keeps stays where it was put — visible to the operator,
+invisible here.
+
+## Which Purpose carries the send
+
+**`transactional_messages`**, and it is not close.
+
+- Ley 2300 art. 5 par. 2 permits requiring consent to messages _"estrictamente relacionados con el
+  bien o servicio adquirido"_, which is why ADR-0007 could make this Purpose required at all. The
+  outcome of a review the person themselves initiated is the paradigm case.
+- **`news` could not carry it.** `news` is optional, so a person who declined it would never learn
+  their Photo was refused — and would keep a permanently invisible Photo with no way to find out.
+- **The send is not gated on the `photo` Purpose.** That Purpose authorises _showing_ a Photo; the
+  message is about a service outcome. Gating it would mean revoking `photo` consent silently disables
+  the only channel that could confirm the deletion.
+
+The email footer states this plainly rather than offering a fake unsubscribe: _"Te escribimos porque
+es un mensaje del servicio, no publicidad. Estos no se pueden desactivar; los de novedades sí, en Tus
+datos."_ An unsubscribe link on a required Purpose is a control that does nothing, and D.1377 art. 7
+forbids treating a person's silence as consent, not the reverse.
+
+**One rule that is not negotiable in any variant: no email ever carries the image.** Not the rejected
+one, not a thumbnail, not a link to one. The rejected bytes are gone by the time the message is
+composed, and an approved photograph does not need reprinting in a mailbox.
+
+## Voice — audit against what exists, plus the context nobody had written
+
+`brand-voice` was run in **audit mode**, not to produce a guide. A guide is its own effort and the map
+puts it past the destination; what did not exist was the one context this ticket lives in.
+
+### The fragments that already exist, and where they are
+
+There is no voice guide, but there are five binding fragments in four places — which is itself the
+map's open item _"where the binding half of `NEXTJS_HANDOFF.md` lives"_:
+
+| Fragment                                                     | Where it lives                     |
+| ------------------------------------------------------------ | ---------------------------------- |
+| Address rule — `tú`, the verb belongs to the reader          | `CONTEXT.md`                       |
+| Gender-agreement rule — the adjective agrees with the object | `CONTEXT.md`                       |
+| Archetype and dimension sketch, Never/Always lists           | `skill-picker-prototype/README.md` |
+| _State the limit, never the risk_                            | ADR-0026                           |
+| The ending refuses to celebrate                              | ADR-0025                           |
+
+### Dimensions, read off those fragments
+
+Extremes in bold, per the skill's rule of two or three.
+
+| Dimension      | Setting | Why                                                                           |
+| -------------- | ------- | ----------------------------------------------------------------------------- |
+| Formality      | 4       | `tú`, contractions of register, no institutional throat-clearing              |
+| Optimism       | 3       | The product refuses to promise work; it cannot afford to be sunny             |
+| Humor          | **1**   | Not solemn, but never funny about somebody's income or face                   |
+| Confidence     | 4       | Hedged copy makes the reader argue instead of act                             |
+| Sophistication | **1**   | Short sentences, common words, no product vocabulary                          |
+| Warmth         | 4       | Neighbour, not institution — and not caregiver                                |
+| Energy         | 2       | Calm. Exclamation marks are the charity register arriving through punctuation |
+| Directness     | **5**   | The whole product is built on saying what it does not do                      |
+
+### The tone matrix entry this ticket adds
+
+Context: **Refusal** — the product delivering bad news about the reader's own body.
+
+> **Energy 2 → 1. Optimism 3 → 2. Nothing else moves.**
+
+The finding is the second sentence. Every instinct on bad news is to raise Warmth, lower Directness
+and lower Confidence, and all three are wrong here:
+
+- **Warmth 4 → 5 produces pity**, which is the charity register the product exists to refuse. _"Sabemos
+  lo difícil que es"_ about a photograph is worse than the blunt version.
+- **Directness 5 → 3 produces euphemism**, and euphemism about a face reads as something being
+  concealed. It also fails the operational test: a person who cannot tell what to change does not
+  re-upload, and re-upload is the appeal.
+- **Confidence 4 → 2 produces _"creemos que quizás"_**, which invites an argument the product has no
+  surface to hold — there is no appeals process, only the upload button.
+
+### Scorecard — the obvious drafts, against the rules
+
+| Draft                                                 | Verdict                                                                                              |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| _Tu foto fue rechazada._                              | **Fail.** The verb acts on the person's face; nothing says what to change.                           |
+| _Lamentamos informarte que…_                          | **Fail.** Formality 4 → 1, and the subject is us being sorry rather than the reader doing something. |
+| _Tu foto no cumple con nuestras normas comunitarias._ | **Fail.** Sends the reader looking for a rule; Sophistication 1 breached by _normas comunitarias_.   |
+| _¡Ups! Algo salió mal con tu foto._                   | **Fail.** Humor 1, and it is a product being cute about a face.                                      |
+| _Tu foto fue aprobada ✅ ¡Felicitaciones!_            | **Fail.** ADR-0026 — there is no badge to earn.                                                      |
+
+### Before / after
+
+1. _"Tu foto fue rechazada. Motivo: contenido inapropiado."_ → **"No podemos mostrar esta foto en un
+   perfil de trabajo. Pon otra donde se te vea la cara."** — _state the limit, never the risk_; the
+   subject becomes what we cannot do, and the second sentence is the exit.
+2. _"Lamentamos informarte que tu foto no cumple con nuestras normas comunitarias."_ → **"Tu foto
+   todavía no está en tu perfil. Una persona la revisó y hay algo que cambiar."** — Directness 5,
+   Sophistication 1, and the gender-agreement rule: the adjective agrees with the profile, never with
+   the reader.
+3. _"¡Felicitaciones! Tu foto fue aprobada ✅"_ → **"Tu foto ya está en tu perfil. Una persona la
+   revisó."** — Energy 1, Humor 1; the fact replaces the celebration.
+
+### Two Never entries this ticket adds
+
+- **Never the passive voice with the person's face as the object.** _"Tu foto fue rechazada"_,
+  _"fue revisada"_, _"no fue aprobada"_. There is a human being on both ends and the sentence should
+  say which one did what.
+- **Never a rule the reader has to go and read.** No _"normas comunitarias"_, no _"nuestras
+  políticas"_, no link to a policy page. The refusal carries its own reason or it is not a refusal,
+  it is a homework assignment.
+
+## Accessibility
+
+Held to the `NEXTJS_HANDOFF.md` bar, which the map records as still binding.
+
+Present: a polite live region announcing every variant and toggle change; arrow keys that do not fire
+while an input is focused; the two upload controls rendered at **equal visual weight** per ADR-0025
+(two outlined buttons, neither filled), which is a legal constraint here and not a preference; no
+meaning carried by colour alone — the highlighted checklist row is bolded as well as tinted; targets
+above 40px; text at 100% zoom reflow.
+
+**Not cleared, and worth knowing:** none of this has been through a screen reader, the email surfaces
+are rendered as HTML on a page rather than in a real client (so nothing here says anything about how
+they degrade in Outlook or in plain text), and the refusal copy has not been read aloud to anybody
+who has actually had a photo refused.
+
+## Departures from the named skills
+
+- **`/prototype`'s UI branch wants a route** (sub-shape A on an existing page, or B as a throwaway
+  route). This is a single HTML file instead — the same departure `skill-picker-prototype` and
+  `trust-presentation-prototype` recorded, and for a narrower reason than the map states.
+  `@repo/design-system` now exists, so _"it does not exist yet"_ is stale; what holds is that it ships
+  un-built React source, `apps/web` has no `src/` at all, and a `file://` page cannot consume React.
+- **`/prototype` warns against variants that differ only in copy.** These do not: they differ in which
+  surface is the record, whether the reason crosses a channel boundary, and whether a refusal is an
+  event at all. But the ticket is right that the copy is the decision, so the file renders every
+  surface at once rather than one page three ways.
+- **`brand-voice` was run in audit mode only**, by the choice recorded at the top of this section. Its
+  intake, archetype selection and full guide were not run.
+- **`shadcn` was not loaded.** Its CLI refuses to run at a monorepo root and wants
+  `-c packages/design-system`; there is one component in that package (`button.tsx`) and nothing on
+  this screen needs it. Tokens are `NEXTJS_HANDOFF.md`'s, matching the sibling prototype — the design
+  system that landed ships the shadcn `vega` preset and the two palettes disagree, which no ADR
+  reconciles and this ticket does not own.
+
+## Open calls this prototype takes without being asked to
+
+Flag any of these that are wrong — they are positions, not defaults.
+
+1. **#29 authors the reason vocabulary and #28 inherits it**, reversing the direction ADR-0010
+   implied. Confirmed with the dev before building.
+2. **There is no operator-only code.** The person is always shown the same code the operator picked.
+3. **`impersonation` and `underage` are not photo codes** — the photo queue judges photos, the safety
+   queue judges accounts, and #28 gets a queue with two exits.
+4. **The approval case gets a message**, and it is not a congratulation.
+5. **The 3-day miss gets a message with no new date.**
+6. **A repeat refusal for the same code gets sharper guidance, never a sterner tone and never a
+   count.**
+7. **`face_not_visible` says the photo does not have to be good**, on the theory that the most common
+   second attempt is no second attempt.
+8. **No email ever carries the image**, in any variant.

--- a/docs/design/photo-refusal-prototype/README.md
+++ b/docs/design/photo-refusal-prototype/README.md
@@ -13,8 +13,31 @@ No build, no server, no dependencies. Nothing here is production code.
 > screen the link opens. Plus four question toggles (`?reason=`, `?approve=`, `?late=`, `?repeat=`).
 > Defaults on load are `variant=D&home=card`.
 
-**Not decided yet.** This file is the artifact to react to, not the answer. Everything below marked
-_position_ is a call the prototype takes so it can be argued with — say so if it is wrong.
+## Verdict
+
+**#29 is decided — ADR-0027.** The file still carries every variant and every toggle, because the
+losing options are the evidence for the winner — but the defaults on load are now the decisions:
+`?variant=D&home=card&approve=told&late=told&repeat=sharper`.
+
+| Question             | Answer                                                                                                                                                |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The vocabulary       | **Six codes, authored copy-first**, each naming a property of the photo and the change that fixes it. #28 inherits it finished.                       |
+| Where the news lives | **D — the email carries the imperative, the app carries the diagnosis.** Nothing that persists in a mailbox is a proposition about the reader.        |
+| The app surface      | **The full card**, not a footnote. Reached by splitting the axis the first pass wrongly bound together.                                               |
+| `impersonation` etc. | **Not photo codes.** The photo queue judges photos, the safety queue judges accounts, and a Review has two exits.                                     |
+| Approval             | **A message, and not a congratulation.** It is the one place _"una persona la revisó"_ can be said about a specific person without penalising anyone. |
+| The missed 3 days    | **A message, with no new date.** Silence cannot be silent anyway — the pending card has to stop asserting something false.                            |
+| A repeat refusal     | **Sharper guidance, never a sterner tone and never a count.** Our failure to explain, not their failure to comply.                                    |
+| Which Purpose        | **`transactional_messages`.** `news` could not carry it, and the send is not gated on the `photo` Purpose.                                            |
+
+### The two that moved after the first pass
+
+**The axis was split.** _"I like A but the app should borrow concept B"_ — and the reason that was
+unbuildable is that every variant bundled an email decision with an app decision. They are
+independent, and the combination that is now the default was unreachable until they came apart.
+
+**Variant D did not exist**, and it is the answer to A's flaw rather than a compromise between A and
+B. See _How A's flaw is addressed_ below.
 
 ## The question, and why it is a tone problem before it is a design problem
 

--- a/docs/design/photo-refusal-prototype/README.md
+++ b/docs/design/photo-refusal-prototype/README.md
@@ -11,7 +11,7 @@ No build, no server, no dependencies. Nothing here is production code.
 > Two independent axes — `?variant=` is **what the email says**, `?home=` is **what the app shows** —
 > rendered across all three surfaces at once: the email as it lands, the signed-in home, and the
 > screen the link opens. Plus four question toggles (`?reason=`, `?approve=`, `?late=`, `?repeat=`).
-> Defaults on load are `variant=A&home=card`.
+> Defaults on load are `variant=D&home=card`.
 
 **Not decided yet.** This file is the artifact to react to, not the answer. Everything below marked
 _position_ is a call the prototype takes so it can be argued with — say so if it is wrong.
@@ -102,13 +102,17 @@ first round of feedback broke that apart — _"I like A but the app should borro
 was right: **what the email says and what the app shows are independent decisions**, and binding them
 together hid the combination that is probably the answer. So:
 
-**`?variant=` — what the email says.** Flip with the arrows, the `←`/`→` keys, or `?variant=A|B|C`.
+**`?variant=` — what the email says.** Flip with the arrows, the `←`/`→` keys, or
+`?variant=A|B|C|D`.
 
-| Key   | Name                     | The email                                                                   | The bet                                                                                        |
-| ----- | ------------------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **A** | Email carries the reason | Subject, reason, guidance and button, all in the inbox                      | The inbox is where people actually are; someone who never opens the site again still learns    |
-| **B** | Email only knocks        | Only that something is waiting — no reason, no detail                       | Nothing about a person's face may leave a channel we control and can delete                    |
-| **C** | No verdict anywhere      | The step is unfinished and here is what to change; nobody reviewed anything | A verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial |
+| Key   | Name                          | The email                                                                   | The bet                                                                                        |
+| ----- | ----------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **A** | Email carries the reason      | Subject, reason, guidance and button, all in the inbox                      | The inbox is where people actually are; someone who never opens the site again still learns    |
+| **B** | Email only knocks             | Only that something is waiting — no reason, no detail                       | Nothing about a person's face may leave a channel we control and can delete                    |
+| **C** | No verdict anywhere           | The step is unfinished and here is what to change; nobody reviewed anything | A verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial |
+| **D** | Email carries the instruction | The outcome, that a human looked, and the change — never the diagnosis      | The message has two halves and only one of them is about the reader — so send the other one    |
+
+**D is the answer to A's flaw and is the default on load**; the reasoning is two sections below.
 
 **`?home=` — what the app shows.**
 
@@ -119,10 +123,9 @@ together hid the combination that is probably the answer. So:
 | `step` | ADR-0025's _sin publicar_ card wearing a different hat: an unfinished step, and no verdict |
 
 The three original variants were `A+line`, `B+card` and `C+step`; those combinations still render.
-**The defaults on load are now `variant=A&home=card`** — A's email with B's card, which was neither
-variant as built. Combinations can be incoherent on purpose: `C+card` puts _"una persona la revisó"_
-on a screen whose email denies any review happened, and looking at that is the fastest way to see
-what C is actually buying.
+**The defaults on load are `variant=D&home=card`.** Combinations can be incoherent on purpose:
+`C+card` puts _"una persona la revisó"_ on a screen whose email denies any review happened, and
+looking at that is the fastest way to see what C is actually buying.
 
 ### Each email variant has a visible flaw, and the file names it under the surfaces
 
@@ -143,18 +146,68 @@ two), it is what ADR-0010's art. 12 disclosure promises will be said plainly, an
 _"te falta un paso"_ is the product deciding a Titular is better off not knowing what was done with
 their data.
 
-### Where this stands — `A+card`, with one argument left open
+### How A's flaw is addressed — variant D, and why it is not a compromise
 
-`A+card` is the current default and the direction the dev picked: the email carries the reason so
-that someone who never returns still learns what happened, and the app carries the full card so the
-person who does return meets the whole thing rather than a footnote.
+`A+card` was the direction picked from the first pass, and A's flaw was the one thing left open: the
+reason lands permanently in a mailbox we can never reach, outliving by years the photograph ADR-0010
+destroys in seconds.
 
-**The one live objection is A's flaw above**, and it is not small: the reason outlives the photograph.
-The middle position, if that lands harder than the reachability argument, is an email that names the
-outcome and the fix but never the reason code — _"Tu foto todavía no está en tu perfil. Una persona la
-revisó y hay algo que cambiar. Entra y te decimos qué es."_ — with the reason living only in the
-session. It costs one extra hop, and every hop between the refusal and the re-upload is a place the
-Photo is lost for good. **That is the trade to settle before the ADR.**
+The two obvious answers are both bad. **Accepting it** leaves the product's most sensitive message in
+its least controlled channel. **Withholding the reason from the email** — B's discipline — costs a
+hop, and every hop between the refusal and the re-upload is a place the Photo is lost for good.
+
+**The third answer came from reading the vocabulary rather than the channel.** The flaw was stated
+generically — _a reason code in an email is a permanent statement about somebody's face_ — and that
+is not what these six strings are. Taken code by code, the harm is not spread evenly at all; it is
+concentrated almost entirely in `not_for_work`, and every other string is a fact about a file.
+
+More usefully: **each message already contains two halves**, a diagnosis (_"es la foto de un
+documento"_) and an imperative (_"aquí solo va una foto tuya: nada de cédulas ni papeles"_). Only the
+first is a proposition about the reader. The second is a rule that is true of everybody on the
+platform, and it carries the same operational information to the one person who knows what they
+uploaded.
+
+So **variant D sends the imperative and keeps the diagnosis in the session.** The email still names
+the outcome and still says a human looked — A's honesty, intact — and what persists in a shared inbox
+says nothing about the reader at all.
+
+| Code               | The email (D)                                             | The app                                                             |
+| ------------------ | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| `face_not_visible` | Que se te vea la cara, de frente y con buena luz.         | No se te ve la cara. Puede que esté muy oscura, muy lejos o movida. |
+| `no_person`        | Va tu cara, no tu negocio ni tu logo.                     | En la foto no hay nadie. …                                          |
+| `other_people`     | Tiene que salir una sola persona: tú.                     | Sale alguien más en la foto. …                                      |
+| `document`         | Aquí solo va una foto tuya: nada de cédulas ni papeles.   | Es la foto de un documento. Esa la borramos apenas la vimos. …      |
+| `contact_visible`  | Sin números de teléfono ni correos escritos en la imagen. | Se ve un número de teléfono en la foto. …                           |
+| `not_for_work`     | Que se te vea la cara, de frente y con buena luz.         | No podemos mostrar esta foto en un perfil de trabajo. …             |
+
+**The last two imperatives are word-for-word identical, and that is the control rather than a
+collision.** A per-code channel policy — five reasons travel, the sensitive one does not — was the
+first idea and it is wrong for a reason this repo has already established twice: **differential
+treatment leaks the thing it protects.** A vaguer email for the bad code makes the vague email
+_mean_ the bad code, which is the same failure ADR-0011 avoided by 404-ing rather than 403-ing and
+ADR-0015 avoided by making the suspended-counterparty string deliberately incurious. Collapsing the
+two imperatives means the email cannot be read backwards to the code.
+
+**D's own cost, stated plainly:** it protects the person whose inbox is shared at the expense of the
+person who only ever reads the email. Somebody refused under `not_for_work` receives the same words
+as somebody whose photo was dark, and if they never open the app they may re-upload against the wrong
+understanding. That is what makes `repeat=sharper` load-bearing here rather than optional.
+
+**The standing rule this proposes, so the argument survives the next code added:** _no reason code may
+enter the vocabulary unless its imperative half is a rule true of everyone on the platform._ That is
+testable against a single sentence, it is the constraint that makes sending the email safe at all,
+and without it the sixth code that gets added quietly reopens the flaw.
+
+### Two problems this ticket surfaced and should not solve
+
+- **No email of ours survives an erasure, and nothing in the map says so.** ADR-0021 hard-deletes the
+  `persons` row and ADR-0010 has an R2 adapter for the bytes, but a sent message is outside every
+  adapter. This is **not a photo problem** — ADR-0015's Offer notifications name a person and a pay
+  figure, which reveals considerably more than _"no se te ve la cara"_ — so fixing it here would be
+  fixing it in the wrong place. Belongs to the map as a finding against the notifications lane.
+- **Nothing here has been through an email client.** The frame is a table cell with a background;
+  dark-mode inversion in Gmail and Outlook is exactly the kind of thing that would undo the "not
+  alarm" decision without anybody noticing. Named in the accessibility section, not fixed.
 
 ## The design — one signature, and it is the reason it exists
 
@@ -414,3 +467,9 @@ Flag any of these that are wrong — they are positions, not defaults.
    rules are never quoted at each other.
 10. **The refusal path uses no alarm colour at all** — no red, no warning mark. A refusal that looks
     like an error teaches the reader they did something wrong, and in five of six cases they did not.
+11. **The email carries the imperative half and never the diagnosis** (variant D), and
+    `not_for_work`'s imperative is deliberately identical to `face_not_visible`'s so the email cannot
+    be read backwards to the code.
+12. **A standing constraint on the vocabulary**: no code may be added unless its imperative half is a
+    rule true of everyone on the platform. This is what makes sending the email safe, so it has to be
+    a rule and not an observation about the six that exist today.

--- a/docs/design/photo-refusal-prototype/index.html
+++ b/docs/design/photo-refusal-prototype/index.html
@@ -15,33 +15,55 @@
       /* ------------------------------------------------------------------
          THROWAWAY PROTOTYPE — ticket #29, wayfinder map #1.
 
-         Three variants of HOW A PERSON LEARNS THEIR PHOTO WAS REFUSED,
-         rendered across all three surfaces at once — the email as it
-         lands, the signed-in home, and the screen the link opens —
-         switchable via ?variant=, plus four question toggles (?reason=,
-         ?approve=, ?late=, ?repeat=).
+         TWO INDEPENDENT AXES, split after the first pass because the
+         feedback proved they were never one decision:
 
-         The reason vocabulary here is authored COPY-FIRST: the Spanish
-         sentence a person reads about their own face is written first and
-         the code is derived from it. ADR-0010 fixes that a refusal carries
-         a code from a fixed vocabulary and forbids free text; it never
-         says what the codes are. #28 inherits this list rather than
-         authoring one.
+           ?variant=  what the EMAIL says  (A the reason · B nothing ·
+                      C the fix, with no verdict anywhere)
+           ?home=     what the APP shows   (card · line · step)
 
-         Tokens copied from apps/landing/NEXTJS_HANDOFF.md, which the map
-         records as still binding. The design system that landed ships the
-         shadcn vega preset and the two disagree; no ADR reconciles them,
-         and this ticket does not own that. Nothing decided here is a
-         colour.
+         Plus four question toggles (?reason=, ?approve=, ?late=,
+         ?repeat=). Defaults on load are variant=A&home=card — A's email
+         with B's card, which is neither variant as first built.
+
+         THE SIGNATURE: the mount. ADR-0010 destroys the rejected bytes
+         within seconds, so the photograph can never be shown back to its
+         owner. That absence is the subject of the whole message, so the
+         reason is set INSIDE the rectangle where the photo is not — a
+         photo-proportioned frame with a mat inset — and the same rectangle
+         returns in outline, on the upload screen, as the place you put the
+         new one. It carries the thesis of the vocabulary structurally: the
+         refusal is a property of that rectangle, never of the person
+         holding it.
+
+         The first pass drew the frame as a dark slab and it was rejected
+         on sight, correctly: on a message about somebody's face a black
+         panel reads as mourning, and the one thing this surface may never
+         do is alarm. The shape was the argument; the darkness was not.
+
+         NOT an avatar placeholder. ADR-0026 bans those on a profile card,
+         where an empty disc beside a human being is a penalty rendered in
+         CSS. This is the person's own photo screen, where the rectangle is
+         the object under discussion. Do not quote one rule at the other.
+
+         The reason vocabulary is authored COPY-FIRST: the Spanish sentence
+         a person reads about their own face is written first and the code
+         is derived from it. ADR-0010 fixes that a refusal carries a code
+         from a fixed vocabulary and forbids free text; it never says what
+         the codes are. #28 inherits this list rather than authoring one.
+
+         Tokens from apps/landing/NEXTJS_HANDOFF.md, which the map records
+         as still binding. The design system that landed ships the shadcn
+         vega preset and the two disagree; no ADR reconciles them, and this
+         ticket does not own that. Nothing decided here is a colour.
 
          Not production code. No tests, no error handling, no abstractions.
-         The photograph is a coloured rectangle: the question here is the
-         sentence next to it, never the face inside it.
          ------------------------------------------------------------------ */
       :root {
         --color-brand-500: #2457e6;
         --color-brand-700: #172d70;
         --color-ink: #172747;
+        --color-ink-deep: #101c33;
         --color-text-muted: #62708a;
         --color-surface: #ffffff;
         --color-page: #f7f9ff;
@@ -206,8 +228,8 @@
       }
 
       .readout {
-        max-width: 78rem;
-        margin: var(--space-6) auto 0;
+        max-width: 82rem;
+        margin: var(--space-8) auto 0;
         padding: var(--space-4) var(--space-5);
         background: #101828;
         color: #d7dce8;
@@ -225,13 +247,13 @@
       /* ---------------- page scaffold ---------------------------------- */
 
       .page {
-        max-width: 78rem;
+        max-width: 82rem;
         margin: 0 auto;
         padding: var(--space-8) var(--space-5) 0;
       }
 
       .sectionhead {
-        margin: var(--space-10) 0 var(--space-4);
+        margin: var(--space-10) 0 var(--space-5);
       }
 
       .sectionhead h2 {
@@ -245,14 +267,14 @@
       .sectionhead p {
         font-size: 0.8125rem;
         color: var(--color-text-muted);
-        margin-top: var(--space-1);
-        max-width: 46rem;
+        margin-top: var(--space-2);
+        max-width: 48rem;
       }
 
       .surfaces {
         display: grid;
         gap: var(--space-5);
-        grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(23rem, 1fr));
         align-items: start;
       }
 
@@ -275,65 +297,26 @@
       }
 
       .surface__body {
-        padding: var(--space-5);
+        padding: var(--space-6);
       }
 
-      /* ---------------- email chrome ----------------------------------- */
+      /* ---------------- type scale ------------------------------------- */
 
-      .mail__meta {
-        border-bottom: 1px solid var(--color-border);
-        padding-bottom: var(--space-3);
-        margin-bottom: var(--space-4);
-      }
-
-      .mail__from {
-        font-size: 0.75rem;
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
         color: var(--color-text-muted);
       }
-
-      .mail__subject {
-        font-size: 1.0625rem;
-        font-weight: 700;
-        line-height: 1.35;
-        margin-top: var(--space-1);
-      }
-
-      .mail__foot {
-        margin-top: var(--space-5);
-        padding-top: var(--space-3);
-        border-top: 1px solid var(--color-border);
-        font-size: 0.6875rem;
-        color: var(--color-text-muted);
-        line-height: 1.6;
-      }
-
-      /* ---------------- phone chrome ----------------------------------- */
-
-      .phone__top {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding-bottom: var(--space-4);
-        margin-bottom: var(--space-4);
-        border-bottom: 1px solid var(--color-border);
-      }
-
-      .phone__wordmark {
-        font-weight: 800;
-        letter-spacing: -0.01em;
-      }
-
-      .phone__nav {
-        font-size: 0.75rem;
-        color: var(--color-text-muted);
-      }
-
-      /* ---------------- copy blocks ------------------------------------ */
 
       .lede {
-        font-size: 1.125rem;
-        font-weight: 700;
-        line-height: 1.35;
+        margin-top: var(--space-2);
+        font-size: 1.25rem;
+        font-weight: 800;
+        line-height: 1.25;
+        letter-spacing: -0.015em;
+        text-wrap: balance;
       }
 
       .para {
@@ -347,37 +330,174 @@
         font-size: 0.875rem;
       }
 
-      .reason {
-        margin-top: var(--space-4);
-        padding: var(--space-4);
-        background: var(--color-page);
-        border-left: 3px solid var(--color-brand-500);
-        border-radius: 0 var(--radius-md) var(--radius-md) 0;
+      /* ---------------- the mount — the signature ----------------------- */
+
+      /* Light, not dark. A dark slab was tried and rejected on sight: on a
+         message about somebody's face it reads as mourning, and the one
+         thing this surface may never do is alarm. What survives is the
+         shape — a photo-proportioned rectangle with a mat inset — which is
+         all the structural argument ever needed. */
+      .mount {
+        position: relative;
+        margin-top: var(--space-5);
+        background: var(--color-surface-brand);
+        color: var(--color-ink);
+        border: 1px solid #c8d5f7;
+        border-radius: var(--radius-md);
+        padding: var(--space-6) var(--space-5);
+        min-height: 11rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
       }
 
-      .reason__title {
+      .mount::after {
+        content: "";
+        position: absolute;
+        inset: 0.4375rem;
+        border: 1px solid rgba(255, 255, 255, 0.85);
+        border-radius: var(--radius-sm);
+        pointer-events: none;
+      }
+
+      .mount__eyebrow {
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-brand-700);
+        opacity: 0.7;
+        margin-bottom: var(--space-3);
+      }
+
+      .mount__title {
+        font-size: 1.0625rem;
         font-weight: 700;
-        font-size: 0.9375rem;
+        line-height: 1.35;
+        text-wrap: balance;
       }
 
-      .reason__body {
-        margin-top: var(--space-2);
-        font-size: 0.875rem;
-        line-height: 1.6;
-      }
-
-      .reason__again {
+      .mount__body {
         margin-top: var(--space-3);
-        padding-top: var(--space-3);
-        border-top: 1px dashed var(--color-border);
         font-size: 0.875rem;
+        line-height: 1.65;
+        color: var(--color-ink);
+        opacity: 0.82;
+      }
+
+      .mount__again {
+        margin-top: var(--space-4);
+        padding-top: var(--space-4);
+        border-top: 1px solid #c8d5f7;
+        font-size: 0.8125rem;
+        line-height: 1.65;
+        color: var(--color-ink);
+        opacity: 0.82;
+      }
+
+      .mount__again strong {
+        color: var(--color-ink);
+      }
+
+      /* The same rectangle, waiting rather than occupied. */
+      .mount--empty {
+        background: var(--color-page);
+        color: var(--color-ink);
+        border: 2px dashed var(--color-border);
+        text-align: center;
+        min-height: 13rem;
+        cursor: pointer;
+        align-items: center;
+      }
+
+      .mount--empty::after {
+        display: none;
+      }
+
+      .mount--empty p {
+        font-size: 0.875rem;
+        color: var(--color-text-muted);
+      }
+
+      .mount--empty p:first-child {
+        font-size: 0.9375rem;
+        font-weight: 700;
+        color: var(--color-ink);
+      }
+
+      /* ---------------- email chrome ----------------------------------- */
+
+      .mail__masthead {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-3);
+        padding-bottom: var(--space-3);
+        border-bottom: 2px solid var(--color-ink);
+      }
+
+      .mail__wordmark {
+        font-weight: 800;
+        font-size: 1.0625rem;
+        letter-spacing: -0.02em;
+      }
+
+      .mail__to {
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        color: var(--color-text-muted);
+      }
+
+      .mail__subject {
+        margin-top: var(--space-4);
+        font-size: 0.75rem;
+        font-family: var(--font-mono);
+        color: var(--color-text-muted);
+      }
+
+      .mail__subject b {
+        display: block;
+        margin-top: var(--space-1);
+        font-family: var(--font-sans);
+        font-size: 1rem;
+        color: var(--color-ink);
+      }
+
+      .mail__foot {
+        margin-top: var(--space-6);
+        padding-top: var(--space-4);
+        border-top: 1px solid var(--color-border);
+        font-size: 0.6875rem;
+        color: var(--color-text-muted);
         line-height: 1.6;
       }
+
+      /* ---------------- app chrome ------------------------------------- */
+
+      .phone__top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-bottom: var(--space-4);
+        margin-bottom: var(--space-5);
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .phone__wordmark {
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+
+      .phone__nav {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
+
+      /* ---------------- actions ---------------------------------------- */
 
       .btn {
         display: inline-block;
-        margin-top: var(--space-5);
-        padding: 0.6rem 1.1rem;
+        padding: 0.65rem 1.15rem;
         background: var(--color-brand-500);
         color: #fff;
         border: 1px solid var(--color-brand-500);
@@ -393,14 +513,23 @@
         border-color: var(--color-border);
       }
 
+      /* ADR-0025: the two Photo controls carry EQUAL visual weight. Two
+         outlined buttons, neither filled — a filled primary beside a
+         ghosted escape is D.1377 art. 6 conditioning arriving via CSS. */
       .btn--equal {
-        margin-top: 0;
+        background: transparent;
+        color: var(--color-brand-700);
+        border-color: var(--color-brand-700);
       }
 
       .btnrow {
         display: flex;
         flex-wrap: wrap;
         gap: var(--space-3);
+        margin-top: var(--space-5);
+      }
+
+      .actions {
         margin-top: var(--space-5);
       }
 
@@ -418,13 +547,8 @@
       .card {
         border: 1px solid var(--color-border);
         border-radius: var(--radius-md);
-        padding: var(--space-4);
+        padding: var(--space-5);
         background: var(--color-surface);
-      }
-
-      .card--attention {
-        border-color: #c8d5f7;
-        background: var(--color-surface-brand);
       }
 
       .card--good {
@@ -435,11 +559,6 @@
       .card--late {
         border-color: #ecd79a;
         background: var(--color-warning-surface);
-      }
-
-      .card--bad {
-        border-color: #f0c3ce;
-        background: var(--color-danger-surface);
       }
 
       .checklist {
@@ -466,43 +585,19 @@
         color: var(--color-text-muted);
       }
 
-      .dropzone {
-        margin-top: var(--space-5);
-        border: 2px dashed var(--color-border);
-        border-radius: var(--radius-md);
-        padding: var(--space-8) var(--space-4);
-        text-align: center;
-        color: var(--color-text-muted);
-        font-size: 0.875rem;
-      }
-
-      .thumb {
-        width: 3.5rem;
-        height: 3.5rem;
-        border-radius: var(--radius-md);
-        background: linear-gradient(140deg, #c9d6f5, #9fb6ea);
-        flex: none;
-      }
-
-      .withthumb {
-        display: flex;
-        gap: var(--space-4);
-        align-items: flex-start;
-      }
-
       /* ---------------- comparison strips ------------------------------ */
 
       .strips {
         display: grid;
         gap: var(--space-4);
-        grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
       }
 
       .strip {
         background: var(--color-surface);
         border: 1px solid var(--color-border);
         border-radius: var(--radius-lg);
-        padding: var(--space-4);
+        padding: var(--space-5);
       }
 
       .strip__tag {
@@ -523,8 +618,13 @@
         color: var(--color-brand-500);
       }
 
+      .strip .mount {
+        margin-top: 0;
+        min-height: 0;
+      }
+
       .note {
-        margin-top: var(--space-3);
+        margin-top: var(--space-4);
         font-size: 0.75rem;
         line-height: 1.6;
         color: var(--color-text-muted);
@@ -537,13 +637,13 @@
       }
 
       .flaw {
-        margin-top: var(--space-4);
-        padding: var(--space-4);
+        margin-top: var(--space-5);
+        padding: var(--space-5);
         border-radius: var(--radius-md);
         background: var(--color-danger-surface);
         border: 1px solid #f0c3ce;
         font-size: 0.8125rem;
-        line-height: 1.6;
+        line-height: 1.65;
       }
 
       .flaw b {
@@ -561,6 +661,12 @@
         white-space: nowrap;
       }
 
+      @media (prefers-reduced-motion: no-preference) {
+        .mount {
+          transition: background-color 120ms ease;
+        }
+      }
+
       @media (max-width: 40rem) {
         .bar {
           border-radius: var(--radius-lg);
@@ -570,16 +676,21 @@
         .bar__group {
           border-left: 0;
         }
+
+        .surface__body {
+          padding: var(--space-5);
+        }
       }
     </style>
   </head>
   <body>
     <div class="banner">
       <strong>PROTOTYPE — how a person learns their Photo was refused (#29)</strong>
-      Three variants of where the news lives and what it asks of the reader, rendered across all three
-      surfaces at once. Flip with <code>←</code> / <code>→</code> or the bar at the bottom. Every
-      Spanish string is the design under review; every English string is instrumentation and gets
-      deleted when this is captured (ADR-0001 as amended by #30).
+      Two independent axes: <code>?variant=</code> is what the <b>email</b> says,
+      <code>?home=</code> is what the <b>app</b> shows. They were one axis in the first pass and the
+      feedback proved they are not. Flip variants with <code>←</code> / <code>→</code>. Every Spanish
+      string is the design under review; every English string is instrumentation and gets deleted when
+      this is captured (ADR-0001 as amended by #30).
     </div>
 
     <main class="page">
@@ -639,16 +750,18 @@
          DATA
          ================================================================= */
 
-      /* Shared strings. Every one of these is repeated identically across
-         the variants that use it at all — the variants disagree about
-         WHERE they appear and WHICH of them appear, never about wording.
-         Gender-agreement rule (CONTEXT.md): no adjective agrees with the
-         reader. Address rule: tú, and the verb belongs to the reader. */
+      /* Shared strings. Every one is repeated identically wherever it is
+         used at all — the axes disagree about WHERE and WHETHER, never
+         about wording. Gender-agreement rule (CONTEXT.md): no adjective
+         agrees with the reader. Address rule: tú, verb belongs to the
+         reader. */
       const S = {
+        eyebrow: "Tu foto",
         lede: "Tu foto todavía no está en tu perfil.",
         human: "Una persona la revisó y hay algo que cambiar.",
         noLoss:
           "Tu perfil sigue igual: sales en las búsquedas y te pueden mandar propuestas. Lo único que falta es la foto.",
+        mountEyebrow: "Lo que hay que cambiar",
         cta: "Poner otra foto",
         ctaStep: "Terminar este paso",
         ctaOpen: "Entrar a Encuentra",
@@ -657,6 +770,8 @@
           "La foto nunca es obligatoria. Si prefieres dejarla así, tu perfil funciona igual de bien.",
         mailFoot:
           "Te escribimos porque es un mensaje del servicio, no publicidad. Estos no se pueden desactivar; los de novedades sí, en Tus datos.",
+        dropTitle: "Aquí va tu foto",
+        dropBody: "Toca para escoger una, o tómate una ahora.",
         checklist: [
           { hit: ["face_not_visible", "not_for_work"], text: "Que se te vea la cara." },
           { hit: ["no_person"], text: "Que salgas tú, no tu negocio ni tu logo." },
@@ -669,7 +784,8 @@
       /* The vocabulary. `label` is the operator's English code label and is
          chrome; every Spanish string here is the design under review.
          `again` is what changes on a repeat of the SAME code under
-         repeat=sharper — more concrete, never sterner. */
+         repeat=sharper — more concrete, never sterner. `fix` is the
+         verdict-free phrasing variant C needs. */
       const REASONS = {
         face_not_visible: {
           label: "Face not visible",
@@ -683,14 +799,16 @@
           label: "Nobody in the photo",
           title: "En la foto no hay nadie.",
           body: "Va una foto tuya, no de tu negocio, tu herramienta ni tu logo. La cara sirve para que quien te va a contratar sepa con quién está hablando.",
-          again: "Si no tienes ninguna, pídele a alguien que te tome una ahí mismo. La del teléfono sirve.",
+          again:
+            "Si no tienes ninguna, pídele a alguien que te tome una ahí mismo. La del teléfono sirve.",
           fix: "Lo que subiste no tiene una persona. Va tu cara, no tu negocio ni tu logo.",
         },
         other_people: {
           label: "Someone else in frame",
           title: "Sale alguien más en la foto.",
           body: "Solo podemos mostrar tu cara: la otra persona no nos dio permiso para mostrar la suya.",
-          again: "Si es la única que tienes, recórtala para que quedes solo tú, o pide que te tomen otra.",
+          again:
+            "Si es la única que tienes, recórtala para que quedes solo tú, o pide que te tomen otra.",
           fix: "En la que subiste sale alguien más, y esa persona no nos dio permiso.",
         },
         document: {
@@ -720,47 +838,59 @@
 
       const REASON_KEYS = Object.keys(REASONS);
 
+      /* AXIS 1 — what the email says. */
       const VARIANTS = {
         A: {
-          name: "Email carries it",
+          name: "Email carries the reason",
           blurb:
-            "The email is the surface of record: subject, reason, guidance and the button, all in the inbox. The app keeps one quiet line, because the person who read the email already knows. Bets that the inbox is where people actually are, and that someone who never opens the site again still learns what happened.",
-          flaw: "The reason is a sentence about somebody's face, sent in clear text to a mailbox that may be shared, archived by Google forever, and impossible for us to delete. ADR-0010 destroys the rejected bytes within seconds; this email outlives them by years.",
+            "The email is a surface of record: subject, reason, guidance and the button, all in the inbox. Bets that the inbox is where people actually are, and that someone who never opens the site again still learns what happened and what to do.",
+          flaw: "The reason is a sentence about somebody's face, sent in clear text to a mailbox that may be shared, archived by a third party forever, and impossible for us to delete. Every other decision in ADR-0010 treats a face as sensitive data whose lifetime we control — and that ADR destroys the rejected bytes within seconds, so this email outlives the photograph it describes by years.",
           mailSubject: "Tu foto todavía no está en tu perfil",
           mailShowsReason: true,
-          homeShape: "line",
-          screenBanner: "reason",
         },
         B: {
-          name: "App carries it, email knocks",
+          name: "Email only knocks",
           blurb:
-            "The email says nothing at all beyond that something is waiting — no reason, no photo, no detail. Everything is inside the session. Bets that nothing about a person's face may leave a channel we control and can delete.",
-          flaw: "A vague “come and look at your account” email with a link is the exact shape of the impersonation attack ADR-0026 just spent a sentence closing — and it is the one email of ours a careful person is right to distrust. It also gets the lowest open rate of the three.",
+            "The email says nothing beyond that something is waiting — no reason, no photo, no detail. Every word about the Photo stays inside the session. Bets that nothing about a person's face may leave a channel we control and can delete.",
+          flaw: "“Hay algo pendiente en tu perfil. Entra y te contamos” with a link is the exact shape of the impersonation attack ADR-0026 spent its one attack-naming sentence closing — and it is the one message of ours a careful person is right to distrust. It also gets the lowest open rate of the three, which matters when the entire mechanism is “the person comes back”.",
           mailSubject: "Hay algo pendiente en tu perfil de Encuentra",
           mailShowsReason: false,
-          homeShape: "card",
-          screenBanner: "reason",
         },
         C: {
-          name: "No verdict, just an unfinished step",
+          name: "No verdict anywhere",
           blurb:
-            "There is no refusal anywhere: no notice, no “una persona la revisó”, no event with a name. The email and the home both say the step is not finished and what to change, and the screen carries the guidance inline. Bets that a verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial.",
-          flaw: "A human did look at this person's face, and this variant never says so. That is the one true operational fact the platform has (ADR-0026's band item 2), it is what ADR-0010's art. 12 disclosure promised would be said plainly, and burying it under “step incomplete” is the product being tactful about something the person has a right to know.",
+            "No refusal exists as an event: no notice, no “una persona la revisó”, nothing with a name. The email says the step is not finished and what to change. Bets that a verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial. View with home=step.",
+          flaw: "A human did look at this person's face, and this variant never says so. That is the single true operational fact the platform has (ADR-0026's band item two), it is what ADR-0010's art. 12 disclosure promises will be said plainly, and burying it under “te falta un paso” is the product deciding a Titular is better off not knowing what was done with their data.",
           mailSubject: "Te falta un paso para poner tu foto",
           mailShowsReason: "fix",
-          homeShape: "step",
-          screenBanner: "checklist",
         },
       };
 
+      /* AXIS 2 — what the app shows. Independent of the email: the first
+         pass bound the two together and the feedback proved they are
+         separate decisions. */
+      const HOMES = {
+        card: "A full card: the mount, the reason, what did not change, the action.",
+        line: "One quiet line inside the profile block — the email already did the work.",
+        step: "ADR-0025's sin-publicar card wearing a different hat: an unfinished step, no verdict.",
+      };
+
       const TOGGLES = {
+        home: { label: "Home", values: ["card", "line", "step"], display: (v) => v },
         reason: { label: "Reason", values: REASON_KEYS, display: (v) => REASONS[v].label },
         approve: { label: "Approve", values: ["told", "silent"], display: (v) => v },
         late: { label: "3-day miss", values: ["told", "silent"], display: (v) => v },
         repeat: { label: "Repeat", values: ["sharper", "same", "escalates"], display: (v) => v },
       };
 
-      const DEFAULTS = { variant: "A", reason: "face_not_visible", approve: "told", late: "told", repeat: "sharper" };
+      const DEFAULTS = {
+        variant: "A",
+        home: "card",
+        reason: "face_not_visible",
+        approve: "told",
+        late: "told",
+        repeat: "sharper",
+      };
 
       /* =================================================================
          STATE
@@ -817,21 +947,35 @@
           .join("")}</ul>`;
       }
 
-      /* Under repeat=sharper the SAME code arriving a second time swaps in
-         the more concrete guidance. Under same it never changes. Under
-         escalates the surface starts counting, which is the version this
-         file exists to make look as bad as it is. */
-      function reasonBlock(reasonKey, attempt, mode) {
+      /* THE MOUNT. The reason is set inside the rectangle where the photo
+         is not, because ADR-0010 destroyed it and the absence is what the
+         message is about. Under repeat=sharper a second refusal for the
+         same code swaps in more concrete guidance; under escalates the
+         surface starts counting, which this file exists to make look as
+         bad as it is. */
+      function mount(reasonKey, attempt, mode) {
         const r = REASONS[reasonKey];
         const second = attempt >= 2;
         let extra = "";
         if (second && mode === "sharper") {
-          extra = `<p class="reason__again">${esc(r.again)}</p>`;
+          extra = `<p class="mount__again">${esc(r.again)}</p>`;
         }
         if (second && mode === "escalates") {
-          extra = `<p class="reason__again"><strong>Es la ${attempt === 2 ? "segunda" : "tercera"} foto que no podemos mostrar.</strong> Si la próxima tampoco sirve, vamos a tener que revisar tu cuenta.</p>`;
+          extra = `<p class="mount__again"><strong>Es la ${attempt === 2 ? "segunda" : "tercera"} foto que no podemos mostrar.</strong> Si la próxima tampoco sirve, vamos a tener que revisar tu cuenta.</p>`;
         }
-        return `<div class="reason"><p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p>${extra}</div>`;
+        return `<div class="mount">
+            <p class="mount__eyebrow">${esc(S.mountEyebrow)}</p>
+            <p class="mount__title">${esc(r.title)}</p>
+            <p class="mount__body">${esc(r.body)}</p>
+            ${extra}
+          </div>`;
+      }
+
+      function emptyMount() {
+        return `<div class="mount mount--empty">
+            <p>${esc(S.dropTitle)}</p>
+            <p>${esc(S.dropBody)}</p>
+          </div>`;
       }
 
       /* =================================================================
@@ -844,66 +988,64 @@
 
         if (v.mailShowsReason === true) {
           body = `
+            <p class="eyebrow">${esc(S.eyebrow)}</p>
             <p class="lede">${esc(S.lede)}</p>
             <p class="para">${esc(S.human)}</p>
-            ${reasonBlock(reasonKey, 1, state.repeat)}
+            ${mount(reasonKey, 1, state.repeat)}
             <p class="para para--muted">${esc(S.noLoss)}</p>
-            <a class="btn" href="#">${esc(S.cta)}</a>`;
+            <p class="actions"><a class="btn" href="#">${esc(S.cta)}</a></p>`;
         } else if (v.mailShowsReason === "fix") {
           body = `
+            <p class="eyebrow">${esc(S.eyebrow)}</p>
             <p class="lede">Todavía no tienes foto en tu perfil.</p>
             <p class="para">${esc(r.fix)}</p>
             <p class="para para--muted">${esc(S.noLoss)}</p>
-            <a class="btn" href="#">${esc(S.ctaStep)}</a>`;
+            <p class="actions"><a class="btn" href="#">${esc(S.ctaStep)}</a></p>`;
         } else {
           body = `
+            <p class="eyebrow">${esc(S.eyebrow)}</p>
             <p class="lede">Hay algo pendiente en tu perfil.</p>
             <p class="para">Entra y te contamos qué es. No es nada urgente y no perdiste nada.</p>
-            <a class="btn" href="#">${esc(S.ctaOpen)}</a>`;
+            <p class="actions"><a class="btn" href="#">${esc(S.ctaOpen)}</a></p>`;
         }
 
         return surface(
           "1 · The email, as it lands",
-          `<div class="mail__meta">
-             <p class="mail__from">Encuentra &lt;hola@encuentra.co&gt; → tú</p>
-             <p class="mail__subject">${esc(v.mailSubject)}</p>
+          `<div class="mail__masthead">
+             <span class="mail__wordmark">Encuentra</span>
+             <span class="mail__to">hola@encuentra.co → tú</span>
            </div>
+           <p class="mail__subject">Asunto<b>${esc(v.mailSubject)}</b></p>
            ${body}
            <p class="mail__foot">${esc(S.mailFoot)}</p>`,
         );
       }
 
-      function renderHome(v, reasonKey) {
+      function renderHome(reasonKey) {
         let block = "";
 
-        if (v.homeShape === "line") {
+        if (state.home === "card") {
+          block = `
+            <p class="eyebrow">${esc(S.eyebrow)}</p>
+            <p class="lede">${esc(S.lede)}</p>
+            <p class="para">${esc(S.human)}</p>
+            ${mount(reasonKey, 1, state.repeat)}
+            <p class="para para--muted">${esc(S.noLoss)}</p>
+            <p class="actions"><a class="btn" href="#">${esc(S.cta)}</a></p>`;
+        } else if (state.home === "line") {
           block = `
             <div class="card">
-              <p style="font-weight:700">Tu perfil</p>
-              <p class="para para--muted">Auxiliar de cocina · Pereira · 7 habilidades</p>
+              <p class="eyebrow">Tu perfil</p>
+              <p class="lede" style="font-size:1rem">Auxiliar de cocina</p>
+              <p class="para para--muted">Pereira · 7 habilidades · publicado</p>
               <p class="quiet">Tu foto no está puesta. <a href="#">${esc(S.cta)}</a></p>
-            </div>`;
-        } else if (v.homeShape === "card") {
-          block = `
-            <div class="card card--attention">
-              <div class="withthumb">
-                <div class="thumb" aria-hidden="true"></div>
-                <div>
-                  <p class="lede">${esc(S.lede)}</p>
-                  <p class="para">${esc(S.human)}</p>
-                </div>
-              </div>
-              ${reasonBlock(reasonKey, 1, state.repeat)}
-              <p class="para para--muted">${esc(S.noLoss)}</p>
-              <a class="btn" href="#">${esc(S.cta)}</a>
             </div>`;
         } else {
           block = `
-            <div class="card card--attention">
-              <p class="lede">Te falta la foto.</p>
-              <p class="para">${esc(REASONS[reasonKey].fix)}</p>
-              <a class="btn" href="#">${esc(S.ctaStep)}</a>
-            </div>`;
+            <p class="eyebrow">${esc(S.eyebrow)}</p>
+            <p class="lede">Te falta la foto.</p>
+            <p class="para">${esc(REASONS[reasonKey].fix)}</p>
+            <p class="actions"><a class="btn" href="#">${esc(S.ctaStep)}</a></p>`;
         }
 
         return surface(
@@ -917,10 +1059,14 @@
       }
 
       function renderScreen(v, reasonKey) {
-        const banner =
-          v.screenBanner === "reason"
-            ? `<p class="para para--muted">${esc(S.landed)}</p>${reasonBlock(reasonKey, 1, state.repeat)}`
-            : "";
+        /* The reason is restated at the destination in every variant: an
+           email read on a bus and opened an hour later has lost its
+           context. C restates it as a checklist hit rather than a mount,
+           because C has no verdict to restate. */
+        const verdictless = v.mailShowsReason === "fix" && state.home === "step";
+        const restated = verdictless
+          ? ""
+          : `<p class="para para--muted">${esc(S.landed)}</p>${mount(reasonKey, 1, state.repeat)}`;
 
         return surface(
           "3 · The screen the link opens · /perfil/foto",
@@ -928,14 +1074,15 @@
              <span class="phone__wordmark">Encuentra</span>
              <span class="phone__nav">Tu foto</span>
            </div>
-           <p class="lede">Tu foto</p>
-           ${banner}
-           <p class="para para--muted" style="margin-top:var(--space-4)">Lo que sirve:</p>
-           ${checklistHtml(reasonKey, v.screenBanner === "checklist")}
-           <div class="dropzone">Toca para escoger una foto<br />o tómate una ahora</div>
+           <p class="eyebrow">${esc(S.eyebrow)}</p>
+           <p class="lede">Pon una foto tuya.</p>
+           ${restated}
+           ${emptyMount()}
+           <p class="para para--muted" style="margin-top:var(--space-5)">Lo que sirve:</p>
+           ${checklistHtml(reasonKey, verdictless)}
            <div class="btnrow">
              <a class="btn btn--equal" href="#">${esc(S.cta)}</a>
-             <a class="btn btn--equal btn--ghost" href="#">Ahora no</a>
+             <a class="btn btn--equal" href="#">Ahora no</a>
            </div>
            <p class="note">${esc(S.optional)}</p>`,
         );
@@ -954,14 +1101,14 @@
       function renderApprove() {
         const told = `
           <div class="card card--good">
-            <p class="lede">Tu foto ya está en tu perfil.</p>
+            <p class="lede" style="margin-top:0">Tu foto ya está en tu perfil.</p>
             <p class="para">Una persona la revisó. Ahora la ve quien entre a tu perfil.</p>
             <p class="para para--muted">Si algún día la quieres quitar, se quita en un toque.</p>
           </div>`;
         const silent = `
           <div class="card">
-            <p class="para para--muted" style="margin-top:0">Nada. La foto aparece en el perfil y el aviso de
-            <em>en revisión</em> deja de estar. Quien no vuelva a entrar nunca se entera.</p>
+            <p class="para para--muted" style="margin-top:0">Nada. The Photo appears on the profile, the
+            <em>en revisión</em> notice stops being there, and whoever does not come back never finds out.</p>
           </div>`;
 
         return (
@@ -969,7 +1116,7 @@
             "approve · told",
             state.approve === "told",
             told,
-            "Says the human looked, which is the one true fact the product has — and it is the moment to say it, because the same sentence on a profile would make a profile without a Photo second-class (ADR-0026). No celebration and no badge: <b>there is nothing to earn here.</b> The last line is ADR-0010 rule 5 — publication is never a licence, so leaving must be one tap and visible.",
+            "Says the human looked, which is the one true fact the product has — and it is the only moment it can be said to somebody, because the same sentence on a profile makes a profile without a Photo carry visibly less (ADR-0026). No celebration and no badge: <b>there is nothing to earn here.</b> The last line is ADR-0010 rule 5 — publication is never a licence, so leaving must be one tap and visible.",
           ) +
           strip(
             "approve · silent",
@@ -983,15 +1130,15 @@
       function renderLate() {
         const told = `
           <div class="card card--late">
-            <p class="lede">Tu foto sigue en revisión.</p>
+            <p class="lede" style="margin-top:0">Tu foto sigue en revisión.</p>
             <p class="para">Dijimos que menos de 3 días y no cumplimos. No se perdió y no tienes que hacer nada.</p>
             <p class="para para--muted">${esc(S.noLoss)}</p>
           </div>`;
         const silent = `
           <div class="card">
-            <p class="para" style="margin-top:0"><strong>La está revisando una persona.</strong></p>
-            <p class="para para--muted">The pending card silently drops <em>“suele tardar menos de 3 días”</em> once
-            the third day passes, and no message is sent.</p>
+            <p class="lede" style="margin-top:0;font-size:1rem">La está revisando una persona.</p>
+            <p class="para para--muted">The pending card silently drops <em>“suele tardar menos de 3 días”</em>
+            once the third day passes, and no message is sent.</p>
           </div>`;
 
         return (
@@ -1005,59 +1152,51 @@
             "late · silent",
             state.late === "silent",
             silent,
-            "The honest version of silence still has to edit the pending card, because leaving <em>menos de 3 días</em> on screen on day five is the product asserting something false. Once you accept that edit, <b>the person can see we missed it and we still have not said so.</b>",
+            "The honest version of silence still has to edit the pending card, because leaving <em>menos de 3 días</em> on screen on day five is the product asserting something false. Once you accept that edit, <b>the person can already see we missed it and we still have not said so.</b>",
           )
         );
       }
 
       function renderRepeat() {
-        const r = REASONS[state.reason];
-        const shell = (inner) => `<div class="card">${inner}</div>`;
-
         return (
           strip(
             "repeat · sharper",
             state.repeat === "sharper",
-            shell(
-              `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p><p class="reason__again">${esc(r.again)}</p>`,
-            ),
-            "Same tone, more concrete guidance when the <em>same</em> code repeats. Treats a second refusal as our failure to explain rather than the person's failure to comply — and it is the only one of the three that makes the second attempt more likely to work.",
+            mount(state.reason, 2, "sharper"),
+            "Same tone, more concrete guidance when the <em>same</em> code repeats. Treats a second refusal as our failure to explain rather than the person's failure to comply — and it is the only one of the three that makes the next attempt more likely to work.",
           ) +
           strip(
             "repeat · same",
             state.repeat === "same",
-            shell(
-              `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p>`,
-            ),
-            "Word-for-word identical, forever. Purest reading of ADR-0013 — the evidentiary rows are for the operator and nothing accumulates where the person can see it — but it repeats guidance that has already failed once.",
+            mount(state.reason, 2, "same"),
+            "Word-for-word identical, forever. Purest reading of ADR-0013 — the evidentiary rows are for the operator and nothing accumulates where the person can see it — but it repeats guidance that has already failed once, which is not restraint, only stubbornness.",
           ) +
           strip(
             "repeat · escalates",
             state.repeat === "escalates",
-            shell(
-              `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p><p class="reason__again"><strong>Es la tercera foto que no podemos mostrar.</strong> Si la próxima tampoco sirve, vamos a tener que revisar tu cuenta.</p>`,
-            ),
-            "<b>Look at this one and then reject it.</b> It is the platform keeping score against somebody's face, it threatens an account over a Purpose that can never be required (ADR-0007), and ADR-0013 refused accumulation-triggered action for the whole product.",
+            mount(state.reason, 3, "escalates"),
+            "<b>Look at this one and then reject it.</b> It is the platform keeping score against somebody's face, it threatens an account over the one Purpose that can never be required (ADR-0007), and ADR-0013 refused accumulation-triggered action for the whole product on the ground that it is a brigading weapon.",
           )
         );
       }
 
       function renderReasons() {
-        return REASON_KEYS.map((k) => {
-          const r = REASONS[k];
-          return strip(
-            `${k} · ${r.label}`,
+        return REASON_KEYS.map((k) =>
+          strip(
+            `${k} · ${REASONS[k].label}`,
             state.reason === k,
-            `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p>`,
+            mount(k, 1, state.repeat),
             k === "not_for_work"
               ? "The only one that does not tell you what to change, and the one the whole vocabulary is shaped around. It states what <em>we</em> cannot do, never what the image is — <b>and the operator has no free text to elaborate with.</b>"
               : k === "document"
-                ? "Says the bytes are already gone, because photographing your cédula and sending it to a website is the thing that will frighten a person most, and ADR-0010 makes the reassurance true."
+                ? "Says the bytes are already gone, in the same breath as the refusal. Photographing your cédula and sending it to a website is the most frightening thing on this list, and ADR-0010 makes the reassurance true rather than soothing."
                 : k === "contact_visible"
-                  ? "Repeats the mechanic and never the format, which is ADR-0026's rule for the prose refusal, applied to an image."
-                  : null,
-          );
-        }).join("");
+                  ? "Repeats the mechanic and never the format, which is ADR-0026's rule for the prose refusal, applied to an image instead of a text field."
+                  : k === "face_not_visible"
+                    ? "Says the photo does not have to be good. The most likely second attempt after a quality refusal is <b>no second attempt at all</b> — someone deciding they have no photo good enough."
+                    : null,
+          ),
+        ).join("");
       }
 
       /* =================================================================
@@ -1098,22 +1237,26 @@
         );
         bar.querySelectorAll("[data-toggle]").forEach((b) =>
           b.addEventListener("click", () =>
-            setState({ [b.dataset.toggle]: b.dataset.value }, `${b.dataset.toggle} ${b.dataset.value}`),
+            setState(
+              { [b.dataset.toggle]: b.dataset.value },
+              `${b.dataset.toggle} ${b.dataset.value}`,
+            ),
           ),
         );
-        bar.querySelector("[data-reset]").addEventListener("click", () =>
-          setState({ ...DEFAULTS }, "Reset to defaults"),
-        );
+        bar
+          .querySelector("[data-reset]")
+          .addEventListener("click", () => setState({ ...DEFAULTS }, "Reset to defaults"));
       }
 
       function renderReadout() {
         const v = VARIANTS[state.variant];
         const r = REASONS[state.reason];
         document.getElementById("readout").innerHTML = `
-          <b>state</b>  variant=${state.variant} · reason=${state.reason} · approve=${state.approve} · late=${state.late} · repeat=${state.repeat}<br />
-          <b>news lives</b>  ${v.mailShowsReason === true ? "in the inbox" : v.mailShowsReason === "fix" ? "split: the fix travels, the verdict does not exist" : "inside the session only"}<br />
+          <b>state</b>  variant=${state.variant} · home=${state.home} · reason=${state.reason} · approve=${state.approve} · late=${state.late} · repeat=${state.repeat}<br />
+          <b>email says</b>  ${v.mailShowsReason === true ? "the reason in full" : v.mailShowsReason === "fix" ? "the fix, and never that anyone reviewed it" : "only that something is waiting"}<br />
+          <b>app shows</b>  ${esc(HOMES[state.home])}<br />
           <b>reason leaves our systems</b>  ${v.mailShowsReason === false ? "no" : "yes — in an email we can never delete"}<br />
-          <b>the word “revisó” is said</b>  ${v.mailShowsReason === "fix" ? "nowhere" : "yes"}<br />
+          <b>the word “revisó” is said</b>  ${v.mailShowsReason === "fix" && state.home === "step" ? "nowhere" : "yes"}<br />
           <b>what survives the refusal</b>  person_id · reason_code=${state.reason} · created_at — and no image (ADR-0010)<br />
           <b>purpose carrying the send</b>  transactional_messages (required, ADR-0007) — never news, and never gated on the photo purpose<br />
           <b>copy shown</b>  “${esc(r.title)}”`;
@@ -1127,7 +1270,7 @@
         const v = VARIANTS[state.variant];
         document.getElementById("variant-blurb").textContent = v.blurb;
         document.getElementById("surfaces").innerHTML =
-          renderMail(v, state.reason) + renderHome(v, state.reason) + renderScreen(v, state.reason);
+          renderMail(v, state.reason) + renderHome(state.reason) + renderScreen(v, state.reason);
         document.getElementById("variant-flaw").innerHTML =
           `<div class="flaw"><b>${esc(state.variant)}'s visible flaw</b>${esc(v.flaw)}</div>`;
         document.getElementById("approve-strips").innerHTML = renderApprove();
@@ -1140,11 +1283,15 @@
 
       document.addEventListener("keydown", (e) => {
         const tag = document.activeElement?.tagName;
-        if (tag === "INPUT" || tag === "TEXTAREA" || document.activeElement?.isContentEditable) return;
+        if (tag === "INPUT" || tag === "TEXTAREA" || document.activeElement?.isContentEditable)
+          return;
         if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
         const keys = Object.keys(VARIANTS);
         const next =
-          keys[(keys.indexOf(state.variant) + (e.key === "ArrowRight" ? 1 : -1) + keys.length) % keys.length];
+          keys[
+            (keys.indexOf(state.variant) + (e.key === "ArrowRight" ? 1 : -1) + keys.length) %
+              keys.length
+          ];
         setState({ variant: next }, `Variant ${next}, ${VARIANTS[next].name}`);
       });
 

--- a/docs/design/photo-refusal-prototype/index.html
+++ b/docs/design/photo-refusal-prototype/index.html
@@ -19,12 +19,21 @@
          feedback proved they were never one decision:
 
            ?variant=  what the EMAIL says  (A the reason · B nothing ·
-                      C the fix, with no verdict anywhere)
+                      C the fix, with no verdict anywhere · D the
+                      imperative half only)
            ?home=     what the APP shows   (card · line · step)
 
          Plus four question toggles (?reason=, ?approve=, ?late=,
-         ?repeat=). Defaults on load are variant=A&home=card — A's email
-         with B's card, which is neither variant as first built.
+         ?repeat=). Defaults on load are variant=D&home=card.
+
+         D EXISTS BECAUSE OF A'S FLAW, and it is the proposed answer to
+         it. A's reason lands permanently in a mailbox we can never reach,
+         which outlives by years the photograph ADR-0010 destroys in
+         seconds. D splits each message instead of choosing a channel: the
+         email carries the outcome, the fact that a human looked, and the
+         IMPERATIVE — the change, phrased as a rule true of everybody — so
+         nothing that persists in a stranger's inbox is a proposition
+         about the reader. The diagnosis lives only in the session.
 
          THE SIGNATURE: the mount. ADR-0010 destroys the rejected bytes
          within seconds, so the photograph can never be shown back to its
@@ -762,6 +771,7 @@
         noLoss:
           "Tu perfil sigue igual: sales en las búsquedas y te pueden mandar propuestas. Lo único que falta es la foto.",
         mountEyebrow: "Lo que hay que cambiar",
+        mountImperative: "Lo que sirve",
         cta: "Poner otra foto",
         ctaStep: "Terminar este paso",
         ctaOpen: "Entrar a Encuentra",
@@ -794,6 +804,7 @@
           again:
             "Prueba de día, cerca de una ventana, con el teléfono a la altura de la cara. Sin gorra y sin gafas oscuras.",
           fix: "La foto que subiste quedó muy oscura, muy lejos o movida. Con que se te vea la cara de frente basta.",
+          imperative: "Que se te vea la cara, de frente y con buena luz.",
         },
         no_person: {
           label: "Nobody in the photo",
@@ -802,6 +813,7 @@
           again:
             "Si no tienes ninguna, pídele a alguien que te tome una ahí mismo. La del teléfono sirve.",
           fix: "Lo que subiste no tiene una persona. Va tu cara, no tu negocio ni tu logo.",
+          imperative: "Va tu cara, no tu negocio ni tu logo.",
         },
         other_people: {
           label: "Someone else in frame",
@@ -810,6 +822,7 @@
           again:
             "Si es la única que tienes, recórtala para que quedes solo tú, o pide que te tomen otra.",
           fix: "En la que subiste sale alguien más, y esa persona no nos dio permiso.",
+          imperative: "Tiene que salir una sola persona: tú.",
         },
         document: {
           label: "A document",
@@ -817,6 +830,7 @@
           body: "No recibimos cédulas, diplomas ni hojas de vida. Esa la borramos apenas la vimos y no queda copia. Aquí va una foto tuya y ya.",
           again: "Ni la cédula ni ningún papel van a servir, ninguna vez. Es solo tu cara.",
           fix: "Lo que subiste era un documento. Ya lo borramos y no queda copia. Aquí va una foto tuya.",
+          imperative: "Aquí solo va una foto tuya: nada de cédulas ni papeles.",
         },
         contact_visible: {
           label: "Contact details visible",
@@ -824,6 +838,7 @@
           body: "Tus datos de contacto se comparten cuando alguien acepta una propuesta, no antes.",
           again: "Vuelve a subirla sin el número a la vista. Recortarla suele bastar.",
           fix: "En la que subiste se ve un número. Tus datos se comparten cuando alguien acepta una propuesta, no antes.",
+          imperative: "Sin números de teléfono ni correos escritos en la imagen.",
         },
         not_for_work: {
           label: "Not for a work profile",
@@ -833,6 +848,11 @@
              ADR-0010 gives the operator no free text to say it with. */
           again: "Pon otra donde se te vea la cara.",
           fix: "Esa no la podemos mostrar en un perfil de trabajo. Pon otra donde se te vea la cara.",
+          /* Deliberately WORD-FOR-WORD identical to face_not_visible's.
+             Two codes collapsing to one imperative is not a defect here,
+             it is the control: it is what stops the shape of the email
+             from telling a reader which of the two arrived. */
+          imperative: "Que se te vea la cara, de frente y con buena luz.",
         },
       };
 
@@ -864,6 +884,14 @@
           mailSubject: "Te falta un paso para poner tu foto",
           mailShowsReason: "fix",
         },
+        D: {
+          name: "Email carries the instruction",
+          blurb:
+            "A's honesty with B's channel discipline, reached by splitting each message rather than by choosing a channel. The email names the outcome, says a human looked, and carries only the IMPERATIVE half — the change, never the diagnosis. The app carries the diagnosis. Nothing that lands permanently in a mailbox is a proposition about the reader.",
+          flaw: "It protects the person whose inbox is shared at the cost of the person who only ever reads the email. Two codes collapse onto one imperative on purpose, so somebody refused under not_for_work is told the same words as somebody whose photo was dark — and if they never open the app, they may re-upload against the wrong understanding. That is a real cost and the reason repeat=sharper is load-bearing here rather than optional.",
+          mailSubject: "Tu foto todavía no está en tu perfil",
+          mailShowsReason: "imperative",
+        },
       };
 
       /* AXIS 2 — what the app shows. Independent of the email: the first
@@ -884,7 +912,7 @@
       };
 
       const DEFAULTS = {
-        variant: "A",
+        variant: "D",
         home: "card",
         reason: "face_not_visible",
         approve: "told",
@@ -992,6 +1020,17 @@
             <p class="lede">${esc(S.lede)}</p>
             <p class="para">${esc(S.human)}</p>
             ${mount(reasonKey, 1, state.repeat)}
+            <p class="para para--muted">${esc(S.noLoss)}</p>
+            <p class="actions"><a class="btn" href="#">${esc(S.cta)}</a></p>`;
+        } else if (v.mailShowsReason === "imperative") {
+          body = `
+            <p class="eyebrow">${esc(S.eyebrow)}</p>
+            <p class="lede">${esc(S.lede)}</p>
+            <p class="para">${esc(S.human)}</p>
+            <div class="mount">
+              <p class="mount__eyebrow">${esc(S.mountImperative)}</p>
+              <p class="mount__title">${esc(r.imperative)}</p>
+            </div>
             <p class="para para--muted">${esc(S.noLoss)}</p>
             <p class="actions"><a class="btn" href="#">${esc(S.cta)}</a></p>`;
         } else if (v.mailShowsReason === "fix") {
@@ -1253,7 +1292,8 @@
         const r = REASONS[state.reason];
         document.getElementById("readout").innerHTML = `
           <b>state</b>  variant=${state.variant} · home=${state.home} · reason=${state.reason} · approve=${state.approve} · late=${state.late} · repeat=${state.repeat}<br />
-          <b>email says</b>  ${v.mailShowsReason === true ? "the reason in full" : v.mailShowsReason === "fix" ? "the fix, and never that anyone reviewed it" : "only that something is waiting"}<br />
+          <b>email says</b>  ${v.mailShowsReason === true ? "the reason in full" : v.mailShowsReason === "imperative" ? "the outcome, that a human looked, and the change — never the diagnosis" : v.mailShowsReason === "fix" ? "the fix, and never that anyone reviewed it" : "only that something is waiting"}<br />
+          <b>permanent record in the mailbox</b>  ${v.mailShowsReason === true ? "a proposition about the reader" : v.mailShowsReason === false ? "nothing" : "an instruction, true of everyone"}<br />
           <b>app shows</b>  ${esc(HOMES[state.home])}<br />
           <b>reason leaves our systems</b>  ${v.mailShowsReason === false ? "no" : "yes — in an email we can never delete"}<br />
           <b>the word “revisó” is said</b>  ${v.mailShowsReason === "fix" && state.home === "step" ? "nowhere" : "yes"}<br />

--- a/docs/design/photo-refusal-prototype/index.html
+++ b/docs/design/photo-refusal-prototype/index.html
@@ -697,9 +697,9 @@
       <strong>PROTOTYPE — how a person learns their Photo was refused (#29)</strong>
       Two independent axes: <code>?variant=</code> is what the <b>email</b> says,
       <code>?home=</code> is what the <b>app</b> shows. They were one axis in the first pass and the
-      feedback proved they are not. Flip variants with <code>←</code> / <code>→</code>. Every Spanish
-      string is the design under review; every English string is instrumentation and gets deleted when
-      this is captured (ADR-0001 as amended by #30).
+      feedback proved they are not. Flip variants with <code>←</code> / <code>→</code>. Every
+      Spanish string is the design under review; every English string is instrumentation and gets
+      deleted when this is captured (ADR-0001 as amended by #30).
     </div>
 
     <main class="page">
@@ -724,8 +724,8 @@
       <div class="sectionhead">
         <h2>The timeout case — the 3 days we said, and missed</h2>
         <p>
-          ADR-0010 displays <em>menos de 3 días</em> and forbids any automatic state transition, so a
-          missed commitment is a copy problem and nothing else.
+          ADR-0010 displays <em>menos de 3 días</em> and forbids any automatic state transition, so
+          a missed commitment is a copy problem and nothing else.
         </p>
       </div>
       <section class="strips" id="late-strips"></section>
@@ -742,8 +742,9 @@
       <div class="sectionhead">
         <h2>The whole vocabulary, in one place</h2>
         <p>
-          Six codes, one message each, authored copy-first. There is no code without a sentence and no
-          sentence a person is not shown. The <code>Reason</code> toggle drives the surfaces above.
+          Six codes, one message each, authored copy-first. There is no code without a sentence and
+          no sentence a person is not shown. The <code>Reason</code> toggle drives the surfaces
+          above.
         </p>
       </div>
       <section class="strips" id="reason-strips"></section>
@@ -1274,14 +1275,16 @@
             setState({ variant: next }, `Variant ${next}, ${VARIANTS[next].name}`);
           }),
         );
-        bar.querySelectorAll("[data-toggle]").forEach((b) =>
-          b.addEventListener("click", () =>
-            setState(
-              { [b.dataset.toggle]: b.dataset.value },
-              `${b.dataset.toggle} ${b.dataset.value}`,
+        bar
+          .querySelectorAll("[data-toggle]")
+          .forEach((b) =>
+            b.addEventListener("click", () =>
+              setState(
+                { [b.dataset.toggle]: b.dataset.value },
+                `${b.dataset.toggle} ${b.dataset.value}`,
+              ),
             ),
-          ),
-        );
+          );
         bar
           .querySelector("[data-reset]")
           .addEventListener("click", () => setState({ ...DEFAULTS }, "Reset to defaults"));

--- a/docs/design/photo-refusal-prototype/index.html
+++ b/docs/design/photo-refusal-prototype/index.html
@@ -1,0 +1,1154 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>PROTOTIPO — La foto no pasó (Encuentra, #29)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=DM+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ------------------------------------------------------------------
+         THROWAWAY PROTOTYPE — ticket #29, wayfinder map #1.
+
+         Three variants of HOW A PERSON LEARNS THEIR PHOTO WAS REFUSED,
+         rendered across all three surfaces at once — the email as it
+         lands, the signed-in home, and the screen the link opens —
+         switchable via ?variant=, plus four question toggles (?reason=,
+         ?approve=, ?late=, ?repeat=).
+
+         The reason vocabulary here is authored COPY-FIRST: the Spanish
+         sentence a person reads about their own face is written first and
+         the code is derived from it. ADR-0010 fixes that a refusal carries
+         a code from a fixed vocabulary and forbids free text; it never
+         says what the codes are. #28 inherits this list rather than
+         authoring one.
+
+         Tokens copied from apps/landing/NEXTJS_HANDOFF.md, which the map
+         records as still binding. The design system that landed ships the
+         shadcn vega preset and the two disagree; no ADR reconciles them,
+         and this ticket does not own that. Nothing decided here is a
+         colour.
+
+         Not production code. No tests, no error handling, no abstractions.
+         The photograph is a coloured rectangle: the question here is the
+         sentence next to it, never the face inside it.
+         ------------------------------------------------------------------ */
+      :root {
+        --color-brand-500: #2457e6;
+        --color-brand-700: #172d70;
+        --color-ink: #172747;
+        --color-text-muted: #62708a;
+        --color-surface: #ffffff;
+        --color-page: #f7f9ff;
+        --color-surface-brand: #e8efff;
+        --color-border: #dce2ef;
+        --color-success: #387e65;
+        --color-success-surface: #e6f6ed;
+        --color-warning: #946016;
+        --color-warning-surface: #fff1c7;
+        --color-danger: #c53b5d;
+        --color-danger-surface: #fff5f7;
+
+        --font-sans: "Manrope", ui-sans-serif, system-ui, sans-serif;
+        --font-mono: "DM Mono", ui-monospace, monospace;
+
+        --space-1: 0.25rem;
+        --space-2: 0.5rem;
+        --space-3: 0.75rem;
+        --space-4: 1rem;
+        --space-5: 1.25rem;
+        --space-6: 1.5rem;
+        --space-8: 2rem;
+        --space-10: 2.5rem;
+        --radius-sm: 0.3125rem;
+        --radius-md: 0.5rem;
+        --radius-lg: 0.75rem;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html {
+        -webkit-text-size-adjust: 100%;
+      }
+
+      body {
+        margin: 0;
+        padding: 0 0 7rem;
+        background: var(--color-page);
+        color: var(--color-ink);
+        font-family: var(--font-sans);
+        font-size: 1rem;
+        line-height: 1.55;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4,
+      p,
+      ul,
+      ol {
+        margin: 0;
+      }
+
+      ul {
+        padding: 0;
+        list-style: none;
+      }
+
+      button {
+        font: inherit;
+        color: inherit;
+        cursor: pointer;
+      }
+
+      a {
+        color: var(--color-brand-500);
+      }
+
+      /* ---------------- instrumentation (English, deleted on capture) --- */
+
+      .banner {
+        background: #101828;
+        color: #fff;
+        padding: var(--space-4) var(--space-6);
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+
+      .banner strong {
+        display: block;
+        font-size: 0.9375rem;
+        letter-spacing: 0.01em;
+        margin-bottom: var(--space-1);
+      }
+
+      .banner code {
+        font-family: var(--font-mono);
+        background: rgba(255, 255, 255, 0.12);
+        padding: 0.05rem 0.3rem;
+        border-radius: var(--radius-sm);
+      }
+
+      .bar {
+        position: fixed;
+        left: 50%;
+        bottom: var(--space-4);
+        transform: translateX(-50%);
+        z-index: 50;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--space-2) var(--space-3);
+        max-width: calc(100vw - 2rem);
+        padding: var(--space-2) var(--space-3);
+        background: #101828;
+        color: #fff;
+        border-radius: 999px;
+        box-shadow: 0 10px 30px rgba(16, 24, 40, 0.35);
+        font-size: 0.75rem;
+      }
+
+      .bar__group {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: 0 var(--space-2);
+        border-left: 1px solid rgba(255, 255, 255, 0.18);
+      }
+
+      .bar__group:first-child {
+        border-left: 0;
+      }
+
+      .bar__label {
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.5625rem;
+        opacity: 0.6;
+        margin-right: var(--space-1);
+      }
+
+      .bar button {
+        background: rgba(255, 255, 255, 0.1);
+        border: 0;
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.2rem 0.6rem;
+        font-size: 0.75rem;
+        line-height: 1.4;
+      }
+
+      .bar button:hover {
+        background: rgba(255, 255, 255, 0.24);
+      }
+
+      .bar button[aria-pressed="true"] {
+        background: #fff;
+        color: #101828;
+        font-weight: 700;
+      }
+
+      .bar__variant {
+        min-width: 12.5rem;
+        text-align: center;
+        font-weight: 700;
+        font-size: 0.8125rem;
+      }
+
+      .readout {
+        max-width: 78rem;
+        margin: var(--space-6) auto 0;
+        padding: var(--space-4) var(--space-5);
+        background: #101828;
+        color: #d7dce8;
+        border-radius: var(--radius-lg);
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        line-height: 1.75;
+        overflow-x: auto;
+      }
+
+      .readout b {
+        color: #fff;
+      }
+
+      /* ---------------- page scaffold ---------------------------------- */
+
+      .page {
+        max-width: 78rem;
+        margin: 0 auto;
+        padding: var(--space-8) var(--space-5) 0;
+      }
+
+      .sectionhead {
+        margin: var(--space-10) 0 var(--space-4);
+      }
+
+      .sectionhead h2 {
+        font-size: 0.6875rem;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--color-text-muted);
+        font-weight: 700;
+      }
+
+      .sectionhead p {
+        font-size: 0.8125rem;
+        color: var(--color-text-muted);
+        margin-top: var(--space-1);
+        max-width: 46rem;
+      }
+
+      .surfaces {
+        display: grid;
+        gap: var(--space-5);
+        grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+        align-items: start;
+      }
+
+      .surface {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+      }
+
+      .surface__tag {
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        background: var(--color-page);
+        border-bottom: 1px solid var(--color-border);
+        padding: var(--space-2) var(--space-4);
+      }
+
+      .surface__body {
+        padding: var(--space-5);
+      }
+
+      /* ---------------- email chrome ----------------------------------- */
+
+      .mail__meta {
+        border-bottom: 1px solid var(--color-border);
+        padding-bottom: var(--space-3);
+        margin-bottom: var(--space-4);
+      }
+
+      .mail__from {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
+
+      .mail__subject {
+        font-size: 1.0625rem;
+        font-weight: 700;
+        line-height: 1.35;
+        margin-top: var(--space-1);
+      }
+
+      .mail__foot {
+        margin-top: var(--space-5);
+        padding-top: var(--space-3);
+        border-top: 1px solid var(--color-border);
+        font-size: 0.6875rem;
+        color: var(--color-text-muted);
+        line-height: 1.6;
+      }
+
+      /* ---------------- phone chrome ----------------------------------- */
+
+      .phone__top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-bottom: var(--space-4);
+        margin-bottom: var(--space-4);
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .phone__wordmark {
+        font-weight: 800;
+        letter-spacing: -0.01em;
+      }
+
+      .phone__nav {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
+
+      /* ---------------- copy blocks ------------------------------------ */
+
+      .lede {
+        font-size: 1.125rem;
+        font-weight: 700;
+        line-height: 1.35;
+      }
+
+      .para {
+        margin-top: var(--space-3);
+        font-size: 0.9375rem;
+        line-height: 1.6;
+      }
+
+      .para--muted {
+        color: var(--color-text-muted);
+        font-size: 0.875rem;
+      }
+
+      .reason {
+        margin-top: var(--space-4);
+        padding: var(--space-4);
+        background: var(--color-page);
+        border-left: 3px solid var(--color-brand-500);
+        border-radius: 0 var(--radius-md) var(--radius-md) 0;
+      }
+
+      .reason__title {
+        font-weight: 700;
+        font-size: 0.9375rem;
+      }
+
+      .reason__body {
+        margin-top: var(--space-2);
+        font-size: 0.875rem;
+        line-height: 1.6;
+      }
+
+      .reason__again {
+        margin-top: var(--space-3);
+        padding-top: var(--space-3);
+        border-top: 1px dashed var(--color-border);
+        font-size: 0.875rem;
+        line-height: 1.6;
+      }
+
+      .btn {
+        display: inline-block;
+        margin-top: var(--space-5);
+        padding: 0.6rem 1.1rem;
+        background: var(--color-brand-500);
+        color: #fff;
+        border: 1px solid var(--color-brand-500);
+        border-radius: var(--radius-md);
+        font-weight: 700;
+        font-size: 0.9375rem;
+        text-decoration: none;
+      }
+
+      .btn--ghost {
+        background: transparent;
+        color: var(--color-brand-700);
+        border-color: var(--color-border);
+      }
+
+      .btn--equal {
+        margin-top: 0;
+      }
+
+      .btnrow {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-top: var(--space-5);
+      }
+
+      .quiet {
+        margin-top: var(--space-4);
+        padding-top: var(--space-4);
+        border-top: 1px solid var(--color-border);
+        font-size: 0.875rem;
+      }
+
+      .quiet a {
+        font-weight: 700;
+      }
+
+      .card {
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        background: var(--color-surface);
+      }
+
+      .card--attention {
+        border-color: #c8d5f7;
+        background: var(--color-surface-brand);
+      }
+
+      .card--good {
+        border-color: #b9e2cd;
+        background: var(--color-success-surface);
+      }
+
+      .card--late {
+        border-color: #ecd79a;
+        background: var(--color-warning-surface);
+      }
+
+      .card--bad {
+        border-color: #f0c3ce;
+        background: var(--color-danger-surface);
+      }
+
+      .checklist {
+        margin-top: var(--space-4);
+        display: grid;
+        gap: var(--space-2);
+      }
+
+      .checklist li {
+        display: flex;
+        gap: var(--space-3);
+        font-size: 0.875rem;
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-sm);
+        background: var(--color-page);
+      }
+
+      .checklist li[data-hit="true"] {
+        background: var(--color-surface-brand);
+        font-weight: 700;
+      }
+
+      .checklist span[aria-hidden="true"] {
+        color: var(--color-text-muted);
+      }
+
+      .dropzone {
+        margin-top: var(--space-5);
+        border: 2px dashed var(--color-border);
+        border-radius: var(--radius-md);
+        padding: var(--space-8) var(--space-4);
+        text-align: center;
+        color: var(--color-text-muted);
+        font-size: 0.875rem;
+      }
+
+      .thumb {
+        width: 3.5rem;
+        height: 3.5rem;
+        border-radius: var(--radius-md);
+        background: linear-gradient(140deg, #c9d6f5, #9fb6ea);
+        flex: none;
+      }
+
+      .withthumb {
+        display: flex;
+        gap: var(--space-4);
+        align-items: flex-start;
+      }
+
+      /* ---------------- comparison strips ------------------------------ */
+
+      .strips {
+        display: grid;
+        gap: var(--space-4);
+        grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+      }
+
+      .strip {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-4);
+      }
+
+      .strip__tag {
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        margin-bottom: var(--space-3);
+      }
+
+      .strip[data-active="true"] {
+        border-color: var(--color-brand-500);
+        box-shadow: 0 0 0 3px rgba(36, 87, 230, 0.12);
+      }
+
+      .strip[data-active="true"] .strip__tag {
+        color: var(--color-brand-500);
+      }
+
+      .note {
+        margin-top: var(--space-3);
+        font-size: 0.75rem;
+        line-height: 1.6;
+        color: var(--color-text-muted);
+        border-top: 1px dashed var(--color-border);
+        padding-top: var(--space-3);
+      }
+
+      .note b {
+        color: var(--color-danger);
+      }
+
+      .flaw {
+        margin-top: var(--space-4);
+        padding: var(--space-4);
+        border-radius: var(--radius-md);
+        background: var(--color-danger-surface);
+        border: 1px solid #f0c3ce;
+        font-size: 0.8125rem;
+        line-height: 1.6;
+      }
+
+      .flaw b {
+        display: block;
+        color: var(--color-danger);
+        margin-bottom: var(--space-1);
+      }
+
+      .sr {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+      }
+
+      @media (max-width: 40rem) {
+        .bar {
+          border-radius: var(--radius-lg);
+          justify-content: center;
+        }
+
+        .bar__group {
+          border-left: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="banner">
+      <strong>PROTOTYPE — how a person learns their Photo was refused (#29)</strong>
+      Three variants of where the news lives and what it asks of the reader, rendered across all three
+      surfaces at once. Flip with <code>←</code> / <code>→</code> or the bar at the bottom. Every
+      Spanish string is the design under review; every English string is instrumentation and gets
+      deleted when this is captured (ADR-0001 as amended by #30).
+    </div>
+
+    <main class="page">
+      <div class="sectionhead">
+        <h2>The refusal, on every surface it touches</h2>
+        <p id="variant-blurb"></p>
+      </div>
+
+      <section class="surfaces" id="surfaces"></section>
+
+      <div id="variant-flaw"></div>
+
+      <div class="sectionhead">
+        <h2>The approval case — is silence right?</h2>
+        <p>
+          The ticket asks whether an approved Photo deserves a message. Both are rendered; the bar's
+          <code>Approve</code> toggle picks which one this run treats as the answer.
+        </p>
+      </div>
+      <section class="strips" id="approve-strips"></section>
+
+      <div class="sectionhead">
+        <h2>The timeout case — the 3 days we said, and missed</h2>
+        <p>
+          ADR-0010 displays <em>menos de 3 días</em> and forbids any automatic state transition, so a
+          missed commitment is a copy problem and nothing else.
+        </p>
+      </div>
+      <section class="strips" id="late-strips"></section>
+
+      <div class="sectionhead">
+        <h2>The second and third time, for the same reason</h2>
+        <p>
+          ADR-0010 keeps an evidentiary row per refusal for #13. This is the question of whether the
+          person-facing surface ever reads it.
+        </p>
+      </div>
+      <section class="strips" id="repeat-strips"></section>
+
+      <div class="sectionhead">
+        <h2>The whole vocabulary, in one place</h2>
+        <p>
+          Six codes, one message each, authored copy-first. There is no code without a sentence and no
+          sentence a person is not shown. The <code>Reason</code> toggle drives the surfaces above.
+        </p>
+      </div>
+      <section class="strips" id="reason-strips"></section>
+
+      <div class="readout" id="readout"></div>
+    </main>
+
+    <nav class="bar" id="bar" aria-label="Prototype controls"></nav>
+    <p class="sr" role="status" aria-live="polite" id="live"></p>
+
+    <script>
+      /* =================================================================
+         DATA
+         ================================================================= */
+
+      /* Shared strings. Every one of these is repeated identically across
+         the variants that use it at all — the variants disagree about
+         WHERE they appear and WHICH of them appear, never about wording.
+         Gender-agreement rule (CONTEXT.md): no adjective agrees with the
+         reader. Address rule: tú, and the verb belongs to the reader. */
+      const S = {
+        lede: "Tu foto todavía no está en tu perfil.",
+        human: "Una persona la revisó y hay algo que cambiar.",
+        noLoss:
+          "Tu perfil sigue igual: sales en las búsquedas y te pueden mandar propuestas. Lo único que falta es la foto.",
+        cta: "Poner otra foto",
+        ctaStep: "Terminar este paso",
+        ctaOpen: "Entrar a Encuentra",
+        landed: "Volviste desde el correo.",
+        optional:
+          "La foto nunca es obligatoria. Si prefieres dejarla así, tu perfil funciona igual de bien.",
+        mailFoot:
+          "Te escribimos porque es un mensaje del servicio, no publicidad. Estos no se pueden desactivar; los de novedades sí, en Tus datos.",
+        checklist: [
+          { hit: ["face_not_visible", "not_for_work"], text: "Que se te vea la cara." },
+          { hit: ["no_person"], text: "Que salgas tú, no tu negocio ni tu logo." },
+          { hit: ["other_people"], text: "Que no salga nadie más." },
+          { hit: ["document"], text: "Nada de cédulas, diplomas ni papeles." },
+          { hit: ["contact_visible"], text: "Sin números ni correos escritos en la imagen." },
+        ],
+      };
+
+      /* The vocabulary. `label` is the operator's English code label and is
+         chrome; every Spanish string here is the design under review.
+         `again` is what changes on a repeat of the SAME code under
+         repeat=sharper — more concrete, never sterner. */
+      const REASONS = {
+        face_not_visible: {
+          label: "Face not visible",
+          title: "No se te ve la cara.",
+          body: "Puede que esté muy oscura, muy lejos o movida. Con que se te vea de frente basta: no tiene que ser bonita ni profesional.",
+          again:
+            "Prueba de día, cerca de una ventana, con el teléfono a la altura de la cara. Sin gorra y sin gafas oscuras.",
+          fix: "La foto que subiste quedó muy oscura, muy lejos o movida. Con que se te vea la cara de frente basta.",
+        },
+        no_person: {
+          label: "Nobody in the photo",
+          title: "En la foto no hay nadie.",
+          body: "Va una foto tuya, no de tu negocio, tu herramienta ni tu logo. La cara sirve para que quien te va a contratar sepa con quién está hablando.",
+          again: "Si no tienes ninguna, pídele a alguien que te tome una ahí mismo. La del teléfono sirve.",
+          fix: "Lo que subiste no tiene una persona. Va tu cara, no tu negocio ni tu logo.",
+        },
+        other_people: {
+          label: "Someone else in frame",
+          title: "Sale alguien más en la foto.",
+          body: "Solo podemos mostrar tu cara: la otra persona no nos dio permiso para mostrar la suya.",
+          again: "Si es la única que tienes, recórtala para que quedes solo tú, o pide que te tomen otra.",
+          fix: "En la que subiste sale alguien más, y esa persona no nos dio permiso.",
+        },
+        document: {
+          label: "A document",
+          title: "Es la foto de un documento.",
+          body: "No recibimos cédulas, diplomas ni hojas de vida. Esa la borramos apenas la vimos y no queda copia. Aquí va una foto tuya y ya.",
+          again: "Ni la cédula ni ningún papel van a servir, ninguna vez. Es solo tu cara.",
+          fix: "Lo que subiste era un documento. Ya lo borramos y no queda copia. Aquí va una foto tuya.",
+        },
+        contact_visible: {
+          label: "Contact details visible",
+          title: "Se ve un número de teléfono en la foto.",
+          body: "Tus datos de contacto se comparten cuando alguien acepta una propuesta, no antes.",
+          again: "Vuelve a subirla sin el número a la vista. Recortarla suele bastar.",
+          fix: "En la que subiste se ve un número. Tus datos se comparten cuando alguien acepta una propuesta, no antes.",
+        },
+        not_for_work: {
+          label: "Not for a work profile",
+          title: "No podemos mostrar esta foto en un perfil de trabajo.",
+          body: "Pon otra donde se te vea la cara.",
+          /* Deliberately identical: there is nothing further to say, and
+             ADR-0010 gives the operator no free text to say it with. */
+          again: "Pon otra donde se te vea la cara.",
+          fix: "Esa no la podemos mostrar en un perfil de trabajo. Pon otra donde se te vea la cara.",
+        },
+      };
+
+      const REASON_KEYS = Object.keys(REASONS);
+
+      const VARIANTS = {
+        A: {
+          name: "Email carries it",
+          blurb:
+            "The email is the surface of record: subject, reason, guidance and the button, all in the inbox. The app keeps one quiet line, because the person who read the email already knows. Bets that the inbox is where people actually are, and that someone who never opens the site again still learns what happened.",
+          flaw: "The reason is a sentence about somebody's face, sent in clear text to a mailbox that may be shared, archived by Google forever, and impossible for us to delete. ADR-0010 destroys the rejected bytes within seconds; this email outlives them by years.",
+          mailSubject: "Tu foto todavía no está en tu perfil",
+          mailShowsReason: true,
+          homeShape: "line",
+          screenBanner: "reason",
+        },
+        B: {
+          name: "App carries it, email knocks",
+          blurb:
+            "The email says nothing at all beyond that something is waiting — no reason, no photo, no detail. Everything is inside the session. Bets that nothing about a person's face may leave a channel we control and can delete.",
+          flaw: "A vague “come and look at your account” email with a link is the exact shape of the impersonation attack ADR-0026 just spent a sentence closing — and it is the one email of ours a careful person is right to distrust. It also gets the lowest open rate of the three.",
+          mailSubject: "Hay algo pendiente en tu perfil de Encuentra",
+          mailShowsReason: false,
+          homeShape: "card",
+          screenBanner: "reason",
+        },
+        C: {
+          name: "No verdict, just an unfinished step",
+          blurb:
+            "There is no refusal anywhere: no notice, no “una persona la revisó”, no event with a name. The email and the home both say the step is not finished and what to change, and the screen carries the guidance inline. Bets that a verdict reads as a verdict however kindly it is worded, so the answer is to not hold a trial.",
+          flaw: "A human did look at this person's face, and this variant never says so. That is the one true operational fact the platform has (ADR-0026's band item 2), it is what ADR-0010's art. 12 disclosure promised would be said plainly, and burying it under “step incomplete” is the product being tactful about something the person has a right to know.",
+          mailSubject: "Te falta un paso para poner tu foto",
+          mailShowsReason: "fix",
+          homeShape: "step",
+          screenBanner: "checklist",
+        },
+      };
+
+      const TOGGLES = {
+        reason: { label: "Reason", values: REASON_KEYS, display: (v) => REASONS[v].label },
+        approve: { label: "Approve", values: ["told", "silent"], display: (v) => v },
+        late: { label: "3-day miss", values: ["told", "silent"], display: (v) => v },
+        repeat: { label: "Repeat", values: ["sharper", "same", "escalates"], display: (v) => v },
+      };
+
+      const DEFAULTS = { variant: "A", reason: "face_not_visible", approve: "told", late: "told", repeat: "sharper" };
+
+      /* =================================================================
+         STATE
+         ================================================================= */
+
+      function readState() {
+        const p = new URLSearchParams(location.search);
+        const s = { ...DEFAULTS };
+        if (VARIANTS[p.get("variant")]) s.variant = p.get("variant");
+        for (const [key, t] of Object.entries(TOGGLES)) {
+          if (t.values.includes(p.get(key))) s[key] = p.get(key);
+        }
+        return s;
+      }
+
+      let state = readState();
+
+      function setState(patch, announce) {
+        state = { ...state, ...patch };
+        const p = new URLSearchParams();
+        p.set("variant", state.variant);
+        for (const key of Object.keys(TOGGLES)) p.set(key, state[key]);
+        history.replaceState(null, "", `${location.pathname}?${p}`);
+        render();
+        if (announce) document.getElementById("live").textContent = announce;
+      }
+
+      /* =================================================================
+         HELPERS
+         ================================================================= */
+
+      const el = (html) => {
+        const t = document.createElement("template");
+        t.innerHTML = html.trim();
+        return t.content.firstElementChild;
+      };
+
+      const esc = (s) =>
+        String(s).replace(
+          /[&<>"]/g,
+          (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
+        );
+
+      function surface(tag, inner) {
+        return `<article class="surface"><div class="surface__tag">${esc(tag)}</div><div class="surface__body">${inner}</div></article>`;
+      }
+
+      function checklistHtml(reasonKey, highlight) {
+        return `<ul class="checklist">${S.checklist
+          .map(
+            (item) =>
+              `<li data-hit="${highlight && item.hit.includes(reasonKey)}"><span aria-hidden="true">·</span><span>${esc(item.text)}</span></li>`,
+          )
+          .join("")}</ul>`;
+      }
+
+      /* Under repeat=sharper the SAME code arriving a second time swaps in
+         the more concrete guidance. Under same it never changes. Under
+         escalates the surface starts counting, which is the version this
+         file exists to make look as bad as it is. */
+      function reasonBlock(reasonKey, attempt, mode) {
+        const r = REASONS[reasonKey];
+        const second = attempt >= 2;
+        let extra = "";
+        if (second && mode === "sharper") {
+          extra = `<p class="reason__again">${esc(r.again)}</p>`;
+        }
+        if (second && mode === "escalates") {
+          extra = `<p class="reason__again"><strong>Es la ${attempt === 2 ? "segunda" : "tercera"} foto que no podemos mostrar.</strong> Si la próxima tampoco sirve, vamos a tener que revisar tu cuenta.</p>`;
+        }
+        return `<div class="reason"><p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p>${extra}</div>`;
+      }
+
+      /* =================================================================
+         SURFACE RENDERERS
+         ================================================================= */
+
+      function renderMail(v, reasonKey) {
+        const r = REASONS[reasonKey];
+        let body = "";
+
+        if (v.mailShowsReason === true) {
+          body = `
+            <p class="lede">${esc(S.lede)}</p>
+            <p class="para">${esc(S.human)}</p>
+            ${reasonBlock(reasonKey, 1, state.repeat)}
+            <p class="para para--muted">${esc(S.noLoss)}</p>
+            <a class="btn" href="#">${esc(S.cta)}</a>`;
+        } else if (v.mailShowsReason === "fix") {
+          body = `
+            <p class="lede">Todavía no tienes foto en tu perfil.</p>
+            <p class="para">${esc(r.fix)}</p>
+            <p class="para para--muted">${esc(S.noLoss)}</p>
+            <a class="btn" href="#">${esc(S.ctaStep)}</a>`;
+        } else {
+          body = `
+            <p class="lede">Hay algo pendiente en tu perfil.</p>
+            <p class="para">Entra y te contamos qué es. No es nada urgente y no perdiste nada.</p>
+            <a class="btn" href="#">${esc(S.ctaOpen)}</a>`;
+        }
+
+        return surface(
+          "1 · The email, as it lands",
+          `<div class="mail__meta">
+             <p class="mail__from">Encuentra &lt;hola@encuentra.co&gt; → tú</p>
+             <p class="mail__subject">${esc(v.mailSubject)}</p>
+           </div>
+           ${body}
+           <p class="mail__foot">${esc(S.mailFoot)}</p>`,
+        );
+      }
+
+      function renderHome(v, reasonKey) {
+        let block = "";
+
+        if (v.homeShape === "line") {
+          block = `
+            <div class="card">
+              <p style="font-weight:700">Tu perfil</p>
+              <p class="para para--muted">Auxiliar de cocina · Pereira · 7 habilidades</p>
+              <p class="quiet">Tu foto no está puesta. <a href="#">${esc(S.cta)}</a></p>
+            </div>`;
+        } else if (v.homeShape === "card") {
+          block = `
+            <div class="card card--attention">
+              <div class="withthumb">
+                <div class="thumb" aria-hidden="true"></div>
+                <div>
+                  <p class="lede">${esc(S.lede)}</p>
+                  <p class="para">${esc(S.human)}</p>
+                </div>
+              </div>
+              ${reasonBlock(reasonKey, 1, state.repeat)}
+              <p class="para para--muted">${esc(S.noLoss)}</p>
+              <a class="btn" href="#">${esc(S.cta)}</a>
+            </div>`;
+        } else {
+          block = `
+            <div class="card card--attention">
+              <p class="lede">Te falta la foto.</p>
+              <p class="para">${esc(REASONS[reasonKey].fix)}</p>
+              <a class="btn" href="#">${esc(S.ctaStep)}</a>
+            </div>`;
+        }
+
+        return surface(
+          "2 · The signed-in home",
+          `<div class="phone__top">
+             <span class="phone__wordmark">Encuentra</span>
+             <span class="phone__nav">Propuestas · Tu perfil</span>
+           </div>
+           ${block}`,
+        );
+      }
+
+      function renderScreen(v, reasonKey) {
+        const banner =
+          v.screenBanner === "reason"
+            ? `<p class="para para--muted">${esc(S.landed)}</p>${reasonBlock(reasonKey, 1, state.repeat)}`
+            : "";
+
+        return surface(
+          "3 · The screen the link opens · /perfil/foto",
+          `<div class="phone__top">
+             <span class="phone__wordmark">Encuentra</span>
+             <span class="phone__nav">Tu foto</span>
+           </div>
+           <p class="lede">Tu foto</p>
+           ${banner}
+           <p class="para para--muted" style="margin-top:var(--space-4)">Lo que sirve:</p>
+           ${checklistHtml(reasonKey, v.screenBanner === "checklist")}
+           <div class="dropzone">Toca para escoger una foto<br />o tómate una ahora</div>
+           <div class="btnrow">
+             <a class="btn btn--equal" href="#">${esc(S.cta)}</a>
+             <a class="btn btn--equal btn--ghost" href="#">Ahora no</a>
+           </div>
+           <p class="note">${esc(S.optional)}</p>`,
+        );
+      }
+
+      /* =================================================================
+         COMPARISON STRIPS
+         ================================================================= */
+
+      function strip(tag, active, inner, note) {
+        return `<article class="strip" data-active="${active}"><p class="strip__tag">${esc(tag)}</p>${inner}${
+          note ? `<p class="note">${note}</p>` : ""
+        }</article>`;
+      }
+
+      function renderApprove() {
+        const told = `
+          <div class="card card--good">
+            <p class="lede">Tu foto ya está en tu perfil.</p>
+            <p class="para">Una persona la revisó. Ahora la ve quien entre a tu perfil.</p>
+            <p class="para para--muted">Si algún día la quieres quitar, se quita en un toque.</p>
+          </div>`;
+        const silent = `
+          <div class="card">
+            <p class="para para--muted" style="margin-top:0">Nada. La foto aparece en el perfil y el aviso de
+            <em>en revisión</em> deja de estar. Quien no vuelva a entrar nunca se entera.</p>
+          </div>`;
+
+        return (
+          strip(
+            "approve · told",
+            state.approve === "told",
+            told,
+            "Says the human looked, which is the one true fact the product has — and it is the moment to say it, because the same sentence on a profile would make a profile without a Photo second-class (ADR-0026). No celebration and no badge: <b>there is nothing to earn here.</b> The last line is ADR-0010 rule 5 — publication is never a licence, so leaving must be one tap and visible.",
+          ) +
+          strip(
+            "approve · silent",
+            state.approve === "silent",
+            silent,
+            "Cheapest, and defensible: an approval is not news. But it leaves the person who was told <em>menos de 3 días</em> with no way to learn the answer except by coming back to check, and <b>ADR-0025's whole argument is that people do not come back.</b>",
+          )
+        );
+      }
+
+      function renderLate() {
+        const told = `
+          <div class="card card--late">
+            <p class="lede">Tu foto sigue en revisión.</p>
+            <p class="para">Dijimos que menos de 3 días y no cumplimos. No se perdió y no tienes que hacer nada.</p>
+            <p class="para para--muted">${esc(S.noLoss)}</p>
+          </div>`;
+        const silent = `
+          <div class="card">
+            <p class="para" style="margin-top:0"><strong>La está revisando una persona.</strong></p>
+            <p class="para para--muted">The pending card silently drops <em>“suele tardar menos de 3 días”</em> once
+            the third day passes, and no message is sent.</p>
+          </div>`;
+
+        return (
+          strip(
+            "late · told",
+            state.late === "told",
+            told,
+            "Names the miss instead of letting it pass, and <b>gives no new date</b> — a second promise we might also miss is worse than none. Costs one email per person per backlog, and email is effectively free (#6).",
+          ) +
+          strip(
+            "late · silent",
+            state.late === "silent",
+            silent,
+            "The honest version of silence still has to edit the pending card, because leaving <em>menos de 3 días</em> on screen on day five is the product asserting something false. Once you accept that edit, <b>the person can see we missed it and we still have not said so.</b>",
+          )
+        );
+      }
+
+      function renderRepeat() {
+        const r = REASONS[state.reason];
+        const shell = (inner) => `<div class="card">${inner}</div>`;
+
+        return (
+          strip(
+            "repeat · sharper",
+            state.repeat === "sharper",
+            shell(
+              `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p><p class="reason__again">${esc(r.again)}</p>`,
+            ),
+            "Same tone, more concrete guidance when the <em>same</em> code repeats. Treats a second refusal as our failure to explain rather than the person's failure to comply — and it is the only one of the three that makes the second attempt more likely to work.",
+          ) +
+          strip(
+            "repeat · same",
+            state.repeat === "same",
+            shell(
+              `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p>`,
+            ),
+            "Word-for-word identical, forever. Purest reading of ADR-0013 — the evidentiary rows are for the operator and nothing accumulates where the person can see it — but it repeats guidance that has already failed once.",
+          ) +
+          strip(
+            "repeat · escalates",
+            state.repeat === "escalates",
+            shell(
+              `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p><p class="reason__again"><strong>Es la tercera foto que no podemos mostrar.</strong> Si la próxima tampoco sirve, vamos a tener que revisar tu cuenta.</p>`,
+            ),
+            "<b>Look at this one and then reject it.</b> It is the platform keeping score against somebody's face, it threatens an account over a Purpose that can never be required (ADR-0007), and ADR-0013 refused accumulation-triggered action for the whole product.",
+          )
+        );
+      }
+
+      function renderReasons() {
+        return REASON_KEYS.map((k) => {
+          const r = REASONS[k];
+          return strip(
+            `${k} · ${r.label}`,
+            state.reason === k,
+            `<p class="reason__title">${esc(r.title)}</p><p class="reason__body">${esc(r.body)}</p>`,
+            k === "not_for_work"
+              ? "The only one that does not tell you what to change, and the one the whole vocabulary is shaped around. It states what <em>we</em> cannot do, never what the image is — <b>and the operator has no free text to elaborate with.</b>"
+              : k === "document"
+                ? "Says the bytes are already gone, because photographing your cédula and sending it to a website is the thing that will frighten a person most, and ADR-0010 makes the reassurance true."
+                : k === "contact_visible"
+                  ? "Repeats the mechanic and never the format, which is ADR-0026's rule for the prose refusal, applied to an image."
+                  : null,
+          );
+        }).join("");
+      }
+
+      /* =================================================================
+         BAR + READOUT
+         ================================================================= */
+
+      function renderBar() {
+        const keys = Object.keys(VARIANTS);
+        const i = keys.indexOf(state.variant);
+        const v = VARIANTS[state.variant];
+
+        let html = `
+          <div class="bar__group">
+            <button data-step="-1" aria-label="Previous variant">←</button>
+            <span class="bar__variant">${esc(state.variant)} — ${esc(v.name)}</span>
+            <button data-step="1" aria-label="Next variant">→</button>
+          </div>`;
+
+        for (const [key, t] of Object.entries(TOGGLES)) {
+          html += `<div class="bar__group"><span class="bar__label">${esc(t.label)}</span>${t.values
+            .map(
+              (val) =>
+                `<button data-toggle="${key}" data-value="${esc(val)}" aria-pressed="${state[key] === val}">${esc(t.display(val))}</button>`,
+            )
+            .join("")}</div>`;
+        }
+
+        html += `<div class="bar__group"><button data-reset="1">Reset</button></div>`;
+
+        const bar = document.getElementById("bar");
+        bar.innerHTML = html;
+
+        bar.querySelectorAll("[data-step]").forEach((b) =>
+          b.addEventListener("click", () => {
+            const next = keys[(i + Number(b.dataset.step) + keys.length) % keys.length];
+            setState({ variant: next }, `Variant ${next}, ${VARIANTS[next].name}`);
+          }),
+        );
+        bar.querySelectorAll("[data-toggle]").forEach((b) =>
+          b.addEventListener("click", () =>
+            setState({ [b.dataset.toggle]: b.dataset.value }, `${b.dataset.toggle} ${b.dataset.value}`),
+          ),
+        );
+        bar.querySelector("[data-reset]").addEventListener("click", () =>
+          setState({ ...DEFAULTS }, "Reset to defaults"),
+        );
+      }
+
+      function renderReadout() {
+        const v = VARIANTS[state.variant];
+        const r = REASONS[state.reason];
+        document.getElementById("readout").innerHTML = `
+          <b>state</b>  variant=${state.variant} · reason=${state.reason} · approve=${state.approve} · late=${state.late} · repeat=${state.repeat}<br />
+          <b>news lives</b>  ${v.mailShowsReason === true ? "in the inbox" : v.mailShowsReason === "fix" ? "split: the fix travels, the verdict does not exist" : "inside the session only"}<br />
+          <b>reason leaves our systems</b>  ${v.mailShowsReason === false ? "no" : "yes — in an email we can never delete"}<br />
+          <b>the word “revisó” is said</b>  ${v.mailShowsReason === "fix" ? "nowhere" : "yes"}<br />
+          <b>what survives the refusal</b>  person_id · reason_code=${state.reason} · created_at — and no image (ADR-0010)<br />
+          <b>purpose carrying the send</b>  transactional_messages (required, ADR-0007) — never news, and never gated on the photo purpose<br />
+          <b>copy shown</b>  “${esc(r.title)}”`;
+      }
+
+      /* =================================================================
+         RENDER
+         ================================================================= */
+
+      function render() {
+        const v = VARIANTS[state.variant];
+        document.getElementById("variant-blurb").textContent = v.blurb;
+        document.getElementById("surfaces").innerHTML =
+          renderMail(v, state.reason) + renderHome(v, state.reason) + renderScreen(v, state.reason);
+        document.getElementById("variant-flaw").innerHTML =
+          `<div class="flaw"><b>${esc(state.variant)}'s visible flaw</b>${esc(v.flaw)}</div>`;
+        document.getElementById("approve-strips").innerHTML = renderApprove();
+        document.getElementById("late-strips").innerHTML = renderLate();
+        document.getElementById("repeat-strips").innerHTML = renderRepeat();
+        document.getElementById("reason-strips").innerHTML = renderReasons();
+        renderBar();
+        renderReadout();
+      }
+
+      document.addEventListener("keydown", (e) => {
+        const tag = document.activeElement?.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || document.activeElement?.isContentEditable) return;
+        if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+        const keys = Object.keys(VARIANTS);
+        const next =
+          keys[(keys.indexOf(state.variant) + (e.key === "ArrowRight" ? 1 : -1) + keys.length) % keys.length];
+        setState({ variant: next }, `Variant ${next}, ${VARIANTS[next].name}`);
+      });
+
+      render();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Resolves **#29 — How a person learns their photo was refused, and comes back**, on the wayfinder map #1.

**ADR-0027**, plus the prototype at `docs/design/photo-refusal-prototype/`.

```sh
open docs/design/photo-refusal-prototype/index.html
```

## The two decisions that carry the rest

**The vocabulary is authored copy-first.** ADR-0010 fixes that a refusal carries a code and forbids operator prose, but never says what the codes are — it handed them to #13, which declined them. Written sentence-first rather than code-first, **five of six causes turn out to be facts about a file**, so _"tu foto fue rechazada"_ never has to be written. The sixth, `not_for_work`, is the only code that does not say what to change, and ADR-0010's no-free-text rule is what makes that survivable.

**The email carries the imperative, the app carries the diagnosis.** Each message has two halves — a diagnosis, which is a proposition about the reader, and an imperative, which is a rule true of everybody. Only the second is safe to leave permanently in a mailbox we can never reach. A per-code channel policy was rejected because **differential treatment leaks the thing it protects**, so `not_for_work` and `face_not_visible` share one imperative word for word.

## Also settled

Approval gets a message and it is not a congratulation · the missed 3 days get one with no new date · a repeat gets sharper guidance, never a count · `transactional_messages` carries the send · `impersonation` and `underage` are not photo codes, so a Review has two exits.

## Amendments

- **ADR-0010** — the vocabulary is authored here, not inherited by #13.
- **ADR-0026** — the no-placeholder rule governs surfaces showing a Person to *somebody else*, not the owner's own Photo screen. The two must never be quoted at each other.
- **ADR-0015** — extended, not amended: it named "a Photo approved" as a candidate trigger for a notification system, and the condition fails.
- **`CONTEXT.md`** — Photo Review gains its two exits.

## Surfaced and not fixed

**No email of ours survives an erasure.** Not a photo problem — ADR-0015's Offer mail reveals far more than any string here — so it went to the map's fog against the notifications lane rather than being solved in the wrong place.

Closes #29.