### PR TITLE
doc(adr): the scheduler runs off the machine and holds only a URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,48 @@ implements, so the real gate command runs green today and needs no edit when the
 CI also needs `TURBO_SCM_BASE=origin/dev` — `--affected` compares against `main`/`master`, never the
 configured default branch.
 
+### Scheduled work
+
+Decided in **ADR-0028**, not yet built. **Nothing runs on the Fly machine's own clock** — no
+`setInterval`, no `node-cron`, no Fly scheduled Machine. The schedule lives on **trigger.dev Cloud**,
+because production's `auto_stop_machines = "off"` hides that staging suspends and `bluegreen` briefly
+runs two machines, so a timer that works in production fires never in staging and twice on every
+release.
+
+Deploy order becomes `migrate → trigger.dev deploy → flyctl deploy`, all in one job, one gate.
+
+**Two rules that are not style preferences:**
+
+- **No personal data ever crosses to trigger.dev.** A task passes a job name; the drainer's fast path
+  passes an outbox row id. trigger.dev stores payloads and outputs for up to 14 days, so anything else
+  makes it an _encargado_ needing a `2.2.2.25.5.2` _contrato de transmisión_ and a register entry
+  disclosing its 27 subprocessors — two of them generative-AI vendors.
+- **A task holds a URL and a secret, never a database connection.** It does
+  `POST /api/jobs/<name>`; the work runs in the app. A task with its own connection would sit outside
+  both of ADR-0017's testing seams, making a compliance control and the erasure net untestable by this
+  repo's own rules. The endpoint does **bounded work per call and reports whether more remains**.
+
+Five jobs, four obligations (**ADR-0015** drainer, **ADR-0020** deadline monitor, **ADR-0010** R2
+sweep, **ADR-0021** retention purges) plus the drainer's backstop. Logic lives where it falls —
+`@repo/db` (purges, reflective and **leaf-first** over a topological order), `@repo/people` (sweep),
+`@repo/consent` (deadline), and a use case for the drainer, which is the only cross-module one.
+**There is no `@repo/jobs`**: ADR-0006 already rejected that shape as a "data rights" module.
+
+**The drainer specifically.** Claim with `FOR UPDATE SKIP LOCKED` **inside the sending transaction** —
+**there is no `claimed_at` column**, so a killed machine releases its locks and recovers with no
+timeout to tune. `tasks.trigger()` after commit is an optimisation; the row is the truth and a
+five-minute sweep is the backstop. **The `attempts` column is the only retry authority** — trigger.dev's
+own retry is off for this job and bounded-on for the other four, which keep no state of their own.
+
+**Report a failed send to Sentry once**, when the row exhausts its retries — never per attempt. Sentry
+Developer allows 5,000 errors/month and a row retried every five minutes produces 8,640, so one poison
+row would hide every other error in the product. Per-attempt detail goes in `last_error`.
+
+**Every job pings Healthchecks.io; only the deadline monitor escalates** (Pushover Emergency). Sentry
+answers _why did it break_, Healthchecks.io answers _did it run at all_ — Sentry cannot see a job that
+never started — and UptimeRobot answers _is the site up_. A watchdog must never share a failure mode
+with the alarm it guards, which is why the operator email rides the outbox and the switch does not.
+
 ### Testing
 
 Decided in **ADR-0017**, not yet built. Vitest 4, one `vitest.config.ts` per package, registered as a

--- a/docs/adr/0010-profile-photos-as-consented-sensitive-data.md
+++ b/docs/adr/0010-profile-photos-as-consented-sensitive-data.md
@@ -211,6 +211,12 @@ key with no surviving Person. Keys are derived from the person identifier so tha
 detectable without a database row to join against. The sweep is what makes the guarantee real rather
 than hopeful — without it, erasure depends on a network call that can fail.
 
+> **Scheduled by ADR-0028.** The sweep is an exported function in **`@repo/people`** — this ADR puts the
+> Photo on the Person, and key derivation means it needs `persons` and R2 and nothing else — run daily
+> from a trigger.dev schedule over an authenticated callback, and pinging Healthchecks.io so that a
+> sweep which stops running is noticed. It does **bounded work per invocation and reports whether more
+> remains**, because a full bucket listing must not outlive an HTTP timeout.
+
 This resembles the map's _"side effects that must not roll back"_ fog, but it is the **mirror image**:
 there the side effect escapes a rollback, here it must survive a commit. It does not resolve that
 patch.

--- a/docs/adr/0015-the-offer-as-an-immutable-snapshot.md
+++ b/docs/adr/0015-the-offer-as-an-immutable-snapshot.md
@@ -250,6 +250,22 @@ than one machine.
 This graduates the map's _"side effects that must not roll back"_ fog, which named #9 and #15 and
 left it to whichever settled first.
 
+> **Completed by ADR-0028 — a use case, woken twice, with the row as the only authority.** The drainer
+> is a use case in `apps/web/src/use-cases/`, reached over an authenticated callback from a trigger.dev
+> schedule that holds no personal data. Two things this ADR left open are decided there and neither is
+> what a reader would assume.
+>
+> **There is no `claimed_at` column.** The claim is `FOR UPDATE SKIP LOCKED` inside the sending
+> transaction, so a machine killed mid-drain releases its locks on disconnect and the rows recover with
+> no timeout to tune. That is this ADR's own instinct for _frozen_ applied one level down: a stored flag
+> needs a write to set it and a write to clear it.
+>
+> **`tasks.trigger()` after commit is an optimisation, never the mechanism.** A network call after
+> commit can fail — which is the reason this ADR wrote the row — so a five-minute sweep backs it up, and
+> the row's `attempts` column is the **sole** retry authority. trigger.dev's own retry is switched off
+> for exactly the reason this ADR refused a `notifications` table: two counters for one send is two
+> sources of truth.
+
 ## Consequences
 
 - **ADR-0011 amended**: _frozen_ is derived from `persons.status`, not a stored Offer status.

