### PR TITLE
Does a publicly searchable Need show its exact Municipality: ADR-0030 (#55)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,8 +89,10 @@ _Avoid_: Listing, Posting, Borrador (reads as a saved draft of a document, not a
 
 **Capability Profile**:
 A kind of Publication: what a Person can do and is willing to do — their skills, experience and
-availability. Optional, and at most one per Person. It is not the Person's identity; name,
-municipality and contact details belong to the `Person`.
+availability. Optional, and at most one per Person. It is not the Person's identity; name and contact
+details belong to the `Person`. The **Municipality belongs to the Publication**, and on a Capability
+Profile it happens to be where the Person is — which is why the same column means something different
+on a Need.
 _Spanish (UI)_: perfil
 _Avoid_: UserProfile, CV, Résumé, Hoja de vida
 
@@ -110,7 +112,9 @@ Where the work would happen — in the hirer's home, in the worker's own home, o
 out in public or across several places, or remotely. A property of a **Need and of an Offer** alike,
 drawn from a fixed vocabulary. It exists because the risk of cleaning a stranger's house is not the
 risk of remote data entry, and the platform must be able to tell those apart: it selects the safety
-guidance shown at a Contact Exchange and raises a Report's place in the queue. It belongs to the
+guidance shown at a Contact Exchange, raises a Report's place in the queue, and decides whether a
+public Need card names its author — on `hirer_home`, the one setting where the Need's Municipality is
+also the author's own, it does not. It belongs to the
 Offer as well because an Offer addressed to a Capability Profile answers no Need, and the guidance
 must still know what it is warning about. It never means the platform has vetted anywhere.
 _Spanish (UI)_: lugar de trabajo
@@ -184,10 +188,11 @@ _Spanish (UI)_: sugerencia
 _Avoid_: Custom skill, Free skill, Other, Pending skill
 
 **Photo**:
-A photograph of a Person. It belongs to the Person, not to a Publication — like their name and
-municipality, it is who they are rather than something they published, and it does not change when
-they publish or unpublish. It has three states rather than two — absent, visible to signed-in Persons,
-or in the Public View — and the third is chosen separately and never by default. Always optional and
+A photograph of a Person. It belongs to the Person, not to a Publication — like their name, it is who
+they are rather than something they published, and it does not change when they publish or unpublish.
+(The Municipality is **not** in that set: it is a property of the Publication.) It has three states
+rather than two — absent, visible to signed-in Persons, or in the Public View — and the third is
+chosen separately and never by default. Always optional and
 never required by anything. It is the only kind of file Encuentra accepts — there are no documents and no hojas de
 vida — and it is named for what it is rather than as an Attachment, so that admitting a second kind
 of file is a decision rather than a migration. Under Colombian law a face is _sensitive_, so it is
@@ -206,8 +211,13 @@ _Avoid_: Approval, Moderation (which is the wider #13 concern, not this one step
 
 **Municipality**:
 A Colombian municipality, identified by its DANE DIVIPOLA code and belonging to a department. Every
-Publication has one. Remote work is a separate property of the Publication, never a municipality
-value. A Public View names only the department, never the municipality.
+Publication has one, and it belongs to the **Publication** rather than to the Person — what it means
+is fixed by the kind: for a Capability Profile it is where the Person is, and for a Need it is where
+the work is. Remote work is a separate property of the Publication, never a municipality value. A
+Public View names only the department, never the municipality — but a **Need** names its exact
+municipality publicly, because for four of the five Work Settings the place of the work says nothing
+about where its author lives. For `hirer_home` it does, and there it is the author's **name** that
+waits for a session instead (ADR-0030).
 _Spanish (UI)_: municipio
 _Avoid_: City, Location, Ciudad
 

--- a/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
+++ b/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
@@ -85,6 +85,14 @@ Dosquebradas rather than Pereira. The full name is kept because a profile is mea
 act this design most wants to enable is a neighbour posting _"hire her"_ into a Facebook group, and
 "María C." undercuts it.
 
+> **Scoped by ADR-0030 — this table is a _Person's_ tiers, and a Need's place is not in it.** Every
+> row above still holds. What ADR-0030 adds is that a **Need's** exact Municipality **is** public: for
+> four of ADR-0013's five Work Settings it is where work happens and says nothing about where its
+> author lives, so this table never reached it. For `hirer_home` — the one setting where a Need's place
+> **is** its author's home municipality — the field held back is the **author's name**, which leaves
+> the public tier rather than the place. ADR-0030 also records that the reason given above for keeping
+> the full name public is specific to a Capability Profile: nobody shares _"hire this household."_
+
 ## Two consents, defaulting in opposite directions
 
 - **The card defaults on.** Appearing on the wall rides on the existing `publish` Purpose — no ninth
@@ -215,5 +223,9 @@ autorizada_ arts. 4(g)/17(d) target, and it is one row per review.
 - **#20 inherits** that a paused Person leaves matching and suggestions entirely.
 - **#12 inherits** the wall itself, and ADR-0010's rule that a profile without a photograph must never
   render second-class now applies on a public surface where the contrast is most visible.
+
+  > **Amended by ADR-0030** — the public Need card carries one branch on Work Setting, and it lives in
+  > the projection rather than in the component.
+
 - **#27 inherits** that a pause is not an erasure, and the "we cannot retrieve what was scraped" sentence.
 - **Access logging returns to the fog**, graduating with #13 if abuse investigation ever needs it.

--- a/docs/adr/0013-safety-between-individuals.md
+++ b/docs/adr/0013-safety-between-individuals.md
@@ -191,6 +191,11 @@ It does two things. It **selects the safety guidance** shown at the Contact Exch
 queue priority** — `hirer_home` reports and `underage` reports are triaged ahead of the rest, because
 those are the two classes where a slow queue is indefensible.
 
+> **A third thing, added by ADR-0030.** It decides **what a public Need card discloses about its
+> author**: on `hirer_home` — the only setting in which a Need's Municipality is also its author's home
+> municipality — the author's name and the link to their Public View wait for a session. The warning
+> below binds that copy too, and ADR-0030's card says nothing about the place being checked.
+
 Undifferentiated safety copy on every Contact Exchange was rejected: shown on all of them it is
 wallpaper, and wallpaper is not read on the one occasion it matters.
 

--- a/docs/adr/0014-search-as-two-bounded-surfaces.md
+++ b/docs/adr/0014-search-as-two-bounded-surfaces.md
@@ -242,13 +242,27 @@ activity #23 could find no carve-out for. Licensed under ADR-0011's standing rul
 control and never a privacy one, which is honest here because the underlying Needs are public by design.
 The authored skill and municipality pages stay indexable and remain the surface that ranks.
 
+> **Defined by ADR-0030 — the municipality page is prose and a link, and lists no Publications.** Only
+> `/skills/<slug>` was ever specified, by ADR-0012; a municipality page was asserted here and defined
+> nowhere. Listing live Needs on it would build the paginated, indexable, Municipality-keyed index this
+> paragraph is careful to avoid.
+
 ## What a public Need shows
 
 Public Need search is new here, and ADR-0011 settled the public tier for a **Person**, not for a Need. A
-public Need card shows **the work, not the author**: Skills, department, remote-or-local, Commitment, Work
-Setting, and the Self-description as prose — shown, never queried. The author appears as **name only**,
-linking to their existing Public View, with **no photo on the Need card**, which keeps ADR-0011's photo
-consent doing one job in one place.
+public Need card shows **the work, not the author**: Skills, ~~department~~, remote-or-local, Commitment,
+Work Setting, and the Self-description as prose — shown, never queried. The author appears as **name
+only**, linking to their existing Public View, with **no photo on the Need card**, which keeps ADR-0011's
+photo consent doing one job in one place.
+
+> **Amended by ADR-0030 — the exact Municipality, and no author at all in one Work Setting.** The card
+> shows the **exact Municipality** rather than the department, because the section above already
+> discloses it: a query accepts a Municipality, results are banded by it and the explanation sentence
+> names the band, so printing the department was a display choice and never a control. And the sentence
+> _"the author appears as name only"_ is now true of four Work Settings and **false of `hirer_home`** —
+> the only setting in which a Need's place is also its author's home municipality, where the name and
+> the link to the Public View wait for a session instead. The query, the bands and the explanation
+> sentence are unchanged for every Need.
 
 This overlaps **#12** and is recorded as a constraint #12 inherits, not as a presentation decision made
 here.
@@ -267,6 +281,10 @@ here.
 - **#20 inherits** the same package, the same flat key, and the banding-plus-rotation pattern as a
   precedent for its own explainability requirement.
 - **#12 inherits** the public Need card contents and the no-photo-on-a-Need rule.
+
+  > **Amended by ADR-0030** — the contents are the exact Municipality, and no author on a `hirer_home`
+  > Need. Discharged in ADR-0026 and re-opened for that one branch.
+
 - **#15 inherits** two rate limiters that must not be unified, and the edge one as a launch requirement.
 - **#23's brief gains one line**: public Need search is _difusión_ under Res. 129 art. 5, marginal to an
   exposure ADR-0011 already accepted.

--- a/docs/adr/0025-the-first-run-asks-which-door-you-came-through.md
+++ b/docs/adr/0025-the-first-run-asks-which-door-you-came-through.md
@@ -65,10 +65,28 @@ The worker's screen carries one sentence that exists because a person would othe
 opposite: **_"En tu perfil público solo se ve el departamento, nunca el municipio."_** That is ADR-0011's
 public tier, said out loud at the moment the data is collected rather than buried in an _aviso_.
 
-**What is deliberately not said** is the equivalent sentence for a Need. Whether a publicly searchable
+~~**What is deliberately not said** is the equivalent sentence for a Need. Whether a publicly searchable
 Need exposes its exact Municipality is genuinely undecided — ADR-0011's table draws that line for a
 _Person_, and ADR-0014 later made Needs public without revisiting it. The copy says only what the
-field is for. **#10 owns closing this**, and until it does, no screen may claim either answer.
+field is for. **#10 owns closing this**, and until it does, no screen may claim either answer.~~
+
+> **Closed by ADR-0030 — #10 had already closed, so #55 owns it.** A Need's exact Municipality **is**
+> public. The Need screen therefore gains a sentence, but only where the Work Setting is `hirer_home` —
+> the one setting in which the place of the work is also the author's home municipality, and the setting
+> in which ADR-0030 withholds the **author's name** from the public card instead of the place:
+>
+> > Como el trabajo es en tu casa, en la búsqueda pública no mostramos tu nombre. El municipio sí se ve.
+>
+> The four other Work Settings get **no sentence at all**. Nobody answering _¿Dónde es el trabajo?_
+> assumes the place is private, and a visibility notice on every Need screen is the undifferentiated
+> copy ADR-0013 refused — not read on the one occasion it matters.
+>
+> **This screen also gains the Work Setting control**, beside the Municipality and the remote checkbox,
+> because ADR-0030's rule cannot run on a Need that has none and the sentence above cannot be composed
+> until it is known. It is the same question this screen already asks — `CONTEXT.md` calls it _lugar de
+> trabajo_, and the Municipality is _which_ place while the Work Setting is _what kind of_ place. The
+> remote checkbox stays where it is, and `remote` being one of the five values is a second reason not to
+> split them across screens. No sixth screen.
 
 ## The Photo sits inside the flow, and never at the end of it
 
@@ -170,6 +188,7 @@ the person leaves holding an action they can take today without waiting for anyo
 | Note at exactly 1 | _"en más búsquedas vas a aparecer"_ | _"mejores personas te vamos a mostrar"_ |
 | Self-description  | **not asked in the first run**      | **asked** — _Cuenta qué hay que hacer_  |
 | Photo             | offered                             | not offered                             |
+| Work Setting      | n/a                                 | asked on _dónde_ (ADR-0030)             |
 | Publishes on      | _dónde_                             | _descripción_                           |
 
 **The Self-description split is the whole of it, and it falls out of an existing decision rather than
@@ -184,6 +203,14 @@ en la oferta que le mandas a alguien."_ ADR-0015 puts terms in the Offer, and no
 Need from restating them — but a Need quoting a rate and a schedule is a _vacante_ in everything but
 name, which is the object UAESPE **Res. 000129 art. 5** reaches and the exposure ADR-0011 accepted
 knowingly and narrowly. Keeping pay out of the Need keeps that exposure where it was.
+
+> **ADR-0030 adds a second line to this screen, for `hirer_home` only**, because the Self-description is
+> public prose and can undo in the author's own words the de-identification ADR-0030 applies to that
+> card:
+>
+> > No pongas tu dirección ni tu nombre aquí: eso se intercambia al aceptar una oferta.
+>
+> On the other four settings there is nothing to protect and the sentence would be wallpaper.
 
 **The Photo is not offered to a hirer in the first run.** It belongs to the Person either way and
 remains available from the profile; nothing in publishing a Need is improved by a face, and ADR-0010's
@@ -219,8 +246,10 @@ guessing wrong in the second sentence someone reads is a worse failure than a sl
   near-empty states appear here unchanged; nothing in this ADR reopens them.
 - **`CONTEXT.md`** gains the **gender-agreement rule** beside the address rule, and **_sin publicar_**
   as the Spanish for a Publication's unpublished state.
-- **#10 owns** whether a publicly searchable Need exposes its exact Municipality. Undecided, named
-  here, and no screen may claim either answer until it is.
+- ~~**#10 owns** whether a publicly searchable Need exposes its exact Municipality. Undecided, named
+  here, and no screen may claim either answer until it is.~~ **Closed by ADR-0030** — #10 had already
+  closed when this was written, so #55 took it. It is public; the `hirer_home` card withholds the
+  author's name instead, and this flow gains the Work Setting control and two conditional sentences.
 - **#12 inherits** the fork's two cards as the first surface anyone sees signed-in, and the rule that
   a profile without a Photo never renders second-class.
 - **#16 inherits nothing testable.** Every decision here is a screen, a string or an ordering, and

--- a/docs/adr/0026-there-is-no-badge-to-earn.md
+++ b/docs/adr/0026-there-is-no-badge-to-earn.md
@@ -177,6 +177,18 @@ View's one sentence about the difference is written to foreclose it:
 The public Need card is ADR-0014's, unchanged — the work and not the author, the author as name only
 linking to their Public View, no Photo — and it carries no trust text either.
 
+> **Amended by ADR-0030 for one Work Setting.** On a `hirer_home` Need the public card has **no author
+> line at all** — and no placeholder: no _Anónimo_, no _Un vecino de Pereira_, no initials, which is the
+> reasoning of _"A profile without a Photo has no Photo-shaped hole"_ reaching the same answer for a
+> different reason. A stand-in word reads as evasion on a card that deliberately carries no trust
+> signal. One sentence names the missing field, in this section's own pattern:
+>
+> > Con una cuenta ves quién lo publicó.
+>
+> The companion sentence _"No ves nada más sobre si es de fiar"_ is **not** repeated there: this section
+> already rules the Need card carries no trust text, and repeating it on every `hirer_home` card is the
+> wallpaper ADR-0013 refused.
+
 ## A profile without a Photo has no Photo-shaped hole
 
 ADR-0010 rule 1 is a rule about data and this is its expression in layout, stated here because
@@ -261,6 +273,10 @@ them.
   surfaces say so by never referring to it.
 - **ADR-0014's public Need card contents and its no-photo-on-a-Need rule are discharged**, presented
   with no trust text of any kind.
+
+  > **Re-opened for one branch by ADR-0030** — a `hirer_home` Need card carries no author line. The
+  > no-trust-text rule is unaffected and constrains the one sentence that replaces it.
+
 - **ADR-0016's deliberately-open rendering decision is discharged**: a suggestion card carries its
   explanation line and nothing else.
 - **ADR-0011's Wall is presented as a sample rather than a proof of vetting** — the landing copy

--- a/docs/adr/0030-a-public-need-names-the-place-not-the-person.md
+++ b/docs/adr/0030-a-public-need-names-the-place-not-the-person.md
@@ -1,0 +1,253 @@
+# A public Need names the place, and in one Work Setting it stops naming the person
+
+Every publicly searchable Need shows its **exact Municipality**. Where the Work Setting is
+`hirer_home`, the **author's name and the link to their Public View wait for a session**, and the
+public card is the work and nothing else.
+
+ADR-0025 left this open deliberately and handed it to **#10**, which had already closed — so the
+question had no owner and no screen was allowed to claim either answer. This ADR is that owner. It
+closes the question in both directions at once: ADR-0011's fields table keeps its meaning untouched,
+because it is a table about a **Person**, and a Need's place becomes public because withholding it was
+never a control in the first place.
+
+## The card was never the control, so the card was never the decision
+
+ADR-0025 framed this as _"does a publicly searchable Need expose its exact Municipality"_, and #12
+answered it as a field list — department, following ADR-0014's `What a public Need shows`. The field
+list is downstream of something nobody looked at.
+
+ADR-0014's `What a query is` governs **both** search surfaces, and public Need search is one of them. A
+query accepts _"a Municipality, a Department, or anywhere"_; results are **banded** by location tier;
+and the explanation is _"3 of your 4 skills, in your municipality"_. So an unauthenticated visitor
+learns a Need's municipality by choosing one and reading which band the Need lands in — over a space of
+1,122 Municipalities that a department narrows to a handful. The exact Municipality of every public
+Need has been exposed since ADR-0014, by the search surface, whatever the card printed.
+
+ADR-0011 set the standing rule that settles this: **no privacy argument may rest on something that is
+not a technically controllable access control.** A card that declines to print a value the same page
+discloses by band membership is the same species of fig leaf as `robots.txt`. Rendering the
+Municipality is therefore not a loosening — it is the card catching up with the query, and it is
+recorded here so that nobody re-derives the field list in isolation a third time.
+
+**Query granularity is unchanged and stays uniform for all Needs.** That is a property of this
+decision worth naming, because the alternative did not have it (below).
+
+## `hirer_home` is the only Work Setting where the two municipalities are one value
+
+ADR-0025 made the load-bearing observation without drawing the conclusion: the Municipality is _"the
+same column, a different owner"_ — asked as _¿Dónde estás?_ for a Capability Profile and _¿Dónde es el
+trabajo?_ for a Need.
+
+Follow that through the five Work Settings ADR-0013 fixed. For `remote`, `worker_home`,
+`business_premises` and `public_or_varied`, a Need's Municipality is **where work happens** and says
+nothing whatever about where its author lives. ADR-0011 has no claim on it, because ADR-0011 is about a
+Person's own location. For `hirer_home` the two collapse: the place the work happens **is** the
+author's home municipality, which ADR-0011 withholds from a public tier by a flat rule.
+
+So the rule differs by Work Setting, and it differs for a derived reason rather than a felt one. Not
+_"`hirer_home` is the frightening one"_ — though ADR-0013 already triages it first — but _"`hirer_home`
+is the only setting in which publishing a Need's place also publishes a Person's place."_ Everything
+else follows from that sentence.
+
+**This is Work Setting's third job, not new machinery.** ADR-0013 gave it two — it selects the safety
+guidance at a Contact Exchange, and it raises a Report's place in the queue. A field that already
+discriminates twice discriminating a third time is cheaper than any new field would be, and ADR-0013's
+warning still binds: **the copy attached to it must never drift into implying the platform vets home
+visits.** Nothing below claims a `hirer_home` Need is checked.
+
+## The side channel is closed, and it is not closed with copy
+
+A Person in economic distress has their exact Municipality withheld from their Public View by an
+ADR-0011 rule with **no control attached** — not a default, not a setting, a rule. If they then publish
+_"somebody fix my roof, at my house in Dosquebradas"_, a `hirer_home` Need would publish that same
+field about that same person on a surface with no session gate.
+
+The tempting answer was to make it an informed choice: say the consequence out loud at collection —
+ADR-0025's own pattern — and let the person decide. **It is refused.** A flat rule that a second object
+routes around is not a rule, and consent that arrives through a field label is the weakest kind
+available: someone answering _¿Dónde es el trabajo?_ is answering a logistics question, not making a
+privacy decision. ADR-0011 chose a rule over a control on purpose for a population it identified as
+pre-selected for economic vulnerability, and a Need is not a place to reopen that choice by accident.
+
+So the field is held back regardless of which object would publish it — and because the query stays
+uniform, what is held back is not the place.
+
+## The author gives way, not the place
+
+Two ways to keep the rule intact, and the choice between them is the substance of this ADR.
+
+**Rejected — coarsen the place.** Public `hirer_home` Needs band and render at department; the exact
+Municipality waits for a session. The name stays public and ADR-0011 stays literal.
+
+**Chosen — withhold the author.** Public `hirer_home` Needs carry the exact Municipality like every
+other Need; the author's name and the link to their Public View wait for a session.
+
+Four reasons, each of them already on the record rather than invented here:
+
+1. **ADR-0026 has already emptied the name of value.** _"Signing in buys more fields about the same
+   unvetted stranger"_, there is no badge to earn, and the Need card carries no trust text either way.
+   A full name attached to an unvetted stranger buys a reader nothing, so removing it costs far less
+   than its prominence suggests.
+2. **ADR-0011's reason for making the full name public does not transfer to a Need.** It kept the name
+   because _"a profile is meant to be shared: the act this design most wants to enable is a neighbour
+   posting 'hire her' into a Facebook group, and 'María C.' undercuts it."_ That argument is about a
+   Capability Profile. Nobody shares _"hire this household."_
+3. **It is the faithful reading of ADR-0014's own sentence** — _"a public Need card shows the work, not
+   the author."_ Coarsening the place publishes the author in full and degrades the work; this
+   finishes the thought ADR-0014 started and stopped one field short of.
+4. **It is less machinery, in the cheaper layer.** Coarsening the place needs a per-Work-Setting branch
+   in the **public search path** — a different band for one setting and a different explanation
+   sentence — which is the one place ADR-0016 established that per-row work is already the scaling
+   problem. Withholding the author needs a branch in **one projection**, and leaves the query identical
+   for every Need.
+
+And the cost the chosen option pays is the cost this platform can least afford under the other one.
+The public Need surface exists because, in ADR-0014's words, _"the person who lost their income can
+look for work with no account at all"_ — the funnel it called the ethically correct one. `hirer_home`
+is plausibly the largest category of Need here: cleaning, cooking, childcare, elder care, gardening,
+repairs. Coarsening exactly that category to _Risaralda_ removes the single fact that tells a worker
+with no income whether they can afford the bus, from exactly the people the surface was built for.
+
+**A third option, refused and recorded so it stays refused:** making `hirer_home` Needs findable only
+with a session. It puts the largest category of work behind the gate the public surface exists to
+remove.
+
+## What the public `hirer_home` card shows instead of a name
+
+**Nothing, and no placeholder.** No _Anónimo_, no _Un vecino de Pereira_, no initials, no disc. The
+card has no author line and re-flows without one — the same reasoning ADR-0026 used to refuse a
+photo-shaped hole, arriving at the same answer for a different reason: here a placeholder does not
+penalise anyone, it invents an identity to fill a gap, and a stand-in word like _Anónimo_ reads as
+evasion on a card that deliberately carries no trust signal.
+
+One sentence names the missing field, in the pattern ADR-0026 already set for the Public View:
+
+> Con una cuenta ves quién lo publicó.
+
+It names a field and stops. ADR-0026's second sentence — _"No ves nada más sobre si es de fiar"_ — is
+**not** repeated here: ADR-0026 ruled the Need card carries no trust text, and repeating that line on
+every `hirer_home` card is exactly the wallpaper ADR-0013 refused.
+
+## The projection drops the name, never the component
+
+The name is omitted by the **public Need projection** — one exported function, living with search in
+`@repo/matching` (which ADR-0014 widened to search and suggestions, and which the Wall reads the same
+rows through) — and never by the card component.
+
+This is a testability decision, not a layering preference. ADR-0017 admits exactly two seams, and a
+React component is not one of them; a rule that lives in JSX is guarded by prose alone. A rule that
+lives in a module function exported from a `@repo/*` package's `index.ts` is guarded by an **Invariant
+Test** naming this ADR — _a public projection of a `hirer_home` Need contains no author name and no
+`public_id`_ — which is the difference between a decision that holds and a decision that held once.
+
+The map's fog records three surfaces guarded by prose alone because ADR-0017 cannot reach them. This
+one deliberately does not join them.
+
+## De-identified by default, never de-identified as a guarantee
+
+ADR-0014 puts the **Self-description on the public Need card as prose** — _"shown, never queried"_ —
+and ADR-0025 makes it the screen that publishes a Need. Nothing sanitises it, so _"es en mi casa en el
+barrio Cuba, pregunten por Marta"_ undoes everything above, in the author's own words.
+
+The prose stays. A `hirer_home` card with no name **and** no description is skills-plus-a-place, which
+is not enough for anyone to decide whether to answer — the field rule would be protecting a surface it
+had already destroyed. Instead this ADR takes the honesty ADR-0011 used for scraping (_"we cannot
+retrieve what a third party already took"_) and applies it here: **the rule is a default, not a
+guarantee**, and it is written down as one so that no _política_, no screen and no future ADR upgrades
+it into a promise.
+
+What that buys is a real requirement rather than a false assurance. ADR-0025's description screen
+already says what does not go in the box — _"El pago y las condiciones no van aquí"_ — and for
+`hirer_home` it gains a second line:
+
+> No pongas tu dirección ni tu nombre aquí: eso se intercambia al aceptar una oferta.
+
+Only for `hirer_home`. On the other four settings there is nothing to protect and the sentence would be
+wallpaper.
+
+## The first run can now say the thing it was forbidden to say
+
+ADR-0025's _dónde_ screen carries one sentence for a worker, because _"a person would otherwise assume
+the opposite"_: _"En tu perfil público solo se ve el departamento, nunca el municipio."_ Its Need
+counterpart was left blank on purpose, pending this decision. It is now:
+
+> Como el trabajo es en tu casa, en la búsqueda pública no mostramos tu nombre. El municipio sí se ve.
+
+**For `hirer_home` only.** The four other settings get no sentence at all — nobody typing an answer to
+_¿Dónde es el trabajo?_ assumes the place is private, and a visibility notice on every Need screen is
+the undifferentiated copy ADR-0013 refused, which is not read on the one occasion it matters. Where
+copy is differentiated by Work Setting the differentiation is the point.
+
+## Work Setting has to be collected before a Need is published, and it is not
+
+Applying any of the above needs a Work Setting at publish time, and ADR-0025's first run never asks for
+one. Its Need path is **fork → skills → dónde → descripción**, and `The Need path is not the mirror
+image` lists no Work Setting on any screen — so a Need published in the first run has none, ADR-0013's
+queue priority has nothing to read, and the sentence above has no condition to test.
+
+**Work Setting joins the _dónde_ screen**, beside the Municipality and the remote checkbox. Three
+reasons and no sixth screen, which ADR-0025 was right to count as a cost:
+
+- It is **the same question**. `CONTEXT.md` calls it _lugar de trabajo_ and _dónde_ already asks
+  _¿Dónde es el trabajo?_ — the Municipality is which place, the Work Setting is what kind of place.
+- The visibility sentence **cannot be written anywhere else**, because it belongs on the screen that
+  collects the Municipality and cannot be composed until the Work Setting is known.
+- The remote flag is already there, and `remote` is one of the five Work Setting values — leaving them
+  on separate screens invites two answers that contradict each other.
+
+**`Commitment` is the same gap and is not closed here.** ADR-0026 lists it on the public Need card and
+no ADR collects it either. Named so that it is discovered on purpose rather than by a blank card, and
+left to whoever owns Need composition beyond the first run — which is also unowned.
+
+## Authored Municipality pages are prose and a link, and list no Publications
+
+ADR-0014 asserts that _"the authored skill and municipality pages stay indexable and remain the surface
+that ranks"_, but only `/skills/<slug>` was ever specified — by ADR-0012. A Municipality page has been
+referred to twice and defined nowhere, which makes it an **indexable public surface keyed to
+Municipality with no owner**, and Municipality-keyed enumeration is precisely what everything above is
+about.
+
+It is closed in one line: an authored Municipality page is **authored prose and a link into the
+search**. It lists no Needs and no Capability Profiles.
+
+Listing live Needs would build a paginated, indexable, Municipality-keyed index of Needs — strictly
+worse than the results page ADR-0014 was careful to mark `noindex`, and it would make the _difusión de
+vacantes_ exposure under UAESPE Res. 000129 art. 5 maximally visible, which is the exact thing ADR-0014
+declined to do. It would also rank on nothing it does not already rank on: ADR-0012's skill pages rank
+on their authored text.
+
+A bounded rotating sample was the other candidate — a third Wall — and `CONTEXT.md` answers it: there
+are two Walls _"because the two kinds of Publication carry opposite risks"_. A Municipality Wall is
+sliced on the wrong axis. Cheap to close now, expensive if someone builds it later believing ADR-0014
+licensed it.
+
+## Consequences
+
+- **ADR-0011 amended, in scope rather than in substance.** Its fields table is a **Person's** tiers and
+  every row still holds. Added: a Need's Municipality is public, because for four Work Settings it is
+  not the author's location at all, and for `hirer_home` — where it is — the author's name leaves the
+  public tier instead. Its consequence _"#12 inherits the wall itself"_ now carries a per-Work-Setting
+  branch. Its standing rule about controllable access is load-bearing here, not merely cited.
+- **ADR-0014 amended in three places.** `What a public Need shows` gains the **exact Municipality**;
+  _"the author appears as name only, linking to their existing Public View"_ is now true of four Work
+  Settings and false of `hirer_home`; and the Municipality page it asserted is defined above as prose
+  that lists nothing. Its query, bands and explanation sentence are **unchanged for every Need**.
+- **ADR-0025's open question is discharged**, its consequence _"#10 owns whether a publicly searchable
+  Need exposes its exact Municipality"_ is closed by this ADR, and its _dónde_ screen gains the Work
+  Setting control plus one conditional sentence. Its description screen gains a second conditional
+  line. The five-screen count is unchanged.
+- **ADR-0013 amended.** Work Setting acquires a third job — it now also decides what a public Need card
+  discloses about its author — and its warning against implying vetting binds the new copy.
+- **ADR-0026 amended.** _"The public Need card is ADR-0014's, unchanged"_ is no longer true for
+  `hirer_home`. Its no-trust-text rule, its no-placeholder reasoning and its Public View sentence
+  pattern are all reused rather than displaced.
+- **ADR-0017 gains an Invariant Test** — the public Need projection contains no author name for a
+  `hirer_home` Need — reachable because the rule was placed at a module-function seam on purpose.
+- **`CONTEXT.md`** — **Municipality** gains what a Need's Municipality means and that it is public;
+  **Capability Profile** and **Photo** are corrected, because both currently say the Municipality
+  belongs to the `Person` while **Publication** says it belongs to the Publication, and this decision
+  depends on the second being right; **Work Setting** gains the third job; **Public View** is untouched.
+- **Whoever builds the Need card inherits** one branch and the rule that the branch lives in the
+  projection.
+- **Need composition beyond the first run has no owner**, and now has two fields waiting for one —
+  Work Setting and Commitment.


### PR DESCRIPTION
Resolves #55.

ADR-0025 asked whether a publicly searchable Need exposes its exact Municipality, deliberately declined to answer, and handed it to **#10 — which had already closed.** No screen was allowed to claim either answer until someone owned it.

## The finding that reframes the question

**The card was never the control.** ADR-0014's `What a query is` governs **both** search surfaces, and public Need search is one of them: a query accepts _"a Municipality, a Department, or anywhere"_, results are **banded** by location tier, and the explanation sentence is _"3 of your 4 skills, in your municipality"_.

So an unauthenticated visitor already learns any Need's municipality by choosing one and reading which band it lands in — over 1,122 Municipalities that a department narrows to a handful. **The exact Municipality of every public Need has been exposed since ADR-0014**, by the search surface, whatever the card printed. ADR-0011's own standing rule settles it: no privacy argument may rest on something that is not a technically controllable access control.

`#12`'s prototype rendering department only was therefore answering the wrong half of the question.

## What ships

**A public Need shows its exact Municipality. Where the Work Setting is `hirer_home`, the author's name and the link to their Public View wait for a session.**

`hirer_home` is singled out for a derived reason, not a felt one. ADR-0025 noted the Municipality is _"the same column, a different owner"_ — _¿Dónde estás?_ vs _¿Dónde es el trabajo?_. Follow that through ADR-0013's five settings:

| Work Setting | A Need's Municipality is… | ADR-0011's claim on it |
| --- | --- | --- |
| `remote`, `worker_home`, `business_premises`, `public_or_varied` | where work happens | none — it is not the author's location |
| `hirer_home` | **the author's home municipality** | withheld from a public tier, by a flat rule |

So it is the only setting in which publishing a Need's place also publishes a **Person's** place — and Work Setting already discriminates twice (ADR-0013: safety guidance, queue priority), so this is its third job rather than new machinery.

## Why the author gives way and not the place

Four reasons, all already on the record:

1. **ADR-0026 already emptied the name of value** — _"signing in buys more fields about the same unvetted stranger"_, no badge to earn, no trust text on the card either way.
2. **ADR-0011's reason for making the full name public does not transfer.** It kept it because _"a neighbour posting 'hire her' into a Facebook group"_ is the act the design most wants to enable. Nobody shares _"hire this household."_
3. It is the faithful reading of **ADR-0014's own sentence** — _"a public Need card shows the work, not the author."_
4. **Less machinery, cheaper layer.** Coarsening the place needs a per-Work-Setting branch in the public **search path**; withholding the author needs one branch in a projection, and leaves the query identical for every Need.

And the cost the rejected option pays is the one this platform can least afford. The public Need surface exists so _"the person who lost their income can look for work with no account at all"_, and `hirer_home` is plausibly the largest category here — cleaning, cooking, childcare, elder care, repairs. Coarsening exactly that category to _Risaralda_ removes the fact that tells a worker with no income whether they can afford the bus.

**Also refused, and recorded so:** making the flat ADR-0011 rule an informed choice at collection (a rule a second object routes around is not a rule), and gating `hirer_home` Needs behind a session entirely.

## Four things decided along the way

- **The projection drops the name, never the component.** ADR-0017 admits two seams and a React component is not one, so a rule living in JSX is guarded by prose. Putting it in one exported function in `@repo/matching` makes it reachable by an **Invariant Test**. The map's fog lists three surfaces guarded by prose alone; this one deliberately does not join them.
- **De-identified by default, never as a guarantee.** The Self-description is public prose (ADR-0014, _"shown, never queried"_) and _"pregunten por Marta"_ undoes everything in the author's own words. The prose stays — a card with no name and no description is skills-plus-a-place, protecting a surface it already destroyed — and ADR-0025's description screen gains a second conditional line instead.
- **Authored Municipality pages list no Publications.** ADR-0014 asserts them twice; only `/skills/<slug>` was ever specified, by ADR-0012. Listing live Needs would build the paginated, indexable, Municipality-keyed index both ADRs spent their reasoning avoiding — and a bounded sample would be a third Wall sliced on the wrong axis.
- **Work Setting joins ADR-0025's _dónde_ screen.** Its Need path is fork → skills → dónde → descripción and asks for **no Work Setting on any screen** — so ADR-0013's queue priority has nothing to read and this ADR's rule has no input. It is the same question that screen already asks (`CONTEXT.md` calls it _lugar de trabajo_), so no sixth screen.

## Copy, in Spanish

| Where | Condition | Copy |
| --- | --- | --- |
| _dónde_, first run | `hirer_home` | _Como el trabajo es en tu casa, en la búsqueda pública no mostramos tu nombre. El municipio sí se ve._ |
| _descripción_, first run | `hirer_home` | _No pongas tu dirección ni tu nombre aquí: eso se intercambia al aceptar una oferta._ |
| Public Need card | `hirer_home` | _Con una cuenta ves quién lo publicó._ |

The four other settings get **no sentence at all** — a visibility notice on every Need screen is the undifferentiated copy ADR-0013 refused. And the card carries **no placeholder** for the missing author: no _Anónimo_, no initials, which is ADR-0026's no-photo-shaped-hole reasoning reaching the same answer for a different reason — a stand-in word reads as evasion on a card that carries no trust signal by design.

## Amendments in this PR

- **ADR-0011** — scoped, not changed. Its fields table is a *Person's* tiers and every row holds.
- **ADR-0014** — `What a public Need shows` gains the exact Municipality; _"the author appears as name only"_ becomes true of four settings; the Municipality page is defined.
- **ADR-0025** — the deliberately-blank paragraph and the `#10 owns` consequence are struck and closed; _dónde_ gains the Work Setting control and one sentence; _descripción_ gains one line.
- **ADR-0013** — Work Setting's third job, still bound by its own no-implied-vetting warning.
- **ADR-0026** — _"the public Need card is ADR-0014's, unchanged"_ no longer holds for `hirer_home`.
- **`CONTEXT.md`** — **Municipality**, **Work Setting** amended; **Capability Profile** and **Photo** corrected, because both said the Municipality belongs to the `Person` while **Publication** said it belongs to the Publication. This decision depends on the second being right.

## Notes for the reviewer

- **ADR number:** takes **0030**. `#58` and `#59` still both claim **0027**, and 0028 remains free for whichever renumbers.
- **`Commitment` is the same gap as `Work Setting` and is not closed here.** ADR-0026 puts it on the public Need card and no ADR collects it either. Named so it is found on purpose rather than by a blank card, and left with Need composition beyond the first run — which is also unowned.
- **The Work Setting amendment to ADR-0025 was derived, not asked.** The rule cannot run on a Need that has no Work Setting and the copy cannot be composed without it, and _dónde_ is the only screen that asks about the place. Worth a second look if you disagree that it belongs there.
- **Verification is reading, not commands.** Nothing in this PR is code. `docs/` prose is hand-wrapped; `.claude/worktrees/**` is in `oxfmt.config.mts`'s ignore list, so `format:check` does not reach these files from inside the worktree and they were wrapped to the same width as the ADRs they sit beside.