--- a/docs/adr/0020-data-subject-requests-and-the-business-day-clock.md
+++ b/docs/adr/0020-data-subject-requests-and-the-business-day-clock.md
@@ -289,6 +289,20 @@ trusted.
 **This ADR specifies what must alarm; #15 owns scheduling it.** Naming the split so it does not fall
 between the two tickets.
 
+> **Completed by ADR-0028, which adds a requirement this ADR did not state.** The job runs daily on
+> trigger.dev Cloud rather than on the machine — so _"ADR-0005's single machine makes a silent cron
+> failure entirely plausible"_ stops being the hazard, and the switch guards the vendor instead.
+> Pinned to **`America/Bogota`**: a UTC midnight run is 7pm the previous day in Bogotá, so a
+> business-day boundary computed in UTC is off by one for part of every day, against the one clock
+> where off-by-one is the whole failure.
+>
+> The added requirement: **a dead man's switch may not share a failure mode with the alarm it
+> guards.** This job's output is an email to the operator, riding ADR-0015's outbox like every other
+> send. A watchdog that also alerted by email would let one mail-path failure take out both the alarm
+> and the thing it watches — so the switch escalates through **Pushover Emergency**, a different vendor
+> on a different channel. It is the only job in the repository that escalates rather than emails, and
+> Sentry's single included cron monitor watches it a second time.
+
 ## What this does not decide
 
 - **The erasure anchor.** `data_requests` declares itself **retained as evidence** — required by

--- a/docs/adr/0021-erasure-a-real-delete-and-no-memory-of-a-ban.md
+++ b/docs/adr/0021-erasure-a-real-delete-and-no-memory-of-a-ban.md
@@ -223,6 +223,17 @@ not change with the number; the number is one constant in one file.
 deadline alarm. Each is a delete over one table against its declared term, and each pings
 Healthchecks.io so that a job which stops running alarms too.
 
+> **Completed by ADR-0028, with one correction to the shape.** Scheduled daily on trigger.dev Cloud,
+> reached over an authenticated callback, pinging Healthchecks.io as this ADR requires. The purge is a
+> single reflective function in **`@repo/db`**, reading the declarations this section puts beside each
+> table — so a new table is purged without anyone remembering to add a job, which is the property
+> ADR-0017's erasure invariant already bought.
+>
+> The correction: _"a delete over one table"_ understates it. Under ADR-0008's `RESTRICT` default the
+> reflection needs a **topological order** over the foreign keys and must delete **leaf-first**, exactly
+> as the erasure sequence below does. A flat list of tables would fail on the first table anything else
+> references.
+
 ## The erasure sequence
 
 **Erasure is immediate. There is no grace period.** A scheduled-delete row is data we were told to

--- a/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
+++ b/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
@@ -278,6 +278,22 @@ the §6.3 processor register.
   reconciliation sweep), and the production public edge (CDN, ADR-0011's Wall cache and purge,
   ADR-0014's edge limiter, and ADR-0009's persisted credential limiter with the Redis-versus-
   `"database"` cost ADR-0013 flagged as never priced).
+
+  > **The first is resolved by ADR-0028, and it adds a third participant to this pipeline.** Scheduled
+  > work runs on trigger.dev Cloud, so `deploy.yml` becomes
+  > `migrate → trigger.dev deploy → flyctl deploy` — one gate, three steps. That is a **second
+  > artifact**, against this ADR's one-artifact spine, and the cost is smaller than it looks: a task
+  > file contains nothing but an authenticated `fetch()` into the app, so the trigger.dev bundle
+  > **imports no domain code and no schema** and has nothing to be stale about. ADR-0024's
+  > expand/contract count is unchanged.
+  >
+  > Two consequences for this ADR specifically. The `fly.toml` files need no edit — nothing depends on
+  > `auto_stop_machines`, and staging's suspended machine is **woken by the callback** because
+  > `auto_start_machines = true`, which is how these jobs get exercised against a real managed Postgres
+  > at all. And `bluegreen` needs no double-fire guard: one HTTP request reaches one machine, so the
+  > _"what breaks when there are two"_ question this ADR handed forward dissolved rather than got
+  > answered.
+
 - **`docs/runbook.md` exists and `CLAUDE.md` points at it.** It is written for an agent to execute.
 - **The art. 17(k) _manual interno_ stays out of the runbook, deliberately.** ADR-0020 observed that
   _"#27 owns the retention schedule, #15 owns the runbook, neither owns this"_. It is a legal

--- a/docs/adr/0028-the-scheduler-runs-off-the-machine-and-holds-only-a-url.md
+++ b/docs/adr/0028-the-scheduler-runs-off-the-machine-and-holds-only-a-url.md
@@ -1,0 +1,393 @@
+# The scheduler runs off the machine and holds only a URL
+
+Issue #47 asked what runs on a schedule, where it runs given ADR-0022's one long-lived Fly machine,
+and what breaks the day there are two. Four obligations were routed here rather than to #15 because
+they share a question none of their parent ADRs asked.
+
+The third question turned out to be the one worth answering, and answering it **dissolved** the other
+two rather than solving them. Once the scheduler is not on the machine and the job arrives as an HTTP
+request, "what happens when there are two machines" has no content: the request reaches one of them.
+There is no leader election in this ADR, and that absence is the decision.
+
+ADR-0022 owns the environments and the pipeline. ADR-0024 owns what the pipeline does to the
+database. This ADR owns what runs when nobody is looking.
+
+## The four obligations
+
+| Obligation                  | Fixed by | What it is                                                                         |
+| --------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| **Outbox drainer**          | ADR-0015 | Every notification is a row written inside the transaction; something must send it |
+| **Deadline monitor**        | ADR-0020 | Daily: open requests due within five business days, emailed to the operator        |
+| **R2 reconciliation sweep** | ADR-0010 | Lists the bucket, drops every object whose Person is gone — the net under erasure  |
+| **Retention purges**        | ADR-0021 | Deletes rows past the term declared beside each table                              |
+
+Two of the four are compliance controls rather than housekeeping. ADR-0020 is explicit that a lapsed
+clock is the event that opens the SIC's door under art. 16, and ADR-0010 is explicit that the sweep is
+_"what makes the guarantee real rather than hopeful"_. That is why this ADR spends more of its length
+on how a failure becomes visible than on how the work gets done.
+
+## The scheduler is trigger.dev Cloud, because every alternative lives on the machine
+
+The candidates #47 named, each checked rather than assumed:
+
+**In-process timers.** Production is `auto_stop_machines = "off"` with `min_machines_running = 1`, so
+timers genuinely would run there — this is not the obvious non-starter it looks like. It fails on the
+other two environments instead. Staging is `auto_stop_machines = "suspend"` with
+`min_machines_running = 0`, so timers would **never fire in the one environment ADR-0022 keeps
+specifically because ADR-0017 declines to test PlanetScale at all**. And `strategy = "bluegreen"`
+brings up a second machine on every release, so every deploy double-fires every timer. A crash-restart
+silently resets the interval, and nothing anywhere records that a run was missed.
+
+**GitHub Actions `schedule`.** Free and unlimited on a public repository, adds no vendor, and runs on
+the same runner that already holds the `migrator` credential — genuinely attractive. It fails on the
+documented behaviour: the minimum interval is **5 minutes**, the event _"can be delayed during periods
+of high loads […] some queued jobs may be dropped"_, and in a public repository **scheduled workflows
+are automatically disabled after 60 days with no repository activity**. For a solo developer on a
+flexible timeline a 60-day quiet spell is ordinary, and the failure is silent disarmament of a
+compliance control. Dropped runs are survivable; auto-disablement is not.
+
+**Fly scheduled Machines.** `--schedule` accepts only a _fuzzy_ `hourly`, `daily`, `weekly` or
+`monthly` cycle — no cron expression — and such a Machine **cannot be started by flyctl or the API**,
+so there is no way to exercise one on demand. Fuzzy is wrong for a deadline monitor and unusable for
+the drainer.
+
+**trigger.dev Cloud** is chosen because the schedule does not live on the machine at all. Everything
+above fails on the same axis: the thing that remembers when to run is co-located with the thing being
+deployed, suspended, restarted or duplicated. Moving it off is the whole decision, and the specific
+vendor is downstream of it.
+
+Facts, read 2026-08-17: Free is **$0/month plus $5 of monthly credits**, and _"you'll need to upgrade
+to keep running tasks once the included $5 of credits is used"_. It allows **10 schedules per
+project**, **1-day log retention**, and **DEV and PROD environments only**. Compute is metered — micro
+at **$0.0000169/second**, run invocation at **$0.000025** — putting our five-minute backstop and four
+daily jobs at roughly **$0.60–1.00/month** against the $5 grant. Schedules are declarative in code
+with full IANA timezone support. Self-hosting is disclaimed by its own documentation — _"we cannot
+guarantee how Trigger.dev will perform on your infrastructure. You assume all responsibility and
+risk"_ — and needs Postgres, Redis and a worker fleet, so it is out at this budget.
+
+## The payload is an id, and that is what keeps trigger.dev out of the register
+
+**No payload, argument or return value crossing to trigger.dev may contain personal data.** Jobs pass
+a job name; the drainer's fast path passes an outbox row id. Nothing else, ever.
+
+This is a rule rather than a preference because the alternative is expensive. trigger.dev **stores
+payloads and outputs** — offloaded to object storage above 512KB, with a hard 14-day run TTL — so a
+drainer payload carrying an email address and Offer terms would put personal data at rest with a new
+processor. That processor would need a _contrato de transmisión_ under `2.2.2.25.5.2` and an entry in
+the `docs/legal/` register, and **its published subprocessor list runs to 27 entries** including AWS,
+ClickHouse, Axiom, PostHog, Vercel, WorkOS and — for _"generative AI services"_ — **OpenAI and
+Anthropic**. Disclosing that accurately in a register aimed at people who have just lost their income
+is a materially different act from disclosing Cloudflare R2.
+
+It also collides with three decisions already taken. ADR-0010 bought R2 specifically because it _"adds
+no new processor"_. ADR-0014 rejected external search on **ADR-0008 grounds first** — a second copy of
+personal data outside the constraint system, with an N+1 erasure adapter. And ADR-0017's reflective
+erasure invariant finds tables by their foreign key to `persons`, so it can never enumerate a copy
+sitting in another company's object storage; that is the `verifications` hole ADR-0021 found, relocated
+off-platform where not even an explicit assertion can reach it.
+
+With the rule, trigger.dev holds a string and a `bigint`. It is a **scheduler, not an _encargado_**,
+and the register is unchanged.
+
+## The task holds a URL and a secret, not a connection
+
+A scheduled task does one thing: `POST /api/jobs/<name>` against the Fly app, authenticated by a
+shared secret compared in constant time. The work runs in the app, on the pool it already has.
+
+The alternative — giving trigger.dev a `DATABASE_URL` and letting the task do the work — was rejected
+on four independent grounds, of which the first is decisive:
+
+1. **It would put the jobs outside every testable seam.** ADR-0017 permits tests at exactly two
+   seams: a module function exported from a `@repo/*` package's `index.ts`, and a use case in
+   `apps/web/src/use-cases/`. A trigger.dev task holding its own connection is neither, so the
+   deadline monitor and the erasure net — a compliance control and a legal guarantee — would be
+   **untestable by the repository's own rules**. As a callback, all four are exercised at seams that
+   already exist, on PGlite, today.
+2. **It would be a third home for a production database credential.** ADR-0022 already states that
+   _"CI necessarily holds a production credential"_ and makes it tolerable only through `app` /
+   `migrator` role separation. A third holder needs a fourth role and a third rotation path.
+3. **PS-5's connection ceiling is unread.** ADR-0022 lists it as an open item; `observability.md` notes
+   connection exhaustion has **no PlanetScale webhook**, so _"the only defence is not causing it"_.
+   Every trigger.dev run is a fresh process and therefore a fresh connection, against a pool of 5 and
+   an unknown ceiling.
+4. **It would lose Sentry.** `observability.md` establishes that Server Actions are _"the one place the
+   integration is not automatic"_ — route handlers are instrumented by the SDK. A task running outside
+   the Next runtime reports to Sentry not at all.
+
+The callback buys one more thing that reads as an accident and is not. Staging's machine is suspended
+with `min_machines_running = 0`, but `auto_start_machines = true`, so **the HTTP request wakes it** — a
+direct-DB task would have run happily against staging's database while the application slept, never
+exercising the path that runs in production.
+
+Costs, stated: the endpoint must do **bounded work per invocation and report whether more remains**, so
+a large R2 sweep cannot outlive an HTTP timeout; and it is a privileged endpoint, whose rate limiting
+belongs to #48 with the other two limiters.
+
+## The outbox row is the claim, so an interrupted job needs no timeout
+
+The drainer claims work with `FOR UPDATE SKIP LOCKED` **inside the sending transaction**, and there is
+no `claimed_at` column.
+
+```sql
+SELECT * FROM notification_outbox
+WHERE sent_at IS NULL AND next_attempt_at <= now()
+ORDER BY created_at
+FOR UPDATE SKIP LOCKED LIMIT 20;
+```
+
+`SKIP LOCKED` is required regardless of topology, because the fast path and the backstop race **by
+design** and because blue-green briefly runs two app processes. Dropping `claimed_at` is the part worth
+arguing: a deploy that kills a machine mid-drain would leave a stored claim set and `sent_at` never
+written, stranding rows permanently — the poison-row failure arriving through the door nobody guarded.
+Letting the transaction be the claim makes recovery automatic, because a killed process releases its
+locks on disconnect, and it leaves no timeout constant to tune wrongly.
+
+This is the same instinct ADR-0015 used deriving `frozen` from `persons.status` and ADR-0020 used
+deriving the `reclamo en trámite` legend: **a stored flag needs a write to set it and a write to clear
+it, either of which can be missed or lost on a restore.** The accepted cost is that the send happens
+inside the transaction holding the lock, so a slow provider call holds row locks — bounded by
+`LIMIT 20` and acceptable at this volume. A claim timeout is the named escape hatch if it ever is not.
+
+**The wake-up path is two mechanisms with one authority.** The use case calls `tasks.trigger()` after
+commit for latency, and a **five-minute scheduled sweep** catches rows whose trigger call failed. The
+trigger is an optimisation; the row is the truth. That keeps ADR-0015's guarantee exactly as written —
+a network call after commit can fail, which is why the row exists — and gives the sweep a second job
+as the poison-row detector.
+
+## trigger.dev may retry a job that keeps no record of itself, and never one that does
+
+- **Drainer: trigger.dev retries off.** The `attempts` and `next_attempt_at` columns are the only
+  retry authority. Two retry counters for one send is two sources of truth, which is the argument
+  ADR-0015 used refusing a `notifications` table and ADR-0013 used refusing a Redis counter.
+- **The three scheduled jobs: bounded retries on**, three attempts with backoff. They hold no state of
+  their own, so a single failed callback means the job silently does not run until Healthchecks.io
+  reports it — a slow alarm for a statutory deadline.
+
+## One retry loop can drain three separate budgets
+
+This is the finding that most changed the design, and none of the parent ADRs could have seen it
+because each budget belongs to a different vendor.
+
+| Budget              | Limit                         | What an unbounded retry does                                                            |
+| ------------------- | ----------------------------- | --------------------------------------------------------------------------------------- |
+| trigger.dev credits | **$5/month**, then tasks stop | Exhausts the grant and **silently disarms the deadline monitor**                        |
+| Sentry errors       | **5,000/month**               | One poison row retried every 5 minutes is **8,640 errors/month** — 1.7× the whole quota |
+| Operator attention  | one person                    | Trains them to ignore the channel the compliance control uses                           |
+
+So retries are bounded for three reasons that happen to coincide, and two rules follow:
+
+- **A failed attempt is recorded in `last_error`. Sentry is told exactly once**, at the transition to
+  poison — never per attempt. Our own column costs no quota, and it outlives trigger.dev's one-day
+  free-tier log retention, which is also why that retention limit does not bind us.
+- **Concurrency is capped explicitly**, so a storm cannot reach $5 before anyone notices.
+
+ADR-0004 chose PlanetScale for _"budget certainty over lowest expected cost"_. A metered credit that
+stops the platform is the opposite shape, and this ADR accepts it **as a named, monitored exception**
+with a $10/month Hobby plan as the escape hatch — not as a surprise anybody discovers during an
+incident. It is the first vendor in this stack whose failure mode is billing.
+
+## Rejected: Redis Pub/Sub
+
+Raised while working the ticket, and rejected on architecture rather than cost.
+
+It cannot be the durability story: Pub/Sub has **no persistence**, so publishing with no subscriber
+connected loses the message permanently — precisely the failure ADR-0015 wrote the outbox row to
+survive. So it could only replace the _poll_, which is the role `tasks.trigger()` already fills for
+free. In that role it is worse three ways:
+
+1. **It needs a long-lived TCP subscriber.** Pub/Sub is excluded from Upstash's REST and GraphQL
+   interfaces because those are request-based rather than connection-based. That subscriber lives on
+   the Fly machine — so the wake-up mechanism moves straight back onto the machine this ADR exists to
+   get off, dying under staging's `suspend` and doubling under blue-green.
+2. **The outbox table is already the durable queue.** `FOR UPDATE SKIP LOCKED` over Postgres is a
+   queue. Redis in front of it is a queue in front of a queue, and a Redis Streams version is worse
+   still — a second durable record of one pending send.
+3. **#48 owns whether Redis enters the stack at all**, including the Redis-versus-`"database"` cost
+   ADR-0013 flagged as never priced. Deciding it here pre-empts a live ticket.
+
+Two things stated in Redis's favour, so the record is honest. Cost is **not** the objection — Upstash
+Free is 500K commands/month. And **ADR-0016's refusal does not reach this case**: that argument was
+about a _cached list_ surfacing a Paused, Suspended or Blocked Person, and a channel carrying a row id
+caches nothing. Redis is not banned by this ADR; it was refused for a different use and is refused here
+for a third reason.
+
+## The dead man's switch generalises. The escalation does not.
+
+**Every scheduled job pings Healthchecks.io** — the four obligations and the drainer's backstop sweep,
+which is the job whose silence is otherwise completely invisible. The app pings on success and pings
+`/fail` on a caught error. Free tier is 20 checks, so count is not a constraint.
+
+**Only the deadline monitor escalates to Pushover Emergency.** The rest notify by email. ADR-0020 made
+the switch load-bearing for that job specifically, and a watchdog that pages for a sweep nobody depends
+on trains the operator to ignore the one that matters. Same mechanism, graded consequence.
+
+The division of labour, which no ADR had written down:
+
+| Question             | Tool                | Why nothing else answers it                                                                                               |
+| -------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| _Why did it break?_  | **Sentry**          | Sees only what reaches the app                                                                                            |
+| _Did it run at all?_ | **Healthchecks.io** | Sentry is **structurally blind** here — credits exhausted, schedule deleted, vendor down: no code ran, so no error exists |
+| _Is the app up?_     | **UptimeRobot**     | ADR-0022: Fly health checks _"do not notify anyone"_                                                                      |
+
+The middle row is why the switch is not redundant with Sentry, and it is the answer ADR-0020 implied
+without stating.
+
+**And the switch must not share a failure mode with what it watches.** The deadline monitor's output is
+an email to the operator, riding the same outbox as everything else — one send path, no second mailer.
+A watchdog that also alerted by email would mean a single mail-path failure took out both the alarm and
+the thing the alarm watches. Pushover is a different vendor and a different channel; that independence
+is the entire property being bought.
+
+## Sentry Crons is not enough, and the reason is the price of the second monitor
+
+Worth recording because it is the obvious consolidation and it fails on numbers rather than taste.
+
+Sentry Developer includes **1 cron monitor and 1 uptime monitor**. We need five heartbeats in
+production and roughly ten across both environments. The trap is how more are obtained: additional
+monitors cost **$0.78 each, but pay-as-you-go is a Team/Business feature** — so the real price of cron
+monitor number two is **$26/month for Team**, which exceeds the entire $25 infrastructure budget.
+Developer also alerts _"via email"_ only; webhooks, Slack and Pushover start at Team. So even for the
+single most important check, Sentry cannot deliver the escalation ADR-0020's compliance control needs,
+and cannot satisfy the independence requirement above.
+
+**The one included monitor is spare capacity and gets used.** Point Sentry Crons at the **deadline
+monitor** as a redundant second watchdog — Healthchecks.io to Pushover Emergency, Sentry to email — on
+the one job where two vendors watching costs nothing and the stakes justify it.
+
+Noted and not acted on: Sentry's included **uptime** monitor could cover production if UptimeRobot ever
+becomes a problem. That is #18 and ADR-0022's decision, not this one's.
+
+## Two trigger.dev projects, because Free has no staging environment
+
+Free provides **DEV and PROD only** — _"staging deploys are only available on the Hobby and Pro
+plans"_. That matters more than it sounds, because ADR-0022 keeps staging precisely since ADR-0017
+declines to test PlanetScale at all, making it the only place these jobs meet a real managed Postgres.
+
+So: **two projects in one organization**, `encuentra-staging` and `encuentra-production`, each using its
+own PROD environment. Schedules and concurrency are per project; plan and credits are per organization,
+so the $5 is shared. Two deploy invocations, which mirrors the `fly.toml` / `fly.staging.toml` split
+already in the repository.
+
+Two things said plainly rather than left as cleverness. This **sits beside a paywall**, and it is
+exactly the shape of thing a vendor closes; **Hobby at $10/month is the named fallback**, and taking it
+would be a budget decision, not an architectural one. And because the $5 is shared, **staging's
+schedules run daily rather than five-minutely**, so the environment that does not matter cannot starve
+the compliance control in the one that does.
+
+## Where the code lives: there is no eleventh package
+
+A `@repo/jobs` package was considered and rejected, because **ADR-0006 already rejected this package
+under another name.** Its refusal of a _"data rights"_ module reads: _"consent records must be readable
+from low in the graph while export and erasure must reach across all of it. One module cannot be both
+without a cycle."_ A jobs package has that same shape — its purpose is reaching across the graph, from
+inside the graph. ADR-0020 recorded the answer this repository already uses: _"fulfilment stays a use
+case in `apps/web` exactly as ADR-0006 designed."_
+
+And three of the four already have homes that fall out of decisions taken elsewhere:
+
+| Job              | Home                          | Tier | Why there                                                                                                    |
+| ---------------- | ----------------------------- | ---- | ------------------------------------------------------------------------------------------------------------ |
+| Retention purges | **`@repo/db`**                | 0    | ADR-0021 puts the term beside ADR-0017's erasure classification in `src/columns.ts`, enumerated reflectively |
+| R2 sweep         | **`@repo/people`**            | 2    | ADR-0010 puts the Photo on the Person, with keys _"derived from the person identifier"_                      |
+| Deadline monitor | **`@repo/consent`**           | 3    | ADR-0020 widened this charter for `data_requests` and put the _festivos_ constant beside the clock           |
+| Outbox drainer   | **`apps/web/src/use-cases/`** | —    | The only cross-module one: the outbox is tier 4, but rendering an Offer notification needs tier 5            |
+
+So the package would have held **one** function, which ADR-0006 has already housed. The route handler
+and the trigger.dev task file are both adapters in `apps/web` — the Server-Action shape with a
+different caller — so **ADR-0006 needs no amendment and the DAG gains no edge**. The first three are
+module functions exported from an `index.ts`, which is ADR-0017's first seam.
+
+**The revisit trigger, because the question is a fair one.** `@repo/jobs` buys portability off
+`apps/web`. The day the callback is replaced by a real worker process — a self-hosted trigger.dev, or a
+direct-DB task — these functions must run without Next.js, and that is when a package earns its place.
+
+One wrinkle recorded here because it is easy to get wrong: a reflective purge must delete **leaf-first**
+under ADR-0008's `RESTRICT` default and explicit-ordering rule, so the reflection needs a topological
+order over the foreign keys, not merely a list of tables.
+
+## Schedules are declarative, and exactly one of them has a timezone
+
+Schedules can be declared in code or created imperatively through the SDK or dashboard. **Declarative
+only.** An imperative schedule is infrastructure with no code review and no way to remove it by
+deleting code — the same objection ADR-0022 raised to hiding an irreversible step behind a deploy.
+
+| Job                     | Production      | Staging | Timezone             |
+| ----------------------- | --------------- | ------- | -------------------- |
+| Drainer backstop sweep  | every 5 minutes | daily   | UTC                  |
+| Deadline monitor        | daily           | daily   | **`America/Bogota`** |
+| Retention purges        | daily           | daily   | UTC                  |
+| R2 reconciliation sweep | daily           | daily   | UTC                  |
+
+The deadline monitor's timezone is not cosmetic. A UTC midnight run is 7pm the previous day in Bogotá,
+so a business-day boundary computed in UTC is off by one for part of every day — against a statutory
+clock where being off by one is the whole failure. Colombia has no DST (ADR-0008), so the offset is
+fixed, but the date boundary still has to be the right one.
+
+## Deploy ordering: a third participant that knows no schema
+
+`trigger.dev deploy` builds and ships its **own** bundle to their cloud, with no digest relationship to
+the Fly image. That is a second artifact against ADR-0022's spine, whose whole argument is that the
+fast-forward merge keeps the `dev`-built digest addressable so _"production deploys the identical
+digest staging ran"_.
+
+The cost is smaller than it first appears, and the reason is the callback. Because a task file contains
+nothing but a `fetch()`, **the trigger.dev bundle imports no domain code and no schema** — so the
+"two artifacts must agree about the schema" problem largely does not arise. The third participant has
+no schema knowledge to be stale about, and ADR-0024's expand/contract choreography is unaffected: still
+two releases, still the same two things that must agree.
+
+Ordering stays in one job for consistency rather than correctness:
+`migrate → trigger.dev deploy → flyctl deploy`, with the trigger.dev step failing the job like any
+other. One gate, three steps, in the order ADR-0024 established.
+
+## Accepted risks
+
+- **The credit grant is a cliff, and what falls off it is a compliance control.** $5/month with
+  bounded retries and a capped concurrency should not reach it; Healthchecks.io is what notices if it
+  does. Nothing prevents it.
+- **The two-project arrangement sits beside a paywall** and could be closed by the vendor at any time.
+  Hobby at $10/month is the fallback, and it does not fit the remaining budget comfortably.
+- **The shared secret on `/api/jobs/*` is the only thing protecting privileged work.** Rate limiting is
+  #48's, so until that lands the endpoint's sole defence is the secret.
+- **Sending inside the claiming transaction holds row locks for the duration of a provider call.**
+  Bounded by `LIMIT 20` and untested under load, because there is no load.
+- **The credit estimate is arithmetic, not a measurement.** $0.60–1.00/month assumes short runs and no
+  retry storms, against an application with no traffic.
+- **trigger.dev's free-tier concurrency is unverified** — the pricing page read 2026-08-17 says 20
+  concurrent runs, secondary sources say 10. Nothing here depends on which, but the figure should be
+  confirmed before anything does.
+- **No job has ever run.** Every schedule, ping, secret and endpoint in this ADR is unprovisioned, like
+  everything else in ADR-0022's pipeline.
+
+## Consequences
+
+- **#47's headline question is answered by dissolution.** There is no leader election, no advisory
+  lock and no double-fire guard, because one HTTP request reaches one machine. If a future design puts
+  a scheduler back on the machine, all of that returns with it.
+- **ADR-0015 is completed.** _"Who drains it belongs to #15"_ now has an answer: a use case in
+  `apps/web`, woken by `tasks.trigger()` after commit and swept every five minutes, with the outbox row
+  as the sole retry authority. The `claimed_at` column its outbox implied is **not** built.
+- **ADR-0020 is completed.** The deadline job is scheduled, pinned to `America/Bogota`, escalating to
+  Pushover Emergency, and watched by a second vendor. Its dead man's switch gains a requirement
+  ADR-0020 did not state: **it may not share a failure mode with the alarm it guards**, which is why the
+  operator email rides the outbox and the switch does not.
+- **ADR-0021 is completed.** The purge jobs are scheduled, and the reflective enumeration it shares with
+  ADR-0017 needs a **topological order**, not a table list.
+- **ADR-0010's sweep has an owner** — `@repo/people`, daily, pinged.
+- **ADR-0022 gains a third deploy participant** and keeps its single gate. Its `fly.toml` files are
+  unchanged; nothing here depends on `auto_stop_machines` except by being immune to it.
+- **ADR-0006 and ADR-0017 need no amendment**, which is the point of the callback. The jobs are
+  adapters over existing seams, so all four are integration-testable on PGlite from the day they are
+  written.
+- **`@repo/db`, `@repo/people` and `@repo/consent` each gain one exported function**; `apps/web` gains
+  `src/trigger/` and `src/app/api/jobs/`. No new package, no new DAG edge.
+- **#18's stack is unchanged and now has three named roles** rather than three tools. Sentry's spare
+  cron monitor is spent; its spare uptime monitor is recorded as available.
+- **#48 inherits the rate limit on `/api/jobs/*`** alongside its two limiters, and inherits the Redis
+  question undecided — this ADR refuses Redis for the drainer only, and says so on grounds that do not
+  generalise.
+- **A new secret exists in every environment** (`TRIGGER_SECRET_KEY` and the callback secret), joining
+  ADR-0021's un-rotatable `subject_key` in whatever the map's backup-and-recovery fog eventually
+  decides.
+- **Nothing about this is provisioned**, and `docs/runbook.md`'s provisioning checklist gains the
+  trigger.dev organization, two projects, five schedules and five Healthchecks.io checks.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -238,7 +238,27 @@ no payment method; no Fly app exists. Work top to bottom — later steps need th
    `registry.fly.io/encuentra:…` requires the production app's token. Recorded as an accepted risk
    in ADR-0022 rather than hidden.
 
-10. **Arm `deploy.yml`** — one edit, named in the file.
-11. **Run the restore drill** (procedures 6 and 2 against a throwaway branch) and record the result
+10. **trigger.dev** (ADR-0028): create one organisation on the **Free** plan, then **two projects** —
+    `encuentra-staging` and `encuentra-production`. Each uses its own **PROD** environment, because
+    Free provides DEV and PROD only and staging deploys need Hobby. Schedules and concurrency are per
+    project; the **$5 monthly credit is shared across the organisation**, which is why staging's
+    schedules run daily and production's backstop runs every five minutes.
+11. **trigger.dev**: set a **concurrency cap** on each project and confirm bounded retries in
+    `trigger.config.ts`. Running out of credit stops tasks, and one of the tasks is a compliance
+    control — this is the only thing standing between a retry storm and a silently disarmed deadline
+    monitor.
+12. **Healthchecks.io**: create one check per job per environment (five each, ten total) on the Free
+    plan's 20. Route **only the production deadline monitor** to Pushover with **Emergency** priority;
+    everything else to email. A ping carries no personal data, so this vendor needs no
+    _contrato de transmisión_.
+13. **Sentry**: point the single included **cron monitor** at the production deadline monitor, as the
+    redundant second watchdog ADR-0028 specifies. The included **uptime** monitor stays unused and
+    available.
+14. **Secrets**: `TRIGGER_SECRET_KEY` per project into GitHub environment secrets (for
+    `trigger.dev deploy`), and a shared **`JOBS_CALLBACK_SECRET`** into both Fly apps _and_ both
+    trigger.dev projects. The callback secret is the only thing protecting `/api/jobs/*` until #48
+    lands its rate limit.
+15. **Arm `deploy.yml`** — one edit, named in the file.
+16. **Run the restore drill** (procedures 6 and 2 against a throwaway branch) and record the result
     here. ADR-0024 treats this as a launch requirement, because the recovery commands above are
     written from documentation rather than from having done it once.


### PR DESCRIPTION
Resolves #47 — the last ticket #15 graduated, and the one that had to wait for the machine topology.

**This is ADR-0028.** It was opened as 0027, which #58 landed first; rebased onto `dev` and renumbered, with every cross-reference in the six amended documents moved with it. The surviving `ADR-0027` mentions in `docs/adr/0010`, `docs/adr/0015`, `docs/adr/0026` and the photo-refusal prototype README belong to *that* ADR and are untouched.

## What it decides

**The scheduler moves off the machine.** trigger.dev Cloud holds the schedule for all five jobs (ADR-0015's outbox drainer and its backstop, ADR-0020's deadline monitor, ADR-0010's R2 sweep, ADR-0021's retention purges). Every alternative keeps the clock co-located with the thing being deployed, suspended, restarted or duplicated — which is the axis they all fail on:

| Candidate | Why not |
| --- | --- |
| In-process timers | Production's `auto_stop_machines = "off"` hides that **staging suspends**, so timers fire never in the only environment ADR-0022 keeps; `bluegreen` double-fires on every release |
| GitHub Actions cron | **Auto-disabled after 60 days of repo inactivity** on a public repo — silent disarmament of a compliance control — and *"some queued jobs may be dropped"* |
| Fly scheduled Machines | Only *fuzzy* `hourly`/`daily`/`weekly`/`monthly`, no cron, and **cannot be started manually** |

**The ticket's headline question dissolved rather than got answered.** With the job arriving as an HTTP request, one request reaches one machine — so there is no leader election, no advisory lock and no double-fire guard anywhere in this ADR. That absence is the decision.

## The two rules that do the real work

- **No personal data ever crosses to trigger.dev.** It stores payloads and outputs for up to 14 days and publishes **27 subprocessors** — including OpenAI and Anthropic for *"generative AI services"*. Carrying an email address would make it an *encargado* needing a `2.2.2.25.5.2` *contrato de transmisión* and a register entry, against ADR-0010 buying R2 precisely because it *"adds no new processor"*. With ids only, it holds a string and a `bigint`.
- **A task holds a URL and a secret, not a database connection.** The decisive argument is testability: a task with its own connection sits outside both of ADR-0017's seams, which would leave a compliance control and the erasure net **untestable by this repo's own rules**. As a callback, all five are exercised at existing seams on PGlite. It also keeps the credential count at two, leaves PS-5's unread connection ceiling no worse, keeps Sentry's automatic route-handler instrumentation, and **wakes staging's suspended machine** via `auto_start_machines`.

## Findings worth reading even if you skip the rest

- **One retry loop can drain three budgets** that each belong to a different vendor: trigger.dev's $5 credit (whose exhaustion silently disarms the deadline monitor), **Sentry's 5,000 errors/month** — a poison row retried every 5 minutes is **8,640 errors**, 1.7× the whole quota — and the operator's attention. Hence: bounded retries, capped concurrency, and **Sentry told once at the transition to poison, never per attempt**.
- **The outbox needs no `claimed_at` column.** `FOR UPDATE SKIP LOCKED` inside the sending transaction means a machine killed mid-drain releases its locks and recovers with no timeout to tune — ADR-0015's own instinct for `frozen`, one level down.
- **Sentry Crons is not enough**, and not for the reason it looks: Developer includes 1 cron monitor, and additional ones are $0.78 each **but pay-as-you-go is a Team feature**, so monitor #2 really costs **$26/month**. It also alerts by email only, which fails the independence requirement below. Its one included monitor *is* spent — as a redundant second watchdog on the deadline job.
- **A dead man's switch may not share a failure mode with the alarm it guards.** ADR-0020 didn't state this. The deadline monitor's output is an email riding the outbox, so an email-only watchdog would let one mail-path failure take out both the alarm and its subject. Pushover Emergency is a different vendor on a different channel.
- **Free has no staging environment** — *"staging deploys are only available on the Hobby and Pro plans"*. Answered with **two projects in one organization**, each using its own PROD environment. Flagged in the ADR as sitting beside a paywall, with $10 Hobby as the named fallback.
- **`@repo/jobs` was considered and rejected** because **ADR-0006 already rejected that shape** as a *"data rights"* module. Three of the four jobs already have homes (`@repo/db` reflectively, `@repo/people`, `@repo/consent`); only the drainer is cross-module, and ADR-0006 houses that as a use case. Revisit trigger recorded.
- **Redis Pub/Sub rejected on architecture, not cost** — no persistence, and its long-lived subscriber would live back on the machine. Noted honestly: ADR-0016's refusal doesn't reach this case, and **#48 still owns whether Redis enters the stack at all**.

## Changes

- **New**: `docs/adr/0028-the-scheduler-runs-off-the-machine-and-holds-only-a-url.md`
- **Completed**: ADR-0015 (drainer), ADR-0020 (deadline monitor, +1 requirement), ADR-0021 (purges, +1 correction: needs a **topological order**, not a table list)
- **Scheduled**: ADR-0010's reconciliation sweep, now owned by `@repo/people`
- **Amended**: ADR-0022 — third deploy participant, and why `fly.toml` needs no edit
- **`CLAUDE.md`**: a `### Scheduled work` section, as the spec to build against
- **`docs/runbook.md`**: five provisioning steps (steps 10–14)

**No `CONTEXT.md` change**, deliberately — an outbox and a scheduler are engineering vocabulary, and ADR-0017 established that those go in `CLAUDE.md`.

## Caveats

Nothing is provisioned, like the rest of ADR-0022's pipeline. The $0.60–1.00/month credit estimate is arithmetic against an app with no traffic. **trigger.dev's free-tier concurrency is unverified** — the pricing page says 20, secondary sources say 10; nothing here depends on which, but it's recorded rather than smoothed over.

*Process note: the ticket named `/mattpocock-skills:grill-with-docs`, which is not installed in this repo, so this ran on the map's documented fallback — `/grilling` + `/domain-modeling`. Flagged as a departure.*

