### PR TITLE
One internal surface, and one face at a time: ADR-0031 (#28)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -215,12 +215,13 @@ image itself is destroyed; the record that it happened is not. It judges the **i
 account**: every reason names something about the photograph, and a doubt about the person behind it
 is a Report rather than a refusal, so a Review has two exits and only one of them touches the Photo.
 
-Reviews happen **oldest first and one face at a time** — never several at once, because a screen of
-strangers' faces invites deciding them in a batch, and no one's standing here changes without a
-person having looked at them. What the Operator picks is **the sentence the Person will read**, not a
-code standing in for it. The Review is a record of its own that outlives the image: a refused
-photograph is destroyed, a second attempt is a new Photo with a new Review, and neither the record
-nor the note of who looked at it survives the Person it was about.
+Reviews happen **oldest first and one face at a time**. The waiting photographs can be seen together,
+but nothing is ever decided from that view — no one's standing here changes without a person having
+looked at them properly, one at a time. What the Operator picks is **the sentence the Person will
+read**, not a code standing in for it. The Review is a record of its own that outlives the image: a
+refused photograph is destroyed, a second attempt is a new Photo with a new Review, and neither the
+record nor the note of who looked at it survives the Person it was about — a note that is written
+every time a face is shown to the Operator, not only when a decision follows.
 _Spanish (UI)_: revisión de la foto
 _Avoid_: Approval, Moderation (which is the wider #13 concern, not this one step), Verification
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,11 +173,17 @@ _Spanish (UI)_: sobre mí (perfil) / descripción (necesidad)
 _Avoid_: Bio, About, Summary, Headline, Resumen (reads as a CV), Keywords, Tags
 
 **Skill Suggestion**:
-What a Person writes when nothing in the vocabulary fits them. It is a message to the operator, not a
-Skill: it never enters the vocabulary at runtime, never appears on a Publication, and is never matched
-on. The operator reads it, and the term it argues for may be authored into a later release. It exists
-because the vocabulary is the only route to being found, so a gap in it makes someone invisible — and
-because a list of what people could not find is the only honest measure of how good the vocabulary is.
+What a Person writes when nothing in the vocabulary fits them. It is a message to the Operator, not a
+Skill: it never appears on a Publication and is never matched on. It exists because the vocabulary is
+the only route to being found, so a gap in it makes someone invisible — and because a list of what
+people could not find is the only honest measure of how good the vocabulary is.
+
+The Operator either sets it aside or agrees it names a real gap, and **agreeing is not adding**: a
+Skill is authored as its own deliberate act, one at a time, and only after answering the question
+that keeps the vocabulary out of art. 5 territory — could a person _without_ the protected attribute
+plausibly hold this? A suggestion that is eventually answered points at the Skill that answered it,
+which is how the measure above stops being a list that only grows. The Person who wrote it is never
+replied to: the only messages available are a promise we will not make and silence.
 
 It is offered **always, not only when a search fails** — behind a failed search it reads as an error
 state, and it would never hear from the person who searched an approximate word and settled. It may
@@ -208,6 +214,13 @@ sends and receives Offers meanwhile. A refusal has a reason drawn from a fixed v
 image itself is destroyed; the record that it happened is not. It judges the **image and never the
 account**: every reason names something about the photograph, and a doubt about the person behind it
 is a Report rather than a refusal, so a Review has two exits and only one of them touches the Photo.
+
+Reviews happen **oldest first and one face at a time** — never several at once, because a screen of
+strangers' faces invites deciding them in a batch, and no one's standing here changes without a
+person having looked at them. What the Operator picks is **the sentence the Person will read**, not a
+code standing in for it. The Review is a record of its own that outlives the image: a refused
+photograph is destroyed, a second attempt is a new Photo with a new Review, and neither the record
+nor the note of who looked at it survives the Person it was about.
 _Spanish (UI)_: revisión de la foto
 _Avoid_: Approval, Moderation (which is the wider #13 concern, not this one step), Verification
 
@@ -340,6 +353,18 @@ _Avoid_: Candidate, Applicant, Employee, Oferente
 
 ### Safety
 
+**Operator**:
+The person who acts for the platform: the one who decides whether a Photo may appear, reads Reports,
+reads what people could not find, and answers a Person exercising their rights. In v1 there is
+exactly **one**, and every decision the platform makes about a Person passes through them, because
+nothing here is automatic — no classifier, no threshold, no state that changes on its own.
+
+They meet all four of those in **one** place rather than four tools, and every time they open
+somebody's Photo it is recorded. They are an ordinary Person with an account like anyone else, and
+the word is deliberately not _admin_: it names what they do, not what they are allowed to do.
+_Spanish (UI)_: no aparece — quien lo usa no necesita que se le nombre
+_Avoid_: Admin, Moderator (which is only one of the four things), Staff, Reviewer, Support
+
 **Report**:
 One Person telling the platform that another Person is doing something wrong. Always about a
 **Person** — never about an object — though it may point at the Publication or Offer that prompted
@@ -348,6 +373,11 @@ reason drawn from a fixed vocabulary and, optionally, the reporter's own words. 
 is never _told_ one exists — but a Person who asks what we hold about them is shown it, with the
 reporter's identity and anything that fingerprints them removed, and may add their own answer beside
 it. Accumulation moves a Report up the queue and never acts on its own.
+
+A Report may also have **no reporter at all**, which means the platform raised it: an Operator who
+doubts an account rather than an image has no other way to say so, since a Photo Review judges only
+the photograph. One raised that way carries a reason code and never any prose — a reporter's words
+are the complaint, an Operator's would be a record we invented.
 _Spanish (UI)_: reporte
 _Avoid_: Flag, Abuse, Ticket, Case. **Complaint** is now a term of its own — see Data rights
 

--- a/docs/adr/0031-one-internal-surface-and-one-face-at-a-time.md
+++ b/docs/adr/0031-one-internal-surface-and-one-face-at-a-time.md
@@ -1,0 +1,424 @@
+# There is one internal surface, and a Photo is judged one face at a time
+
+ADR-0010 pre-moderates every Photo — nothing is visible to anyone but its owner until an operator
+approves it — which makes a review surface a **launch requirement** rather than tooling. Without one
+the feature does not function at all. ADR-0027 then authored the refusal vocabulary copy-first and
+handed this ticket _"a finished vocabulary and a queue with two exits"_, keeping for itself only how
+an operator picks a code, the queue order, the access log and the three-day alert.
+
+Prototyped at `docs/design/photo-review-prototype/` on `prototype/photo-review-queue`: two ways of
+judging one photograph, inside the shell decided below.
+
+## Four lists, one surface
+
+ADR-0013 already refused to let this be a photo tool: the safety queue is _"another list inside the
+operator surface #28 builds, sharing its authentication, layout and operator access log"_, and it
+counted three — Photo Review, Reports, and ADR-0012's Skill Suggestions — on the ground that **a solo
+developer maintaining three internal applications maintains none of them.**
+
+That argument does not stop at three. **There are four**, and the fourth is `data_requests`.
+
+ADR-0020 assumed this surface without naming it: the _reclamo en trámite_ legend _"appears in
+`/my-data` and in the operator surface"_, a locked-out Person or a _causahabiente_ arrives at the
+published contact address where _"an operator creates the row by hand"_, and ADR-0028's daily monitor
+emails the operator against a statutory clock. Every piece of that is decided and none of it has a
+screen.
+
+It is also the one list where being missed is a **regulatory event** rather than a slow day: art. 16
+makes exhausting our procedure a _requisito de procedibilidad_, so a lapsed clock is precisely what
+opens the SIC's door. That is an argument for putting it where the operator already looks, not for
+giving it its own application.
+
+**Navigation is a sidebar with four links, each carrying a count**, exact to 99 and then `99+`. The
+count is a `SELECT count(*)`, never a cached number — ADR-0013 settled that shape for safety counters
+and the reason carries: _"a Redis counter is a second source of truth that drifts and cannot be
+audited."_ ADR-0016's refusal of Redis on safety grounds points the same way.
+
+The Photo list carries **the age of its oldest item** beside the count, and that is not decoration:
+ADR-0010's commitment is about age. Three photographs four days old is the alarm; sixty an hour old
+is not.
+
+## Getting in
+
+**A `role` on `users`, a second factor, and a separate door.**
+
+Better Auth's `admin` plugin supplies the role and the access-control statement. Two roles, `user`
+and `operator` — **not `admin`**, because every ADR in this repository and `CONTEXT.md` already say
+_operator_, and ADR-0001 asks identifiers to mean what the domain means. `defaultRole: "user"`,
+`adminRoles: ["operator"]`, and the statement's resources are the four lists, so a later split —
+reads photographs but not Reports — is configuration rather than a migration.
+
+**Every `/operator/*` route checks the role on the server.** That check is the boundary. The
+sign-in page at `/operator/login` is a real thing to build but it is not the boundary: Better Auth is
+one instance issuing one session, so a second route buys presentation, not security. It is worth
+building anyway because it keeps the operator out of ADR-0007's four consent boxes and ADR-0025's
+Person-shaped first run on the way in. It carries `noindex`, no signup link and no social buttons.
+**ADR-0022 makes staging public**, so the server-side check is the only thing standing there.
+
+### 2FA for operators, and ADR-0009 survives intact
+
+ADR-0009 declined 2FA in one sentence: _"It adds a second thing to lose to an audience already at
+risk of lockout, and it needs a delivery channel this ADR has just declined to pay for."_
+
+**Both halves of that reason are about Persons, and neither reaches an operator.** A TOTP
+authenticator app has no delivery channel at all — the channel is what made phone OTP cost $50.87
+against #18's $4.46–$7.46 remainder — and the operator is not an audience at risk of lockout with
+nowhere to turn, because the operator is the desk. So the amendment is narrow: **2FA is required for
+`operator` and unavailable to everybody else.** ADR-0009's reasoning about Persons is untouched.
+
+One inherited constraint, from the plugin rather than from us: **2FA enables only on credential
+accounts.** The operator therefore signs in with **email and password**, never Google or Facebook,
+which narrows ADR-0009's three credential types to one for this account alone.
+
+### Operator lockout is a compliance failure mode
+
+The `twoFactor` table carries `failedVerificationCount` and `lockedUntil`. ADR-0020 makes the
+operator the **only rights desk** — _"Ley 1581 forces a recovery desk to exist for rights, and only
+for rights"_ — and ADR-0028's deadline monitor emails that same operator. An operator who loses their
+phone stops the photo queue, the safety queue **and** the art. 15 clock, with nobody to appeal to.
+
+**Backup codes are generated at enrolment and stored off-platform beside ADR-0021's `subject_key`
+HMAC**, which is already an irreplaceable secret the map's backup-and-recovery patch owns. One place,
+one procedure, in `docs/runbook.md`. Naming it here so it is not discovered on the day it matters.
+
+### Two plugin features we take and never use
+
+The `admin` plugin's **ban feature cannot be disabled or omitted**, so `users` gains `banned`,
+`banReason` and **`banExpires`** whether we want them or not.
+
+ADR-0013 forbids exactly what they do: _"Suspension is indefinite and operator-reversible, **never
+timed**. A timed ban implies a rehabilitation process that nobody is staffed to run, and an expiry
+date is a promise the platform would keep automatically without anyone having looked."_ Suspension
+lives on `persons.status`, owned by `@repo/people`, set by a `@repo/safety` use case, and that does
+not change.
+
+**So the columns exist as dead weight, the endpoints are never called, and an Invariant Test guards
+it.** ADR-0017 built that mechanism for this case precisely — a test guarding a decision rather than
+a feature, named for its ADR, with `grep` as the index. Without it the next reader finds a working
+ban API in the schema and uses it, and the schema is the last place a prohibition can be read.
+
+**Impersonation is disabled**, and this is the sharper of the two. The plugin adds `impersonatedBy`
+to sessions; an admin browsing as a Person would see that Person's pending Photo **through the
+ordinary product surface**, where the access log below does not run. It would also walk straight
+through ADR-0011's visibility design. A control that another ADR built is not allowed to have a
+silent bypass, so the feature is off and the ADR says why.
+
+## Photo Review: three states, one order
+
+**`pending` → `approved` | `refused`**, under ADR-0008's `text({ enum })` + `check()` rule, and
+**no claim state**: with one operator a claim is a lock against nobody.
+
+A review is **its own append-only row**, not a mutable status on the Photo. That is what makes it the
+evidentiary row ADR-0010 requires — _"person, reason code, timestamp"_ surviving the destroyed image —
+and it means **a re-upload is a new Photo with a new review**, rather than a state machine that
+loops. ADR-0010 made re-upload the appeal; this is that decision in a table.
+
+**Order is strictly oldest-first, with no operator-selectable sort.** ADR-0013 gives the _safety_
+queue a priority rule (`hirer_home`, `underage`) and it earns it with a harm argument. No candidate
+priority here has one, and every candidate sorts **people** rather than photographs — which is the
+failure ADR-0010 rule 1 and ADR-0026 both exist to prevent. Under oldest-first the age of the head of
+the queue already **is** the sort key, so displaying it asserts nothing the order does not.
+
+## One face at a time
+
+**The operator judges one photograph at a time.** The contact sheet was built rather than argued
+about, and it loses on three counts.
+
+It puts a dozen strangers' faces on one screen, deepening the residual ADR-0010 accepted and this ADR
+declines to mitigate. Its obvious next feature is a checkbox and an _approve selected_ button, which
+is what ADR-0010 refuses outright: **a person's standing on this platform never changes without a
+human having looked** — the same sentence ADR-0013 reused to refuse accumulation-triggered action. And
+it is the only variant where the access log stops matching the decision: one screen, twelve faces,
+twelve rows, one glance.
+
+The speed argument is real and is not dismissed. It loses because the queue is small by construction
+— most Persons upload once (ADR-0010's own reason for accepting a queue at all) — so the throughput a
+sheet buys is throughput we do not need, paid for in the one currency this surface is expensive in.
+
+**The photograph is set inside a mount**: a photo-proportioned frame with a mat inset. ADR-0027 fixed
+that shape for the refusal notice, where it holds the space the photograph is not. Here it is full.
+It is the same rectangle on both sides of the same event, and using it twice is the point.
+
+## The operator picks a sentence, not a code
+
+The surface is **Spanish**, like every surface a person reads (ADR-0001). Identifiers stay English —
+`pending`, `face_not_visible`, `shortlisted` — which is ADR-0001's actual line, sharpened by #30:
+Spanish chrome grows Spanish state keys, and that is the two-language codebase the ADR exists to
+prevent.
+
+That matters more here than on an ordinary internal screen. **The six refusal options render as the
+Spanish sentences the person will receive**, at reading size, in the body face, with the identifier
+set small beside them. ADR-0027 authored that vocabulary copy-first for one reason: a list written for
+an operator's queue — `INVALID`, `POLICY_VIOLATION`, `LOW_QUALITY` — _"translates into exactly the
+sentence this ADR exists to avoid, and by the time it is being translated the translation is the only
+lever left."_ **A picker that displays codes reintroduces the operator-convenience list through the
+back door**, on the one screen where the decision is actually made. The operator is choosing a
+sentence about a person's face and the interface should not let that feel like anything else.
+
+Selecting a code also shows **the imperative** — the half that travels by email. `not_for_work` and
+`face_not_visible` share one imperative word for word, and the surface says so rather than leaving it
+to look like a copy-paste error, because that collapse is the control that stops the email being read
+backwards to the code.
+
+**There is no free-text field**, per ADR-0010.
+
+## The two exits, and a Report with no reporter
+
+ADR-0027 fixed the shape: **the photo queue judges photos and the safety queue judges accounts.**
+Where no image-level code is true, the Photo is approved and any doubt about the person is an
+ADR-0013 matter. `impersonation` and `underage` are Report codes and were deliberately kept out of the
+photo vocabulary.
+
+**A Report has a reporter, and this one has none.** ADR-0013 roots a Report on a Person, written by a
+signed-in Person; an operator raising a matter about an account is not that.
+
+**`reports.reporter_person_id` becomes nullable, and a null reporter means the platform raised it.**
+No synthetic operator Person — a fabricated Titular in a table of real ones would corrupt every
+count, every art. 8(a) answer and every erasure adapter that walks it.
+
+**An operator-raised Report carries a code and never free text.** ADR-0013 permits reporter prose on
+an explicit asymmetry — _"an operator writing prose about a face is **us** creating a record about
+someone, while a reporter describing what happened to them **is** the complaint"_ — and an
+operator-raised Report is entirely the first case. The asymmetry decides it without a new argument.
+
+## What the log records
+
+ADR-0011 killed the general profile-view log it was going to feed, so ADR-0010's operator access log
+**owns itself** and lands here.
+
+**The logged act is the issuance of the signed URL.** ADR-0010 serves bytes by time-limited GET and
+never from a public bucket, so that issuance is the only moment a face actually reaches an operator's
+screen. Logging there is automatic; logging in the interface depends on whoever writes the component
+remembering to. It also gives ADR-0010's own grain — _"one row per review rather than one per page
+view"_ — for free under the one-at-a-time decision.
+
+**Rendering a list writes nothing**, because a list that shows no photograph discloses no face.
+Logging it would inflate the record and weaken what the record means.
+
+The surface **tells the operator this is happening** rather than only recording it. The residual is
+that the operator sees every face on the platform; the log is the whole mitigation, and a mitigation
+nobody is shown is a claim rather than a control.
+
+## Three days
+
+ADR-0010 displays _menos de 3 días_, backs it with an alert, and forbids any automatic transition. So
+this is an alarm and a piece of copy, never a state machine.
+
+**A daily trigger.dev schedule, pinned to `America/Bogota`, emailing the operator through ADR-0015's
+outbox and pinging Healthchecks.io** — the shape ADR-0028 established for ADR-0020's deadline monitor,
+reused rather than reinvented. It is the sixth schedule.
+
+**No SMS and no Pushover.** ADR-0028 reserves the escalating channel for a dead man's switch, on a
+rule worth not eroding: _a dead man's switch may not share a failure mode with the alarm it guards._ A
+photo backlog is not a compliance deadline, and #6 priced SMS to +57 out of the budget anyway.
+
+Queue age is surfaced **in the list**, as the oldest item's age. The pending card shown to the Person
+is ADR-0027's, unchanged.
+
+## Neither record survives its subject
+
+`photo_reviews` and the operator access log are new tables referencing `persons`, so ADR-0017 forces
+each to declare an **erasure classification** where it is defined and ADR-0021 joins **a retention
+term** to the same declaration. The reflective invariant fails on a table that has not.
+
+**Both are `with Person`, both 12 months.**
+
+ADR-0021 has already run this argument once and reached this answer. It declined the ban blocklist
+because _"a retained coded fraud reason about someone who asked to be forgotten is plausibly `dato
+sensible`"_ under art. 5's open list. **A retained refusal code about somebody's face is that argument
+at full strength** — `face_not_visible` is a proposition about a person's appearance, and the object it
+describes is a _dato biométrico_ ADR-0010 treats as sensitive throughout. Keeping either row past the
+erasure would mean the platform remembers something about the body of a person who asked to be
+forgotten.
+
+The access log has no independent customer to keep it for. ADR-0011 rested it on arts. 4(g)/17(d), and
+ADR-0020 later found those _"secure the store rather than except a Titular's access"_; its real basis is
+**art. 8(c), the Titular's right to know who accessed their data** — and after an erasure there is no
+Titular to exercise it.
+
+Twelve months matches `offer_send_attempts`, the existing table for an attempt that led nowhere.
+
+**The cost, named:** after an erasure we cannot show a regulator who viewed that face. That is the same
+trade ADR-0021 accepted for the ban record, taken again for consistency rather than rediscovered.
+
+## Skill Suggestions, and the end of a read-only catalog
+
+ADR-0012 gives the operator a queue of what people could not find, and calls it _"the only honest
+measure of how good the vocabulary is"_. It never says what the operator can **do** with one.
+
+**Four states: `pending` → `shortlisted` | `dismissed`, and `authored` carrying a `skill_id`.**
+_Shortlisted_ is chosen as a word that cannot be misread as _added_.
+
+### `@repo/catalog` becomes writable by an operator, and the sieve moves into the form
+
+ADR-0006 declares `@repo/catalog` _"seeded, read-only at runtime, so no term is created by a user,
+ever"_ — which would mean every new word costs a seed change, a migration and a deploy. **That reading
+is reversed here**, and ADR-0012's own reasoning is what reverses it: it rejected case-by-case
+adjudication partly because _"the Skill Suggestion queue **abolishes 'seed time'** — term-adding is
+continuous"_. A vocabulary designed to grow continuously should not need a release per word.
+
+The catalog is already a Postgres table; _read-only at runtime_ was a discipline, not a property. So
+the real question was only **who may write it**, and three of the four objections are work rather than
+argument: `search_text` moves from seed-time precomputation to computation on write (ADR-0014's
+promise that _`unaccent` never runs in a query_ is preserved, only its reason changes); the slug needs
+a uniqueness constraint because it becomes a public indexable URL segment under ADR-0011; retirement
+stays `retired` + `superseded_by`, unchanged.
+
+**The fourth objection is real and is answered rather than waived.** ADR-0012's proxy rule — _a term
+names something you do, never something you are_ — is an **art. 5 discrimination sieve**, not editorial
+taste. A release runs it past a diff and the pull-request gate; a form runs it past one person late at
+night.
+
+**So the sieve moves into the form.** Before a Skill saves, the operator answers ADR-0012's own
+tie-breaker — _could a person **without** the protected attribute plausibly hold this?_ — and the
+answer is stored on the row. ADR-0012 rejected case-by-case judgement because _"Ley 1581 puts the
+burden on the Responsable to **demonstrate** compliance: a written rule plus a term list is
+demonstrable, 'we used our judgement on each one' is not."_ A recorded answer per term is **more**
+demonstrable than a seed diff, not less: the diff records that a term was added, this records that the
+rule was applied to it.
+
+Accepted with it: **a term authored at 11pm is live and indexed immediately, with no second reader.**
+The mitigation is that `retired` is one click and existing links keep resolving, which ADR-0012 already
+built.
+
+### The person is never told
+
+No reply, ever, in v1. ADR-0012 forbids promising the term, and between _"we added it"_ and silence
+there is no honest message.
+
+**This closes something larger.** ADR-0015 named three events that would earn a `notifications` table
+— _a Report resolved, a Photo approved, a Skill Suggestion answered_. ADR-0013 killed the first (never
+notified), ADR-0027 killed the second and observed the list was _"one event short of the argument"_.
+This is the third. **ADR-0015's condition now has no candidate left in v1**, and the outbox remains all
+this product needs.
+
+## Data requests: the door ADR-0020 never located
+
+Everything about this list is ADR-0020's decision rendered. It adds exactly one thing: **the form for a
+request that arrived by email**, which ADR-0020 requires — _"an operator creates the row by hand"_ — and
+never places.
+
+Three controls and no more: **add**, **mark complete** (which stamps `due_at`, once, never
+recomputed), **mark resolved**. The list shows the two ADR-0020 columns, the derived _reclamo en
+trámite_ legend, and business days remaining.
+
+The reply itself is composed and sent out of band, exactly as ADR-0020 specifies — _"redacting prose is
+judgement no code can make"_ — and this surface records that it happened without authoring it.
+
+## The exposure we do not reduce
+
+ADR-0010 accepted a residual on the record: pre-moderation means the operator views every face on the
+platform. **Nothing here reduces it, and that is a decision rather than an omission.**
+
+Blur-until-click and thumbnails-first were both considered. The operator's task **is** to look at the
+face, and ADR-0027's vocabulary makes four of six codes undecidable from a blurred or small image —
+`other_people`, `contact_visible`, `document` and `face_not_visible` in particular. Friction that must
+be clicked through every time buys no privacy: the row count in the access log is identical either way.
+
+The honest mitigation is the one already built: there is exactly one operator, every issuance is
+recorded, the queue is small, and the surface says so on the screen.
+
+## Two boundaries, so they are not quoted wrongly later
+
+**ADR-0026 forbids per-person signals and does not reach this surface.** That prohibition governs
+surfaces showing a Person **to somebody else** — a report count beside a profile turns queue latency
+into a public accusation. The operator's queue shows **work to the operator**, and ADR-0013 requires it
+to: _"accumulation reorders the queue and does nothing else."_ ADR-0027 drew the first boundary on
+ADR-0026 (the owner's own Photo screen); this is the second, and the two must never be quoted at each
+other.
+
+**ADR-0025's equal-weight rule does not reach it either.** A filled primary beside a ghosted escape is
+forbidden on **consent** surfaces, because D.1377 art. 6's ban on conditioning arrives through CSS. It
+protects a Titular being asked to hand over sensitive data. Nobody consents on this surface, so the
+ordinary pairing is allowed.
+
+## The sidebar tokens stop being aliases
+
+`globals.css` parked every `--sidebar-*` token as an alias of the page token it would otherwise
+duplicate, and said the day a real navigation surface is designed is the day to give them values
+_"deliberately, and with the pairs re-audited"_. **This is that surface** — the first and, in v1, the
+only persistent navigation in the product, since ADR-0011 gives the public side a Wall and a Public
+View rather than a nav.
+
+The sidebar sits **one step off the page**, not a second palette: same hue, same ink, a deeper ground.
+Three tokens left the alias — `--sidebar`, because a nav that only just leaves the page reads as a
+rendering artefact; `--sidebar-accent`, because the page value was picked against white and nearly
+vanishes on the sidebar's own ground, leaving hover and the current item to separate by almost nothing;
+and `--sidebar-border`, measured against the darker of the two surfaces it divides. The ink and the
+brand stay aliases: they do not change because the ground did. `--sidebar-primary` marks the **current
+item**, never a call to action.
+
+All four sidebar pairs clear the gate against the real stylesheet.
+
+## Consequences
+
+- **ADR-0009 is amended** — 2FA is required for `operator` and unavailable to everyone else; that
+  account is email/password only. Its reasoning about Persons is untouched.
+- **ADR-0013 is amended** — `reports.reporter_person_id` is nullable, a null reporter means the
+  platform raised it, and an operator-raised Report carries a code and no prose. Its count of internal
+  queues goes from three to four.
+- **ADR-0006 is amended** — `@repo/catalog` is no longer read-only at runtime; an operator may author a
+  Skill. No new package and no new DAG edge: the write is a use case in `apps/web/src/use-cases/`, the
+  shape ADR-0028 already chose when it refused an eleventh package for `@repo/jobs`.
+- **ADR-0012 is amended** — terms are authored at runtime, and the proxy rule moves from authoring
+  discipline into the write path as a recorded per-term answer.
+- **ADR-0014 is amended** — `search_text` is computed on write rather than at seed time; the promise
+  that `unaccent` never runs in a query is unchanged.
+- **ADR-0010's** operator access log, three-day alert and evidentiary row are implemented; its residual
+  is confirmed unmitigated.
+- **ADR-0011's** re-homing of the access log is discharged.
+- **ADR-0020's** missing hand-create path is located.
+- **ADR-0015 is extended, not amended** — its third and last notification candidate is decided
+  negatively, so the condition it set has nothing left to trigger it in v1.
+- **ADR-0021's retention table gains two rows**: `photo_reviews` and the operator access log, both
+  `with Person`, both 12 months.
+- **ADR-0029 is completed** — the `--sidebar-*` block it parked now carries values, audited.
+- **`CONTEXT.md`** gains **Operator**, which every ADR has used since ADR-0010 without ever defining;
+  **Photo Review** and **Skill Suggestion** are amended.
+- **ADR-0017 gains an Invariant Test** — the `admin` plugin's ban endpoints are never called and
+  `persons.status` is the only suspension.
+- **`docs/runbook.md`** gains the operator's backup codes, stored with the `subject_key` HMAC.
+- **Nothing here has an automated guard beyond that one test.** Under ADR-0017 this surface is a set of
+  React components and Server Action adapters, which are two of the three things v1 deliberately does
+  not test. The list joins the one ADR-0025 opened.
+
+## Rejected
+
+**A separate admin application.** ADR-0013's argument, applied to the count it actually has.
+
+**Impersonation.** The one admin-plugin capability that silently defeats a control another ADR built:
+an impersonated session reads a Person's pending Photo through the product surface, where the access
+log does not run.
+
+**Using the plugin's ban.** Timed, automatic, and forbidden by ADR-0013 — kept out by a test rather
+than by a comment, because the schema is where the prohibition would otherwise have to be read.
+
+**A contact sheet.** Faster, and it buys throughput this queue does not need at the cost of putting a
+dozen strangers' faces on one screen and making batch approval the obvious next feature.
+
+**A claim or `in_review` state.** A lock against nobody.
+
+**Any priority order on the photo queue.** Every candidate sorts people rather than photographs.
+
+**Blur-until-click and thumbnails-first.** Friction that buys no privacy: the operator's task is to
+look at the face, and four of six codes are undecidable without it.
+
+**A code list in the picker.** Reintroduces the operator-convenience vocabulary ADR-0027 rejected, on
+the one screen where the decision is made.
+
+**Logging list renders.** A list shows no face; logging it weakens what the log means.
+
+**A synthetic operator Person to author platform-raised Reports.** A fabricated Titular in a table of
+real ones.
+
+**Replying to a Skill Suggestion.** Any message is either a promise ADR-0012 forbids or silence with
+extra steps.
+
+**Release-only authorship of Skills.** A deploy per word, against a vocabulary ADR-0012 designed to
+grow continuously.
+
+**Authoring a Skill as a draft invisible until the next release.** Reintroduces the deploy the change
+exists to remove.
+
+**SMS or Pushover for the three-day alert.** Priced out by #6, and it would erode ADR-0028's rule that
+the escalating channel belongs to the dead man's switch alone.

--- a/docs/adr/0031-one-internal-surface-and-the-queue-decides-nothing.md
+++ b/docs/adr/0031-one-internal-surface-and-the-queue-decides-nothing.md
@@ -1,4 +1,4 @@
-# There is one internal surface, and a Photo is judged one face at a time
+# There is one internal surface, the queue decides nothing, and a Photo is judged one face at a time
 
 ADR-0010 pre-moderates every Photo — nothing is visible to anyone but its owner until an operator
 approves it — which makes a review surface a **launch requirement** rather than tooling. Without one
@@ -7,7 +7,9 @@ handed this ticket _"a finished vocabulary and a queue with two exits"_, keeping
 an operator picks a code, the queue order, the access log and the three-day alert.
 
 Prototyped at `docs/design/photo-review-prototype/` on `prototype/photo-review-queue`: two ways of
-judging one photograph, inside the shell decided below.
+judging one photograph, inside the shell decided below. **Building both is what produced the answer,
+and it was neither of them** — the losing variant turned out to be the right _queue_ once it was
+stripped of the power to decide anything.
 
 ## Four lists, one surface
 
@@ -119,25 +121,46 @@ priority here has one, and every candidate sorts **people** rather than photogra
 failure ADR-0010 rule 1 and ADR-0026 both exist to prevent. Under oldest-first the age of the head of
 the queue already **is** the sort key, so displaying it asserts nothing the order does not.
 
-## One face at a time
+## The queue decides nothing, and a Photo is judged one face at a time
 
-**The operator judges one photograph at a time.** The contact sheet was built rather than argued
-about, and it loses on three counts.
+The two candidates were one-at-a-time and a contact sheet, and **building both produced a third
+answer that neither of them was** — which is the useful outcome and the reason this was prototyped
+rather than argued.
 
-It puts a dozen strangers' faces on one screen, deepening the residual ADR-0010 accepted and this ADR
-declines to mitigate. Its obvious next feature is a checkbox and an _approve selected_ button, which
-is what ADR-0010 refuses outright: **a person's standing on this platform never changes without a
-human having looked** — the same sentence ADR-0013 reused to refuse accumulation-triggered action. And
-it is the only variant where the access log stops matching the decision: one screen, twelve faces,
-twelve rows, one glance.
+**The contact sheet is the queue, and it carries no control that changes anything.** Every approval
+and every refusal happens on a detail page reached by opening one photograph. So the sheet is
+**navigation**, and judgment stays where it was.
 
-The speed argument is real and is not dismissed. It loses because the queue is small by construction
-— most Persons upload once (ADR-0010's own reason for accepting a queue at all) — so the throughput a
-sheet buys is throughput we do not need, paid for in the one currency this surface is expensive in.
+That resolves the decisive objection rather than trading it away. The argument against a sheet was
+never its density — it was that _approve selected_ is one checkbox away, and ADR-0010 refuses that
+outright: **a person's standing on this platform never changes without a human having looked**, the
+same sentence ADR-0013 reused to refuse accumulation-triggered action. A sheet that decides nothing
+cannot grow that feature by accident, and this ADR forbids it growing one on purpose.
 
-**The photograph is set inside a mount**: a photo-proportioned frame with a mat inset. ADR-0027 fixed
-that shape for the refusal notice, where it holds the space the photograph is not. Here it is full.
-It is the same rectangle on both sides of the same event, and using it twice is the point.
+It also answers the objection to one-at-a-time that the prototype made visible: an operator working a
+queue they cannot see is working blind, with no idea whether five photographs are waiting or fifty,
+and ADR-0010's whole commitment is about **age**. The sheet is where that is legible.
+
+**Two costs it does not dodge, and neither is waived.**
+
+The first is exposure. A dozen strangers' faces on one screen is the residual ADR-0010 accepted,
+deepened — and this ADR still declines to mitigate it with blur or a smaller thumbnail, for the
+reasons below. What it buys is that the operator meets those faces **once, while navigating**, rather
+than never seeing the shape of their own queue.
+
+The second is the access log, and it **changes a grain ADR-0010 wrote**. That ADR expected _"one row
+per review rather than one per page view"_. Twelve thumbnails are twelve faces served, so twelve
+signed URLs and twelve rows for one glance. **We log them all**, because the rule that survives
+contact with this design is the simpler one: **if a face is rendered, it is recorded.** Anything else
+would mean the log is silent about disclosures that actually happened, and art. 8(c) is the Titular's
+right to know who accessed their data — not who filed a decision about it. So ADR-0010's grain is
+amended: **one row per face seen.** The log gets noisier and more truthful, and the noise is real —
+a day's browsing writes far more rows than a day's decisions.
+
+**The photograph is set inside a mount** on the detail page: a photo-proportioned frame with a mat
+inset. ADR-0027 fixed that shape for the refusal notice, where it holds the space the photograph is
+not. Here it is full. It is the same rectangle on both sides of the same event, and using it twice is
+the point.
 
 ## The operator picks a sentence, not a code
 
@@ -189,11 +212,18 @@ ADR-0011 killed the general profile-view log it was going to feed, so ADR-0010's
 **The logged act is the issuance of the signed URL.** ADR-0010 serves bytes by time-limited GET and
 never from a public bucket, so that issuance is the only moment a face actually reaches an operator's
 screen. Logging there is automatic; logging in the interface depends on whoever writes the component
-remembering to. It also gives ADR-0010's own grain — _"one row per review rather than one per page
-view"_ — for free under the one-at-a-time decision.
+remembering to.
 
-**Rendering a list writes nothing**, because a list that shows no photograph discloses no face.
-Logging it would inflate the record and weaken what the record means.
+**That is the whole rule, and it is deliberately not conditioned on the operator's intent: if a face
+is rendered, it is recorded.** An earlier draft of this ADR paired one-at-a-time review with the
+tidier claim that a list render writes nothing — true only while the list showed no photographs. The
+queue shows thumbnails, so it discloses twelve faces, and a log that stayed quiet about them would be
+silent about the disclosures most likely to happen. **ADR-0010's _"one row per review rather than one
+per page view"_ is amended to one row per face seen.**
+
+A screen that genuinely renders no photograph — the Reports, Skill Suggestions and Data Requests
+lists — still writes nothing, because nothing was disclosed. The condition is the face, never the
+page.
 
 The surface **tells the operator this is happening** rather than only recording it. The residual is
 that the operator sees every face on the platform; the log is the whole mitigation, and a mitigation
@@ -308,15 +338,23 @@ judgement no code can make"_ — and this surface records that it happened witho
 ## The exposure we do not reduce
 
 ADR-0010 accepted a residual on the record: pre-moderation means the operator views every face on the
-platform. **Nothing here reduces it, and that is a decision rather than an omission.**
+platform. **Nothing here reduces it, the thumbnail queue slightly deepens it, and that is a decision
+rather than an omission.**
 
-Blur-until-click and thumbnails-first were both considered. The operator's task **is** to look at the
-face, and ADR-0027's vocabulary makes four of six codes undecidable from a blurred or small image —
+Blur-until-click was considered and refused. The operator's task **is** to look at the face, and
+ADR-0027's vocabulary makes four of six codes undecidable from a blurred or small image —
 `other_people`, `contact_visible`, `document` and `face_not_visible` in particular. Friction that must
-be clicked through every time buys no privacy: the row count in the access log is identical either way.
+be clicked through every time buys no privacy, because the disclosure still happens and is still
+logged.
 
-The honest mitigation is the one already built: there is exactly one operator, every issuance is
-recorded, the queue is small, and the surface says so on the screen.
+**Thumbnails-first was refused as a _review_ mode and adopted as a _navigation_ one**, and the
+distinction is the whole of it. A thumbnail is too small to decide from, which is why nothing on the
+queue decides. It is large enough to tell one waiting photograph from another, which is what a queue
+is for. The cost is that the operator meets every face once while navigating and again while
+deciding — and both are recorded, because the log condition is the face rather than the intent.
+
+The honest mitigation is the one already built: there is exactly one operator, every rendered face is
+recorded, the queue is small by construction, and the surface says so on the screen.
 
 ## Two boundaries, so they are not quoted wrongly later
 
@@ -365,7 +403,10 @@ All four sidebar pairs clear the gate against the real stylesheet.
 - **ADR-0014 is amended** — `search_text` is computed on write rather than at seed time; the promise
   that `unaccent` never runs in a query is unchanged.
 - **ADR-0010's** operator access log, three-day alert and evidentiary row are implemented; its residual
-  is confirmed unmitigated.
+  is confirmed unmitigated and, with a thumbnail queue, slightly deepened. **Its log grain is amended**
+  — _"one row per review rather than one per page view"_ becomes **one row per face seen**, because the
+  queue renders photographs and a log silent about them would be silent about the commonest
+  disclosure. Its refusal of batch action is reinforced rather than eroded: the queue decides nothing.
 - **ADR-0011's** re-homing of the access log is discharged.
 - **ADR-0020's** missing hand-create path is located.
 - **ADR-0015 is extended, not amended** — its third and last notification candidate is decided
@@ -393,8 +434,15 @@ log does not run.
 **Using the plugin's ban.** Timed, automatic, and forbidden by ADR-0013 — kept out by a test rather
 than by a comment, because the schema is where the prohibition would otherwise have to be read.
 
-**A contact sheet.** Faster, and it buys throughput this queue does not need at the cost of putting a
-dozen strangers' faces on one screen and making batch approval the obvious next feature.
+**A contact sheet that decides anything.** The sheet ships as the queue, but no control on it may
+change a Photo's state, and **`approve selected` may never be built** — that is the whole reason a
+sheet was nearly refused outright.
+
+**Judging from thumbnails.** Four of six ADR-0027 codes are undecidable at that size, so a decision
+taken on the sheet would be a guess wearing a code.
+
+**A queue with no photographs in it.** It would have kept ADR-0010's log grain intact and cost the
+operator any sense of what is waiting — and the grain was the weaker of the two things to protect.
 
 **A claim or `in_review` state.** A lock against nobody.
 
@@ -406,7 +454,9 @@ look at the face, and four of six codes are undecidable without it.
 **A code list in the picker.** Reintroduces the operator-convenience vocabulary ADR-0027 rejected, on
 the one screen where the decision is made.
 
-**Logging list renders.** A list shows no face; logging it weakens what the log means.
+**Logging by page rather than by face.** Both directions were rejected: a rule that logs every list
+render records disclosures that did not happen, and one that never logs a list stays silent about the
+twelve that did. The face is the condition.
 
 **A synthetic operator Person to author platform-raised Reports.** A fabricated Titular in a table of
 real ones.

--- a/docs/design/photo-review-prototype/README.md
+++ b/docs/design/photo-review-prototype/README.md
@@ -1,0 +1,71 @@
+# Prototype — the operator surface, and how a Photo is judged (#28)
+
+Throwaway. Open `index.html` in a browser; there is nothing to install and nothing to run.
+
+## The question
+
+Only one, because the grilling session settled everything else before this file existed: **one
+internal surface, a sidebar with four links, each carrying a count.**
+
+What was left open is how an operator judges a single photograph:
+
+| `?view=` |                                                                                                          |
+| -------- | -------------------------------------------------------------------------------------------------------- |
+| `single` | One photo at a time. **Proposed.**                                                                       |
+| `sheet`  | A contact sheet of twelve. The faster alternative, built so it can be argued with rather than dismissed. |
+
+Two supporting toggles, because both change what the surface has to say: `?age=late` puts the queue
+past ADR-0010's three days, and `?repeat=on` shows a person's second refusal on the same code.
+
+## What it is trying to show
+
+**The mount, inverted.** The [#29 prototype](../photo-refusal-prototype/) set the refusal _inside_ a
+photo-proportioned frame with a mat inset, because ADR-0010 destroys the rejected bytes and the
+message is therefore about something neither party can see — the reason lived in the space where the
+photo is not. Here the same rectangle holds the photograph. It is the one surface in the product
+where the mount is full, and the decision is made inside it.
+
+**The operator picks a sentence, not a code.** The six options render as the **Spanish text the
+person will receive**, at reading size, in the body face, with the English identifier set small
+beside them. ADR-0027 authored that vocabulary copy-first precisely because a list written for an
+operator's queue — `INVALID`, `LOW_QUALITY` — translates into the sentence that ADR exists to avoid.
+A picker showing codes quietly undoes the argument. Selecting one also reveals **what actually
+leaves the building**: the imperative half, which is all the email carries.
+
+`not_for_work` and `face_not_visible` share one imperative word for word, and the prototype says so
+on the card rather than leaving it to look like a copy-paste error. It is the control that stops the
+email being read backwards to the code.
+
+**Where the log happens.** The line under the mount states that opening the photo was recorded. The
+logged act is the issuance of the signed URL — the only moment a face actually reaches the screen.
+
+## Language
+
+The operator surface is **Spanish**, like every other surface a person reads. This file's own chrome
+— the bar at the bottom, the state readout, the note on the contact sheet — is **English**, per
+ADR-0001 as amended by #30: a prototype's controls are chrome, and Spanish chrome grows Spanish state
+keys. Identifiers are English everywhere: `pending`, `face_not_visible`, `shortlisted`.
+
+## Tokens
+
+**ADR-0029's, copied verbatim** from `packages/design-system/src/styles/globals.css`. This is the
+first prototype in the repo with a real token layer to build on — #29's used the dead
+`NEXTJS_HANDOFF.md` values because ADR-0029 did not exist yet. Nothing here invents a colour.
+
+The `--sidebar-*` values are the one exception, and they are this ticket's proposal: `globals.css`
+parked them as aliases _"until a real navigation surface is designed"_, and this is that surface.
+They have since landed in `globals.css` and cleared `pnpm --filter @repo/design-system
+check-contrast`.
+
+There is no dark mode. Do not add a media query.
+
+## Deliberately fake
+
+The photographs are CSS gradients with a geometric figure, labelled _foto de prueba_. A prototype
+about strangers' faces has no business carrying invented ones, and ADR-0010 rule 4 — never a
+technical means of identification — is worth honouring in a mock too.
+
+## Not cleared
+
+No screen-reader pass. The sidebar has no roving tabindex and no skip link. The counts are static.
+Nothing here is tested, and under ADR-0017 nothing here _can_ be.

--- a/docs/design/photo-review-prototype/README.md
+++ b/docs/design/photo-review-prototype/README.md
@@ -2,17 +2,28 @@
 
 Throwaway. Open `index.html` in a browser; there is nothing to install and nothing to run.
 
-## The question
+## The question, and the answer that was neither option
 
-Only one, because the grilling session settled everything else before this file existed: **one
-internal surface, a sidebar with four links, each carrying a count.**
+Only one question, because the grilling session settled everything else before this file existed:
+**one internal surface, a sidebar with four links, each carrying a count.** What was open is how an
+operator judges a photograph — one at a time, or from a contact sheet of many.
 
-What was left open is how an operator judges a single photograph:
+**Seeing both produced a third answer**, which is why this was built rather than argued. The sheet
+ships as the **queue** and decides nothing; _Abrir_ lands on the detail page, where every approval
+and refusal happens one face at a time.
 
-| `?view=` |                                                                                                          |
-| -------- | -------------------------------------------------------------------------------------------------------- |
-| `single` | One photo at a time. **Proposed.**                                                                       |
-| `sheet`  | A contact sheet of twelve. The faster alternative, built so it can be argued with rather than dismissed. |
+| `?view=` |                                                                         |
+| -------- | ----------------------------------------------------------------------- |
+| `sheet`  | The queue. No control on it changes anything. **Default.**              |
+| `single` | The detail page _Abrir_ opens — the only place a Photo's state changes. |
+
+That keeps ADR-0010's rule (_a person's standing never changes without a human having looked_) while
+answering the objection one-at-a-time could not: an operator working a queue they cannot see has no
+idea whether five photographs are waiting or fifty, and ADR-0010's commitment is about **age**.
+
+**Two costs it does not dodge**, both stated on the queue itself: a dozen faces on one screen is the
+exposure ADR-0010 accepted, deepened; and twelve thumbnails are twelve signed URLs, so the access
+log's grain becomes _one row per face seen_ rather than ADR-0010's _"one row per review"_.
 
 Two supporting toggles, because both change what the surface has to say: `?age=late` puts the queue
 past ADR-0010's three days, and `?repeat=on` shows a person's second refusal on the same code.

--- a/docs/design/photo-review-prototype/index.html
+++ b/docs/design/photo-review-prototype/index.html
@@ -1032,13 +1032,27 @@
     <script>
       const DEFAULTS = { view: "single", age: "fresh", repeat: "off" };
 
-      function state() {
+      // State is a plain object, seeded from the URL on load. The URL is kept in
+      // sync as a courtesy — so a variant can be linked or reloaded — but it is
+      // NOT the source of truth, because this file is opened with a double click
+      // and on a file:// origin the history API throws a SecurityError in
+      // Chrome. The other prototypes in this repo drive state off the URL and
+      // quietly lose their switcher when opened that way.
+      let S = { ...DEFAULTS };
+
+      {
         const q = new URLSearchParams(location.search);
-        const s = { ...DEFAULTS };
         for (const k of Object.keys(DEFAULTS)) {
-          if (q.get(k)) s[k] = q.get(k);
+          if (q.get(k)) S[k] = q.get(k);
         }
-        return s;
+      }
+
+      function syncUrl() {
+        try {
+          history.replaceState(null, "", "?" + new URLSearchParams(S).toString());
+        } catch {
+          /* file:// — the buttons still work, the address bar just does not follow */
+        }
       }
 
       // Build the contact sheet so the density is real rather than suggested.
@@ -1077,7 +1091,7 @@
       }
 
       function render() {
-        const s = state();
+        const s = S;
 
         document.getElementById("view-single").hidden = s.view !== "single";
         document.getElementById("view-sheet").hidden = s.view !== "sheet";
@@ -1106,16 +1120,18 @@
         console.log("[prototype #28] state:", s);
       }
 
-      render();
-      addEventListener("popstate", render);
       for (const a of document.querySelectorAll(".chrome a")) {
         a.addEventListener("click", (e) => {
           e.preventDefault();
-          history.pushState({}, "", a.href);
+          S = { ...S, [a.dataset.p]: a.dataset.v };
+          syncUrl();
           render();
           scrollTo({ top: 0 });
         });
       }
+
+      syncUrl();
+      render();
     </script>
   </body>
 </html>

--- a/docs/design/photo-review-prototype/index.html
+++ b/docs/design/photo-review-prototype/index.html
@@ -1,0 +1,1121 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>PROTOTIPO — Revisión de fotos (Encuentra, #28)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Figtree:wght@500;600;700&family=Inter:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ------------------------------------------------------------------
+         THROWAWAY PROTOTYPE — ticket #28, wayfinder map #1.
+
+         THE QUESTION, and it is only one. The shell was settled in the
+         grilling session before this file existed: one internal surface,
+         a sidebar with four links, each carrying a count. What was NOT
+         settled is how an operator judges a single photograph:
+
+           ?view=single   one photo at a time     (proposed)
+           ?view=sheet    a contact sheet of many (the fast alternative)
+
+         Everything else here is an existing ADR rendered so the two
+         variants can be compared at real density. Supporting toggles:
+
+           ?age=late      the queue has missed ADR-0010's 3 days
+           ?repeat=on     this person's SECOND refusal on the same code
+
+         THE SIGNATURE: the mount, inverted. The #29 prototype set the
+         refusal INSIDE a photo-proportioned frame with a mat inset,
+         because ADR-0010 destroys the rejected bytes and the message is
+         about something neither party can see — the reason lived in the
+         space where the photo is not. Here the same rectangle holds the
+         photograph itself. It is the one surface in the product where
+         the mount is full, and the decision is made inside it.
+
+         THE SECOND MOVE, and the one worth arguing about: the six
+         refusal options are rendered as THE SPANISH SENTENCES THE PERSON
+         WILL READ, at reading size, in the body face. The English code is
+         set small and grey beside each. ADR-0027 authored that vocabulary
+         copy-first precisely because a list written for an operator's
+         queue — INVALID, LOW_QUALITY — translates into the sentence that
+         ADR exists to avoid. A picker that shows codes quietly undoes it.
+         So the operator picks a sentence about a person, and can see that
+         is what they are doing.
+
+         TOKENS ARE ADR-0029's, copied verbatim from
+         packages/design-system/src/styles/globals.css. This is the first
+         prototype in the repo that has a real token layer to build on —
+         #29's used the dead NEXTJS_HANDOFF.md values because ADR-0029 did
+         not exist yet. Nothing here invents a colour. The --sidebar-*
+         values are the ONE exception and they are this ticket's proposal:
+         globals.css parks them as aliases "until a real navigation
+         surface is designed", and this is that surface.
+
+         NO DARK MODE. ADR-0029 removed it. Do not add a media query.
+
+         LANGUAGE: the operator surface is Spanish, like every other
+         surface a person reads (ADR-0001). This file's OWN chrome — the
+         bar at the bottom, the state readout — is English, per ADR-0001
+         as amended by #30: a prototype's controls are chrome, and Spanish
+         chrome grows Spanish state keys. Identifiers stay English
+         everywhere: pending, face_not_visible, shortlisted.
+
+         Not production code. No tests, no error handling, no
+         abstractions. The photographs are CSS, not people: this surface
+         is about strangers' faces and a prototype has no business
+         carrying invented ones.
+         ------------------------------------------------------------------ */
+
+      /* ---- ADR-0029 token layer, verbatim ---------------------------- */
+      :root {
+        --brand-50: oklch(0.975 0.012 248);
+        --brand-100: oklch(0.945 0.026 248);
+        --brand-200: oklch(0.885 0.057 248);
+        --brand-300: oklch(0.81 0.094 248);
+        --brand-400: oklch(0.715 0.114 248);
+        --brand-500: oklch(0.62 0.13 248);
+        --brand-600: oklch(0.545 0.13 248);
+        --brand-700: oklch(0.48 0.122 248);
+        --brand-800: oklch(0.41 0.109 248);
+        --brand-900: oklch(0.33 0.089 248);
+        --brand-950: oklch(0.235 0.066 248);
+
+        --background: oklch(1 0 0);
+        --foreground: oklch(0.2 0.012 248);
+        --card: oklch(1 0 0);
+        --card-foreground: oklch(0.2 0.012 248);
+
+        --primary: var(--brand-700);
+        --primary-foreground: oklch(1 0 0);
+
+        --secondary: oklch(0.955 0.008 248);
+        --secondary-foreground: oklch(0.2 0.012 248);
+        --accent: oklch(0.955 0.008 248);
+        --accent-foreground: oklch(0.2 0.012 248);
+        --muted: oklch(0.97 0.004 248);
+        --muted-foreground: oklch(0.54 0.02 248);
+
+        --border: oklch(0.915 0.006 248);
+        --input: oklch(0.65 0.02 248);
+        --ring: var(--brand-700);
+
+        --success: oklch(0.45 0.1 155);
+        --success-surface: oklch(0.965 0.028 155);
+        --success-border: oklch(0.82 0.06 155);
+
+        --warning: oklch(0.45 0.094 75);
+        --warning-surface: oklch(0.965 0.028 75);
+        --warning-border: oklch(0.82 0.072 75);
+
+        --destructive: oklch(0.45 0.13 22);
+        --destructive-foreground: oklch(1 0 0);
+        --destructive-surface: oklch(0.965 0.016 22);
+        --destructive-border: oklch(0.82 0.078 22);
+
+        /* ---- PROPOSED by #28. globals.css parks every one of these as an
+           alias of the page token it would otherwise duplicate, and says the
+           day a real navigation surface is designed is the day to give them
+           values "deliberately, and with the pairs re-audited". This is that
+           day, and these are the values. The sidebar sits one step off the
+           page rather than inventing a second palette, the accent is the
+           hover/current surface, and the primary is the current item. ---- */
+        --sidebar: oklch(0.975 0.008 248);
+        --sidebar-foreground: oklch(0.2 0.012 248);
+        --sidebar-primary: var(--brand-700);
+        --sidebar-primary-foreground: oklch(1 0 0);
+        --sidebar-accent: oklch(0.94 0.016 248);
+        --sidebar-accent-foreground: oklch(0.2 0.012 248);
+        --sidebar-border: oklch(0.9 0.01 248);
+        --sidebar-ring: var(--brand-700);
+
+        --radius: 0.625rem;
+
+        --font-sans: "Inter", system-ui, sans-serif;
+        --font-heading: "Figtree", system-ui, sans-serif;
+        --font-mono: "Geist Mono", ui-monospace, monospace;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: var(--font-sans);
+        background: var(--background);
+        color: var(--foreground);
+        font-size: 15px;
+        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      h1,
+      h2,
+      h3 {
+        font-family: var(--font-heading);
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        margin: 0;
+      }
+
+      :focus-visible {
+        outline: 2px solid var(--ring);
+        outline-offset: 2px;
+        border-radius: 4px;
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+      }
+
+      /* ---- shell ------------------------------------------------------ */
+      .app {
+        display: grid;
+        grid-template-columns: 244px 1fr;
+        min-height: 100vh;
+      }
+
+      .sidebar {
+        background: var(--sidebar);
+        border-right: 1px solid var(--sidebar-border);
+        padding: 20px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .wordmark {
+        font-family: var(--font-heading);
+        font-weight: 700;
+        font-size: 15px;
+        padding: 0 10px 4px;
+        color: var(--sidebar-foreground);
+      }
+
+      .wordmark span {
+        display: block;
+        font-family: var(--font-sans);
+        font-weight: 500;
+        font-size: 12px;
+        color: var(--muted-foreground);
+        letter-spacing: 0.02em;
+      }
+
+      .nav {
+        margin-top: 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .nav a {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 9px 10px;
+        border-radius: calc(var(--radius) * 0.8);
+        text-decoration: none;
+        color: var(--sidebar-foreground);
+        font-size: 14px;
+        font-weight: 500;
+        min-height: 40px;
+      }
+
+      @media (hover: hover) and (pointer: fine) {
+        .nav a:hover {
+          background: var(--sidebar-accent);
+          color: var(--sidebar-accent-foreground);
+        }
+      }
+
+      .nav a[aria-current="page"] {
+        background: var(--sidebar-primary);
+        color: var(--sidebar-primary-foreground);
+      }
+
+      .nav a .label {
+        flex: 1;
+      }
+
+      /* The count. Exact to 99, then 99+ — an unbounded number is how a
+         backlog becomes a wall. It is a count of ITEMS, never of people:
+         ADR-0026 forbids per-person signals, and that rule governs surfaces
+         showing a Person to somebody else. This one shows work to the
+         operator. */
+      .count {
+        font-family: var(--font-mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 12px;
+        font-weight: 500;
+        padding: 1px 7px;
+        border-radius: 999px;
+        background: var(--secondary);
+        color: var(--muted-foreground);
+      }
+
+      .nav a[aria-current="page"] .count {
+        background: color-mix(in oklab, var(--sidebar-primary-foreground) 22%, transparent);
+        color: var(--sidebar-primary-foreground);
+      }
+
+      .nav .zero .count {
+        opacity: 0.55;
+      }
+
+      .sidebar-foot {
+        margin-top: auto;
+        padding: 10px;
+        font-size: 12px;
+        color: var(--muted-foreground);
+        border-top: 1px solid var(--sidebar-border);
+      }
+
+      /* ---- main ------------------------------------------------------- */
+      .main {
+        padding: 28px 32px 96px;
+        max-width: 1180px;
+      }
+
+      .page-head {
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        flex-wrap: wrap;
+        margin-bottom: 4px;
+      }
+
+      .page-head h1 {
+        font-size: 22px;
+      }
+
+      /* Queue age, not queue size. ADR-0010's commitment is about AGE:
+         three photos four days old is the alarm; sixty an hour old is not.
+         Under strictly-oldest-first the age of the head of the queue IS
+         the sort key, so this asserts nothing the order does not already. */
+      .age {
+        font-size: 13px;
+        color: var(--muted-foreground);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .age.late {
+        color: var(--warning);
+        font-weight: 500;
+      }
+
+      .subhead {
+        color: var(--muted-foreground);
+        font-size: 14px;
+        margin: 0 0 22px;
+        max-width: 62ch;
+      }
+
+      /* The missed-3-days notice. ADR-0029 rule: `warning` is never a state
+         the person is merely WAITING ON — that reclassified the yellow card
+         the #29 prototype rendered. Here the waiting party is the operator,
+         who is the one who can act, so the token is used as intended. */
+      .late-note {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        background: var(--warning-surface);
+        border: 1px solid var(--warning-border);
+        border-radius: var(--radius);
+        padding: 12px 14px;
+        font-size: 14px;
+        margin-bottom: 22px;
+      }
+
+      .late-note strong {
+        color: var(--warning);
+      }
+
+      /* ---- the mount -------------------------------------------------- */
+      .review {
+        display: grid;
+        grid-template-columns: minmax(280px, 420px) 1fr;
+        gap: 32px;
+        align-items: start;
+      }
+
+      .mount {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 14px 14px 16px;
+        box-shadow: 0 1px 2px oklch(0.2 0.012 248 / 0.05);
+      }
+
+      .mount .plate {
+        aspect-ratio: 4 / 5;
+        border-radius: calc(var(--radius) * 0.6);
+        overflow: hidden;
+        position: relative;
+        background: var(--muted);
+      }
+
+      .mount figcaption {
+        margin-top: 12px;
+        font-size: 12.5px;
+        color: var(--muted-foreground);
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .mount figcaption b {
+        font-weight: 500;
+        color: var(--foreground);
+      }
+
+      /* The access log line. Q4: the logged act is the issuance of the
+         signed URL, which is the only moment a face actually reaches this
+         screen. Stated to the operator rather than merely recorded — the
+         residual ADR-0010 accepted is that the operator sees every face,
+         and the log is the whole mitigation. */
+      .logged {
+        margin-top: 10px;
+        font-size: 12px;
+        color: var(--muted-foreground);
+        display: flex;
+        gap: 7px;
+        align-items: baseline;
+      }
+
+      .logged code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+      }
+
+      /* The photographs are CSS. A prototype about strangers' faces has no
+         business carrying invented ones, and ADR-0010 rule 4 forbids any
+         pipeline that could identify a person from an image — a rule worth
+         honouring in the mock too. */
+      .fake {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+      }
+
+      .fake::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          var(--brand-100),
+          var(--brand-200) 45%,
+          var(--brand-300)
+        );
+      }
+
+      .fake i {
+        position: relative;
+        display: block;
+        width: 38%;
+        aspect-ratio: 1;
+        border-radius: 999px;
+        background: color-mix(in oklab, var(--brand-800) 55%, transparent);
+        transform: translateY(-8%);
+      }
+
+      .fake i::after {
+        content: "";
+        position: absolute;
+        left: -46%;
+        top: 118%;
+        width: 192%;
+        aspect-ratio: 2 / 1.15;
+        border-radius: 999px 999px 0 0;
+        background: color-mix(in oklab, var(--brand-800) 55%, transparent);
+      }
+
+      .fake.v2::before {
+        background: linear-gradient(150deg, oklch(0.93 0.03 75), oklch(0.84 0.06 60));
+      }
+      .fake.v3::before {
+        background: linear-gradient(170deg, oklch(0.93 0.03 155), oklch(0.83 0.05 165));
+      }
+      .fake.v4::before {
+        background: linear-gradient(140deg, oklch(0.93 0.02 300), oklch(0.84 0.05 310));
+      }
+      .fake.v2 i,
+      .fake.v2 i::after {
+        background: color-mix(in oklab, oklch(0.4 0.08 60) 60%, transparent);
+      }
+      .fake.v3 i,
+      .fake.v3 i::after {
+        background: color-mix(in oklab, oklch(0.38 0.07 165) 60%, transparent);
+      }
+      .fake.v4 i,
+      .fake.v4 i::after {
+        background: color-mix(in oklab, oklch(0.38 0.07 310) 60%, transparent);
+      }
+
+      .mock-tag {
+        position: absolute;
+        left: 8px;
+        bottom: 8px;
+        z-index: 2;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        background: oklch(1 0 0 / 0.86);
+        color: var(--muted-foreground);
+        padding: 2px 6px;
+        border-radius: 4px;
+      }
+
+      /* ---- the decision ----------------------------------------------- */
+      .decide h2 {
+        font-size: 15px;
+        margin-bottom: 2px;
+      }
+
+      .decide .hint {
+        font-size: 13.5px;
+        color: var(--muted-foreground);
+        margin: 0 0 16px;
+        max-width: 58ch;
+      }
+
+      .exits {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 26px;
+      }
+
+      .btn {
+        font: inherit;
+        font-weight: 500;
+        min-height: 40px;
+        padding: 0 16px;
+        border-radius: calc(var(--radius) * 0.8);
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: transform 140ms ease;
+      }
+
+      .btn:active {
+        transform: scale(0.97);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .btn {
+          transition: none;
+        }
+        .btn:active {
+          transform: none;
+        }
+      }
+
+      .btn-primary {
+        background: var(--primary);
+        color: var(--primary-foreground);
+      }
+
+      .btn-outline {
+        background: var(--background);
+        color: var(--foreground);
+        border-color: var(--input);
+      }
+
+      .btn-quiet {
+        background: transparent;
+        color: var(--muted-foreground);
+        border-color: transparent;
+        padding: 0 10px;
+      }
+
+      /* A filled primary beside a ghosted escape is forbidden on CONSENT
+         surfaces (ADR-0025, D.1377 art. 6 conditioning arriving through
+         CSS). That rule protects a Titular being asked to hand over
+         sensitive data. Nobody is consenting here, so the pairing is
+         allowed — and this is exactly the kind of boundary that gets
+         quoted wrongly later, so the ADR says it out loud. */
+
+      .codes {
+        border-top: 1px solid var(--border);
+        padding-top: 18px;
+      }
+
+      .codes > p {
+        margin: 0 0 14px;
+        font-size: 13.5px;
+        color: var(--muted-foreground);
+        max-width: 58ch;
+      }
+
+      .code {
+        display: grid;
+        grid-template-columns: 20px 1fr;
+        gap: 12px;
+        padding: 12px 14px;
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 0.8);
+        margin-bottom: 8px;
+        cursor: pointer;
+        background: var(--card);
+      }
+
+      @media (hover: hover) and (pointer: fine) {
+        .code:hover {
+          border-color: var(--input);
+        }
+      }
+
+      .code:has(input:checked) {
+        border-color: var(--primary);
+        background: var(--brand-50);
+      }
+
+      .code input {
+        margin: 4px 0 0;
+        accent-color: var(--primary);
+        width: 16px;
+        height: 16px;
+      }
+
+      /* The sentence at reading size in the body face — this is the copy the
+         person receives, not a label for a code. The identifier is set small
+         and monospaced beside it: English in code, Spanish on the screen,
+         and the seam visible rather than hidden. */
+      .code .say {
+        font-size: 14.5px;
+        line-height: 1.5;
+      }
+
+      .code .say em {
+        font-style: normal;
+        font-weight: 600;
+      }
+
+      .code .id {
+        display: block;
+        margin-top: 6px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--muted-foreground);
+        letter-spacing: 0.01em;
+      }
+
+      /* ADR-0027: the imperative is the half that travels by email, because
+         it is a rule true of everybody. Shown here so the operator can see
+         what actually leaves the building. */
+      .code .mail {
+        display: none;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dashed var(--border);
+        font-size: 13px;
+        color: var(--muted-foreground);
+      }
+
+      .code:has(input:checked) .mail {
+        display: block;
+      }
+
+      .code .mail b {
+        color: var(--foreground);
+        font-weight: 500;
+      }
+
+      /* Sharper guidance on a repeat of the SAME code. Never a sterner tone,
+         never a count (ADR-0027). */
+      .repeat {
+        margin: 14px 0 0;
+        background: var(--secondary);
+        border-radius: calc(var(--radius) * 0.8);
+        padding: 12px 14px;
+        font-size: 13.5px;
+      }
+
+      .repeat b {
+        font-weight: 600;
+      }
+
+      .note {
+        margin-top: 20px;
+        font-size: 13px;
+        color: var(--muted-foreground);
+        border-left: 2px solid var(--border);
+        padding-left: 12px;
+        max-width: 60ch;
+      }
+
+      /* ---- contact sheet variant -------------------------------------- */
+      .sheet {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+        gap: 14px;
+      }
+
+      .sheet .cell {
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 0.8);
+        overflow: hidden;
+        background: var(--card);
+      }
+
+      .sheet .plate {
+        aspect-ratio: 4 / 5;
+        position: relative;
+        background: var(--muted);
+      }
+
+      .sheet .cell-foot {
+        display: flex;
+        gap: 6px;
+        padding: 8px;
+        align-items: center;
+        justify-content: space-between;
+        font-size: 12px;
+        color: var(--muted-foreground);
+      }
+
+      .sheet .cell-foot button {
+        font: inherit;
+        font-size: 12px;
+        min-height: 32px;
+        padding: 0 10px;
+        border-radius: 6px;
+        border: 1px solid var(--input);
+        background: var(--background);
+        cursor: pointer;
+      }
+
+      .sheet-warn {
+        border: 1px solid var(--destructive-border);
+        background: var(--destructive-surface);
+        border-radius: var(--radius);
+        padding: 14px 16px;
+        margin-bottom: 22px;
+        font-size: 14px;
+        max-width: 76ch;
+      }
+
+      .sheet-warn strong {
+        color: var(--destructive);
+      }
+
+      /* ---- prototype chrome (English — ADR-0001 as amended by #30) ----- */
+      .chrome {
+        position: fixed;
+        left: 50%;
+        transform: translateX(-50%);
+        bottom: 16px;
+        z-index: 40;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+        justify-content: center;
+        background: var(--brand-950);
+        color: oklch(1 0 0);
+        padding: 8px 12px;
+        border-radius: 999px;
+        box-shadow: 0 8px 28px oklch(0.2 0.012 248 / 0.28);
+        font-size: 12.5px;
+        max-width: calc(100vw - 24px);
+      }
+
+      .chrome .grp {
+        display: flex;
+        gap: 4px;
+        align-items: center;
+      }
+
+      .chrome .k {
+        opacity: 0.6;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        margin-right: 2px;
+      }
+
+      .chrome a {
+        color: oklch(1 0 0);
+        text-decoration: none;
+        padding: 4px 10px;
+        border-radius: 999px;
+        border: 1px solid oklch(1 0 0 / 0.28);
+        min-height: 28px;
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .chrome a[data-on="true"] {
+        background: oklch(1 0 0);
+        color: var(--brand-950);
+        font-weight: 600;
+      }
+
+      .chrome .sep {
+        width: 1px;
+        align-self: stretch;
+        background: oklch(1 0 0 / 0.22);
+        margin: 0 2px;
+      }
+
+      @media (max-width: 900px) {
+        .app {
+          grid-template-columns: 1fr;
+        }
+        .sidebar {
+          border-right: 0;
+          border-bottom: 1px solid var(--sidebar-border);
+        }
+        .nav {
+          flex-direction: row;
+          flex-wrap: wrap;
+          margin-top: 8px;
+        }
+        .review {
+          grid-template-columns: 1fr;
+        }
+        .main {
+          padding: 20px 18px 120px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <nav class="sidebar" aria-label="Secciones">
+        <div class="wordmark">
+          Encuentra
+          <span>Interno</span>
+        </div>
+
+        <div class="nav">
+          <a href="#" aria-current="page">
+            <span class="label">Fotos</span>
+            <span class="count" id="c-photos">12</span>
+          </a>
+          <a href="#">
+            <span class="label">Reportes</span>
+            <span class="count">3</span>
+          </a>
+          <a href="#">
+            <span class="label">Sugerencias</span>
+            <span class="count">8</span>
+          </a>
+          <a href="#">
+            <span class="label">Solicitudes</span>
+            <span class="count">1</span>
+          </a>
+        </div>
+
+        <div class="sidebar-foot">Cada foto que abres queda registrada: quién la vio y cuándo.</div>
+      </nav>
+
+      <main class="main">
+        <!-- SINGLE ------------------------------------------------------ -->
+        <section id="view-single">
+          <div class="page-head">
+            <h1>Fotos por revisar</h1>
+            <span class="age" id="age-line">La más antigua lleva 14 horas</span>
+          </div>
+          <p class="subhead">
+            Nadie ve estas fotos todavía, solo quien las subió. Lo demás del perfil sigue
+            funcionando: publica, aparece en las búsquedas y recibe propuestas mientras tanto.
+          </p>
+
+          <div class="late-note" id="late-note" hidden>
+            <span aria-hidden="true">⏳</span>
+            <div>
+              <strong>Pasamos los 3 días.</strong> Hay 4 fotos que llevan más de 3 días esperando.
+              Dijimos que menos de 3 y no cumplimos.
+            </div>
+          </div>
+
+          <div class="review">
+            <figure class="mount" style="margin: 0">
+              <div class="plate">
+                <div class="fake"><i></i></div>
+                <span class="mock-tag">foto de prueba</span>
+              </div>
+              <figcaption>
+                <span>Subida el <b>14 ago</b>, 09:20</span>
+                <span>Primera foto</span>
+              </figcaption>
+              <div class="logged">
+                <span aria-hidden="true">•</span>
+                <span
+                  >Quedó registrado que la abriste.
+                  <code>photo_access_log</code>
+                </span>
+              </div>
+            </figure>
+
+            <div class="decide">
+              <h2>¿Se puede publicar?</h2>
+              <p class="hint">
+                Aquí se revisa la foto, no la persona. Si la duda es sobre la cuenta —que no sea
+                quien dice ser, que parezca menor de edad— eso es un reporte, no un rechazo.
+              </p>
+
+              <div class="exits">
+                <button class="btn btn-primary" type="button">Publicar la foto</button>
+                <button class="btn btn-outline" type="button">No publicar</button>
+                <button class="btn btn-quiet" type="button">Reportar la cuenta</button>
+              </div>
+
+              <div class="codes">
+                <p>
+                  Si no se puede publicar, elige el motivo. Esto es exactamente lo que va a leer la
+                  persona.
+                </p>
+
+                <label class="code">
+                  <input type="radio" name="reason" />
+                  <span class="say">
+                    <em>No se te ve la cara.</em> Puede que esté muy oscura, muy lejos o movida. Con
+                    que se te vea de frente basta: no tiene que ser bonita ni profesional.
+                    <span class="id">face_not_visible</span>
+                    <span class="mail">
+                      Por correo va solo esto:
+                      <b>Que se te vea la cara, de frente y con buena luz.</b>
+                    </span>
+                  </span>
+                </label>
+
+                <label class="code">
+                  <input type="radio" name="reason" />
+                  <span class="say">
+                    <em>En la foto no hay nadie.</em> Va una foto tuya, no de tu negocio, tu
+                    herramienta ni tu logo. La cara sirve para que quien te va a contratar sepa con
+                    quién está hablando.
+                    <span class="id">no_person</span>
+                    <span class="mail">
+                      Por correo va solo esto:
+                      <b>Va tu cara, no tu negocio ni tu logo.</b>
+                    </span>
+                  </span>
+                </label>
+
+                <label class="code">
+                  <input type="radio" name="reason" />
+                  <span class="say">
+                    <em>Sale alguien más en la foto.</em> Solo podemos mostrar tu cara: la otra
+                    persona no nos dio permiso para mostrar la suya.
+                    <span class="id">other_people</span>
+                    <span class="mail">
+                      Por correo va solo esto:
+                      <b>Tiene que salir una sola persona: tú.</b>
+                    </span>
+                  </span>
+                </label>
+
+                <label class="code">
+                  <input type="radio" name="reason" />
+                  <span class="say">
+                    <em>Es la foto de un documento.</em> No recibimos cédulas, diplomas ni hojas de
+                    vida. Esa la borramos apenas la vimos y no queda copia. Aquí va una foto tuya y
+                    ya.
+                    <span class="id">document</span>
+                    <span class="mail">
+                      Por correo va solo esto:
+                      <b>Aquí solo va una foto tuya: nada de cédulas ni papeles.</b>
+                    </span>
+                  </span>
+                </label>
+
+                <label class="code">
+                  <input type="radio" name="reason" />
+                  <span class="say">
+                    <em>Se ve un número de teléfono en la foto.</em> Tus datos de contacto se
+                    comparten cuando alguien acepta una propuesta, no antes.
+                    <span class="id">contact_visible</span>
+                    <span class="mail">
+                      Por correo va solo esto:
+                      <b>Sin números de teléfono ni correos escritos en la imagen.</b>
+                    </span>
+                  </span>
+                </label>
+
+                <label class="code">
+                  <input type="radio" name="reason" />
+                  <span class="say">
+                    <em>No podemos mostrar esta foto en un perfil de trabajo.</em> Pon otra donde se
+                    te vea la cara.
+                    <span class="id">not_for_work</span>
+                    <span class="mail">
+                      Por correo va solo esto:
+                      <b>Que se te vea la cara, de frente y con buena luz.</b> — el mismo texto que
+                      <code>face_not_visible</code>, a propósito: si fuera distinto, el correo
+                      delataría el motivo.
+                    </span>
+                  </span>
+                </label>
+
+                <div class="repeat" id="repeat-note" hidden>
+                  <b>Es la segunda vez con este mismo motivo.</b> Al correo se le agrega una
+                  indicación más concreta: «Prueba de día, cerca de una ventana, con el teléfono a
+                  la altura de la cara. Sin gorra y sin gafas oscuras.» El tono no cambia y no se
+                  menciona que es la segunda vez.
+                </div>
+
+                <p class="note">
+                  No hay campo de texto libre. El motivo sale de esta lista o no sale: lo que
+                  escribiríamos aquí sería una frase nuestra sobre la cara de alguien.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- SHEET ------------------------------------------------------- -->
+        <section id="view-sheet" hidden>
+          <div class="page-head">
+            <h1>Fotos por revisar</h1>
+            <span class="age" id="age-line-2">La más antigua lleva 14 horas</span>
+          </div>
+          <p class="subhead">
+            La misma cola, vista de corrido. Más rápida de recorrer, y esa velocidad es justamente
+            lo que hay que mirar con cuidado.
+          </p>
+
+          <div class="sheet-warn">
+            <strong>Prototype note — this variant is here to be rejected or defended.</strong>
+            It puts a dozen strangers' faces on one screen at once, which deepens the residual
+            ADR-0010 accepted; and the obvious next feature is a checkbox and an
+            <em>approve selected</em> button, which is precisely what ADR-0010 refuses:
+            <em
+              >a person's standing on this platform never changes without a human having looked.</em
+            >
+            It is also the only variant where the access log's grain stops matching the decision —
+            one screen, twelve faces, twelve rows, one glance.
+          </div>
+
+          <div class="sheet" id="sheet-grid"></div>
+        </section>
+      </main>
+    </div>
+
+    <!-- Prototype chrome. English on purpose — this bar is not part of the
+         product surface (ADR-0001 as amended by #30). -->
+    <div class="chrome" role="group" aria-label="Prototype controls">
+      <span class="grp">
+        <span class="k">view</span>
+        <a href="?view=single" data-p="view" data-v="single">single</a>
+        <a href="?view=sheet" data-p="view" data-v="sheet">sheet</a>
+      </span>
+      <span class="sep"></span>
+      <span class="grp">
+        <span class="k">age</span>
+        <a href="?age=fresh" data-p="age" data-v="fresh">fresh</a>
+        <a href="?age=late" data-p="age" data-v="late">late</a>
+      </span>
+      <span class="sep"></span>
+      <span class="grp">
+        <span class="k">repeat</span>
+        <a href="?repeat=off" data-p="repeat" data-v="off">off</a>
+        <a href="?repeat=on" data-p="repeat" data-v="on">on</a>
+      </span>
+    </div>
+
+    <script>
+      const DEFAULTS = { view: "single", age: "fresh", repeat: "off" };
+
+      function state() {
+        const q = new URLSearchParams(location.search);
+        const s = { ...DEFAULTS };
+        for (const k of Object.keys(DEFAULTS)) {
+          if (q.get(k)) s[k] = q.get(k);
+        }
+        return s;
+      }
+
+      // Build the contact sheet so the density is real rather than suggested.
+      function buildSheet() {
+        const grid = document.getElementById("sheet-grid");
+        if (grid.children.length) return;
+        const ages = [
+          "14 h",
+          "1 d",
+          "1 d",
+          "2 d",
+          "2 d",
+          "2 d",
+          "3 d",
+          "3 d",
+          "4 d",
+          "4 d",
+          "5 d",
+          "5 d",
+        ];
+        grid.innerHTML = ages
+          .map((age, i) => {
+            const v = ["", "v2", "v3", "v4"][i % 4];
+            return `<div class="cell">
+              <div class="plate">
+                <div class="fake ${v}"><i></i></div>
+                <span class="mock-tag">prueba</span>
+              </div>
+              <div class="cell-foot">
+                <span>${age}</span>
+                <button type="button">Abrir</button>
+              </div>
+            </div>`;
+          })
+          .join("");
+      }
+
+      function render() {
+        const s = state();
+
+        document.getElementById("view-single").hidden = s.view !== "single";
+        document.getElementById("view-sheet").hidden = s.view !== "sheet";
+        if (s.view === "sheet") buildSheet();
+
+        const late = s.age === "late";
+        document.getElementById("late-note").hidden = !late;
+        const ageText = late ? "La más antigua lleva 5 días" : "La más antigua lleva 14 horas";
+        for (const id of ["age-line", "age-line-2"]) {
+          const el = document.getElementById(id);
+          el.textContent = ageText;
+          el.classList.toggle("late", late);
+        }
+        document.getElementById("c-photos").textContent = late ? "31" : "12";
+
+        document.getElementById("repeat-note").hidden = s.repeat !== "on";
+
+        // Chrome reflects state, and every link carries the whole state so
+        // switching one axis never silently resets another.
+        for (const a of document.querySelectorAll(".chrome a")) {
+          const next = { ...s, [a.dataset.p]: a.dataset.v };
+          a.href = "?" + new URLSearchParams(next).toString();
+          a.dataset.on = String(s[a.dataset.p] === a.dataset.v);
+        }
+
+        console.log("[prototype #28] state:", s);
+      }
+
+      render();
+      addEventListener("popstate", render);
+      for (const a of document.querySelectorAll(".chrome a")) {
+        a.addEventListener("click", (e) => {
+          e.preventDefault();
+          history.pushState({}, "", a.href);
+          render();
+          scrollTo({ top: 0 });
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/docs/design/photo-review-prototype/index.html
+++ b/docs/design/photo-review-prototype/index.html
@@ -15,16 +15,28 @@
       /* ------------------------------------------------------------------
          THROWAWAY PROTOTYPE — ticket #28, wayfinder map #1.
 
-         THE QUESTION, and it is only one. The shell was settled in the
-         grilling session before this file existed: one internal surface,
-         a sidebar with four links, each carrying a count. What was NOT
-         settled is how an operator judges a single photograph:
+         THE QUESTION, and how it was answered. The shell was settled in
+         the grilling session before this file existed: one internal
+         surface, a sidebar with four links, each carrying a count. What
+         was open is how an operator judges a photograph — one at a time,
+         or from a contact sheet of many.
 
-           ?view=single   one photo at a time     (proposed)
-           ?view=sheet    a contact sheet of many (the fast alternative)
+         SEEING BOTH PRODUCED A THIRD ANSWER, which is the useful outcome
+         and is what the file now shows:
 
-         Everything else here is an existing ADR rendered so the two
-         variants can be compared at real density. Supporting toggles:
+           ?view=sheet    the queue. Decides NOTHING. (default)
+           ?view=single   the detail page Abrir lands on, where every
+                          approval and refusal actually happens.
+
+         The sheet is navigation, not judgment. That keeps ADR-0010's
+         rule — a person's standing never changes without a human having
+         looked — while giving the operator a way to see the whole queue.
+         What it does NOT dodge: a dozen faces on one screen is the
+         exposure ADR-0010 accepted, deepened; and twelve thumbnails are
+         twelve signed URLs, so the access log's grain becomes one row per
+         face SEEN rather than ADR-0010's "one row per review".
+
+         Supporting toggles:
 
            ?age=late      the queue has missed ADR-0010's 3 days
            ?repeat=on     this person's SECOND refusal on the same code
@@ -294,6 +306,27 @@
         gap: 14px;
         flex-wrap: wrap;
         margin-bottom: 4px;
+      }
+
+      .back-row {
+        margin: 0 0 12px;
+      }
+
+      .back {
+        font: inherit;
+        font-size: 13.5px;
+        background: none;
+        border: 0;
+        padding: 6px 8px 6px 0;
+        color: var(--muted-foreground);
+        cursor: pointer;
+        min-height: 32px;
+      }
+
+      @media (hover: hover) and (pointer: fine) {
+        .back:hover {
+          color: var(--foreground);
+        }
       }
 
       .page-head h1 {
@@ -699,9 +732,14 @@
         cursor: pointer;
       }
 
+      /* Prototype chrome, so it is deliberately NOT wearing a semantic triad.
+         ADR-0029 reserves `destructive` for a limit of the platform and
+         `warning` for a state somebody can act on; a note addressed to whoever
+         is reading the prototype is neither, and borrowing a state colour here
+         would teach the wrong thing about the tokens. */
       .sheet-warn {
-        border: 1px solid var(--destructive-border);
-        background: var(--destructive-surface);
+        border: 1px solid var(--border);
+        background: var(--muted);
         border-radius: var(--radius);
         padding: 14px 16px;
         margin-bottom: 22px;
@@ -710,7 +748,7 @@
       }
 
       .sheet-warn strong {
-        color: var(--destructive);
+        color: var(--foreground);
       }
 
       /* ---- prototype chrome (English — ADR-0001 as amended by #30) ----- */
@@ -826,6 +864,9 @@
       <main class="main">
         <!-- SINGLE ------------------------------------------------------ -->
         <section id="view-single">
+          <p class="back-row">
+            <button class="back" type="button" id="back-to-queue">← Volver a la cola</button>
+          </p>
           <div class="page-head">
             <h1>Fotos por revisar</h1>
             <span class="age" id="age-line">La más antigua lleva 14 horas</span>
@@ -986,20 +1027,24 @@
             <span class="age" id="age-line-2">La más antigua lleva 14 horas</span>
           </div>
           <p class="subhead">
-            La misma cola, vista de corrido. Más rápida de recorrer, y esa velocidad es justamente
-            lo que hay que mirar con cuidado.
+            La cola completa, de la más antigua a la más reciente. Aquí no se decide nada: abre una
+            para revisarla.
           </p>
 
           <div class="sheet-warn">
-            <strong>Prototype note — this variant is here to be rejected or defended.</strong>
-            It puts a dozen strangers' faces on one screen at once, which deepens the residual
-            ADR-0010 accepted; and the obvious next feature is a checkbox and an
-            <em>approve selected</em> button, which is precisely what ADR-0010 refuses:
-            <em
-              >a person's standing on this platform never changes without a human having looked.</em
+            <strong
+              >Prototype note — the sheet is navigation, and judgment stays on the detail
+              page.</strong
             >
-            It is also the only variant where the access log's grain stops matching the decision —
-            one screen, twelve faces, twelve rows, one glance.
+            That keeps ADR-0010's rule intact —
+            <em>a person's standing never changes without a human having looked</em> — because there
+            is no control here that changes anything, and <em>approve selected</em> must never be
+            added. <br /><br />
+            <strong>Two costs it does not dodge.</strong> A dozen strangers' faces are on one
+            screen, which is the exposure ADR-0010 accepted, deepened. And each thumbnail is a face
+            served, so <em>twelve signed URLs and twelve access-log rows for one glance</em> — the
+            log's grain stops being ADR-0010's "one row per review" and becomes one row per face
+            seen, which is the honest reading of art. 8(c) but not the one that ADR wrote.
           </div>
 
           <div class="sheet" id="sheet-grid"></div>
@@ -1030,7 +1075,10 @@
     </div>
 
     <script>
-      const DEFAULTS = { view: "single", age: "fresh", repeat: "off" };
+      // `sheet` is the queue and `single` is the detail page you reach from it —
+      // chosen after seeing both. The sheet decides nothing; every approval and
+      // every refusal still happens one face at a time on `single`.
+      const DEFAULTS = { view: "sheet", age: "fresh", repeat: "off" };
 
       // State is a plain object, seeded from the URL on load. The URL is kept in
       // sync as a courtesy — so a variant can be linked or reloaded — but it is
@@ -1083,11 +1131,21 @@
               </div>
               <div class="cell-foot">
                 <span>${age}</span>
-                <button type="button">Abrir</button>
+                <button type="button" data-open="1">Abrir</button>
               </div>
             </div>`;
           })
           .join("");
+
+        // Abrir is navigation, not a decision. It lands on the same detail page
+        // the `single` switch shows — that is the whole point of the shape.
+        grid.addEventListener("click", (e) => {
+          if (!e.target.closest("[data-open]")) return;
+          S = { ...S, view: "single" };
+          syncUrl();
+          render();
+          scrollTo({ top: 0 });
+        });
       }
 
       function render() {
@@ -1129,6 +1187,13 @@
           scrollTo({ top: 0 });
         });
       }
+
+      document.getElementById("back-to-queue").addEventListener("click", () => {
+        S = { ...S, view: "sheet" };
+        syncUrl();
+        render();
+        scrollTo({ top: 0 });
+      });
 
       syncUrl();
       render();

--- a/docs/design/photo-review-prototype/index.html
+++ b/docs/design/photo-review-prototype/index.html
@@ -751,6 +751,190 @@
         color: var(--foreground);
       }
 
+      /* ---- the other three lists -------------------------------------- */
+      .rows {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        max-width: 860px;
+      }
+
+      .row {
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--card);
+        padding: 14px 16px;
+      }
+
+      .row-top {
+        display: flex;
+        gap: 10px;
+        align-items: baseline;
+        flex-wrap: wrap;
+        margin-bottom: 6px;
+      }
+
+      .row-top .who {
+        font-weight: 600;
+      }
+
+      .row-top .when {
+        font-size: 12.5px;
+        color: var(--muted-foreground);
+        margin-left: auto;
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* A reason code, shown as its Spanish label with the identifier beside
+         it — the same seam as the photo picker. */
+      .tag {
+        font-size: 12.5px;
+        padding: 2px 9px;
+        border-radius: 999px;
+        background: var(--secondary);
+        color: var(--secondary-foreground);
+      }
+
+      .tag code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--muted-foreground);
+        margin-left: 6px;
+      }
+
+      /* Triaged ahead of the rest: ADR-0013 gives hirer_home and underage a
+         harm argument, which is why THIS queue has a priority order and the
+         photo queue does not. */
+      .tag.ahead {
+        background: var(--warning-surface);
+        color: var(--warning);
+        border: 1px solid var(--warning-border);
+      }
+
+      .tag.platform {
+        background: var(--brand-50);
+        color: var(--brand-800);
+        border: 1px solid var(--brand-200);
+      }
+
+      /* The reporter's own words. ADR-0013 permits them and never shows them
+         to the reported Person; ADR-0020 narrows that to identity only when
+         the Person asks what we hold. */
+      .quote {
+        margin: 10px 0 0;
+        padding: 10px 12px;
+        border-left: 2px solid var(--border);
+        background: var(--muted);
+        border-radius: 0 6px 6px 0;
+        font-size: 14px;
+      }
+
+      .quote .src {
+        display: block;
+        font-size: 11.5px;
+        color: var(--muted-foreground);
+        margin-bottom: 4px;
+      }
+
+      .quote.answer {
+        border-left-color: var(--brand-300);
+      }
+
+      .row-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 12px;
+        padding-top: 12px;
+        border-top: 1px solid var(--border);
+      }
+
+      .row-actions button {
+        font: inherit;
+        font-size: 13px;
+        min-height: 36px;
+        padding: 0 12px;
+        border-radius: 7px;
+        border: 1px solid var(--input);
+        background: var(--background);
+        color: var(--foreground);
+        cursor: pointer;
+      }
+
+      .row-actions button.primary {
+        background: var(--primary);
+        border-color: var(--primary);
+        color: var(--primary-foreground);
+      }
+
+      .count-note {
+        font-size: 12.5px;
+        color: var(--muted-foreground);
+      }
+
+      /* The proxy-rule gate. ADR-0012's tie-breaker, asked before a Skill can
+         be authored and stored on the row — which is what makes runtime
+         authorship MORE demonstrable than a seed diff rather than less. */
+      .gate {
+        margin-top: 12px;
+        border: 1px solid var(--brand-200);
+        background: var(--brand-50);
+        border-radius: calc(var(--radius) * 0.8);
+        padding: 12px 14px;
+      }
+
+      .gate p {
+        margin: 0 0 10px;
+        font-size: 13.5px;
+      }
+
+      .gate label {
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+        font-size: 14px;
+        margin-bottom: 6px;
+        cursor: pointer;
+      }
+
+      .gate input {
+        margin-top: 3px;
+        accent-color: var(--primary);
+      }
+
+      /* Business days left on a statutory clock. Only this list has one. */
+      .clock {
+        font-family: var(--font-mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 12.5px;
+        padding: 2px 9px;
+        border-radius: 999px;
+        background: var(--secondary);
+        color: var(--secondary-foreground);
+      }
+
+      .clock.tight {
+        background: var(--warning-surface);
+        color: var(--warning);
+        border: 1px solid var(--warning-border);
+      }
+
+      .clock.none {
+        background: transparent;
+        color: var(--muted-foreground);
+        border: 1px dashed var(--border);
+      }
+
+      .legend {
+        display: inline-block;
+        margin-top: 8px;
+        font-size: 12.5px;
+        color: var(--muted-foreground);
+        border: 1px dashed var(--border);
+        border-radius: 6px;
+        padding: 2px 8px;
+      }
+
       /* ---- prototype chrome (English — ADR-0001 as amended by #30) ----- */
       .chrome {
         position: fixed;
@@ -840,19 +1024,19 @@
         </div>
 
         <div class="nav">
-          <a href="#" aria-current="page">
+          <a href="#" data-page="photos" aria-current="page">
             <span class="label">Fotos</span>
             <span class="count" id="c-photos">12</span>
           </a>
-          <a href="#">
+          <a href="#" data-page="reports">
             <span class="label">Reportes</span>
             <span class="count">3</span>
           </a>
-          <a href="#">
+          <a href="#" data-page="suggestions">
             <span class="label">Sugerencias</span>
             <span class="count">8</span>
           </a>
-          <a href="#">
+          <a href="#" data-page="requests">
             <span class="label">Solicitudes</span>
             <span class="count">1</span>
           </a>
@@ -1049,13 +1233,265 @@
 
           <div class="sheet" id="sheet-grid"></div>
         </section>
+
+        <!-- REPORTES ---------------------------------------------------- -->
+        <section id="page-reports" hidden>
+          <div class="page-head">
+            <h1>Reportes</h1>
+            <span class="age">3 sin revisar</span>
+          </div>
+          <p class="subhead">
+            Un reporte es sobre una persona, no sobre una publicación ni sobre una foto. Acumular
+            reportes sube a alguien en esta lista y no hace nada más: nadie queda suspendido solo
+            porque varias personas lo reportaron.
+          </p>
+
+          <div class="sheet-warn">
+            <strong>Prototype note.</strong> No response-time commitment is shown anywhere —
+            ADR-0013 refuses one because
+            <em>a clock nobody is staffed to keep is worse than silence</em>, and Block is what
+            holds the line meanwhile. The counts here are the one place ADR-0026's ban on per-person
+            signals does not reach, because this shows work to the operator rather than a Person to
+            somebody else.
+          </div>
+
+          <div class="rows">
+            <article class="row">
+              <div class="row-top">
+                <span class="who">Persona #4812</span>
+                <span class="tag ahead"
+                  >Trabajo en casa de quien contrata <code>hirer_home</code></span
+                >
+                <span class="tag">Pidió plata por adelantado <code>advance_fee</code></span>
+                <span class="when">hace 2 h</span>
+              </div>
+              <p class="count-note">
+                3 reportes en total · el pointer va a la propuesta #91204 · sube en la lista, nada
+                más
+              </p>
+              <blockquote class="quote">
+                <span class="src"
+                  >Lo que escribió quien reportó — no se le muestra a la persona reportada</span
+                >
+                Me pidió $50.000 por el uniforme antes de empezar y me dijo que fuera a la casa.
+              </blockquote>
+              <blockquote class="quote answer">
+                <span class="src"
+                  >La respuesta de la persona reportada — la escribió una vez, no se le muestra a
+                  quien reportó</span
+                >
+                Yo no pedí nada, el uniforme lo pone la empresa donde trabajo.
+              </blockquote>
+              <div class="row-actions">
+                <button type="button">Desestimar</button>
+                <button type="button">Bajar la publicación</button>
+                <button type="button" class="primary">Suspender la cuenta</button>
+                <button type="button">Escalar como incidente</button>
+              </div>
+            </article>
+
+            <article class="row">
+              <div class="row-top">
+                <span class="who">Persona #5077</span>
+                <span class="tag platform"
+                  >Lo levantó la plataforma <code>sin reportante</code></span
+                >
+                <span class="tag">Parece menor de edad <code>underage</code></span>
+                <span class="when">hace 6 h</span>
+              </div>
+              <p class="count-note">
+                1 reporte · viene de una revisión de foto: la foto se publicó, la duda es sobre la
+                cuenta
+              </p>
+              <p class="count-note">
+                Sin texto libre, a propósito: las palabras de quien reporta son la queja, las
+                nuestras serían un registro que inventamos.
+              </p>
+              <div class="row-actions">
+                <button type="button">Desestimar</button>
+                <button type="button">Bajar la publicación</button>
+                <button type="button" class="primary">Suspender la cuenta</button>
+                <button type="button">Escalar como incidente</button>
+              </div>
+            </article>
+
+            <article class="row">
+              <div class="row-top">
+                <span class="who">Persona #4390</span>
+                <span class="tag">Mensajes iguales en masa <code>spam</code></span>
+                <span class="when">hace 1 d</span>
+              </div>
+              <p class="count-note">1 reporte · el pointer va a la necesidad #8821</p>
+              <blockquote class="quote">
+                <span class="src">Lo que escribió quien reportó</span>
+                Me llegó la misma propuesta cuatro veces con otro nombre.
+              </blockquote>
+              <div class="row-actions">
+                <button type="button">Desestimar</button>
+                <button type="button">Bajar la publicación</button>
+                <button type="button" class="primary">Suspender la cuenta</button>
+                <button type="button">Escalar como incidente</button>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <!-- SUGERENCIAS ------------------------------------------------- -->
+        <section id="page-suggestions" hidden>
+          <div class="page-head">
+            <h1>Sugerencias</h1>
+            <span class="age">8 sin leer</span>
+          </div>
+          <p class="subhead">
+            Lo que la gente buscó y no encontró. Es la única medida honesta de qué tan buena es la
+            lista de habilidades, y quien la escribió nunca recibe respuesta: lo único que podríamos
+            decirle es una promesa que no vamos a hacer.
+          </p>
+
+          <div class="sheet-warn">
+            <strong>Prototype note.</strong> <em>Shortlisting is not adding.</em> Authoring a Skill
+            is its own deliberate act, and it is gated on ADR-0012's proxy rule — the tie-breaker is
+            asked here and the answer is stored on the row, which is what makes runtime authorship
+            more demonstrable than a seed diff rather than less.
+          </div>
+
+          <div class="rows">
+            <article class="row">
+              <div class="row-top">
+                <span class="who">«manicurista a domicilio»</span>
+                <span class="tag">pendiente <code>pending</code></span>
+                <span class="when">hace 3 h</span>
+              </div>
+              <p class="count-note">
+                Escrita 4 veces este mes · quien la escribió eligió mientras tanto
+                <em>cuidado personal</em>
+              </p>
+              <div class="gate">
+                <p>
+                  Antes de crear el término:
+                  <strong>¿podría tenerlo alguien sin el atributo protegido?</strong> Un término
+                  nombra algo que haces, nunca algo que eres.
+                </p>
+                <label
+                  ><input type="radio" name="g1" /> Sí — nombra un oficio, lo puede hacer
+                  cualquiera</label
+                >
+                <label
+                  ><input type="radio" name="g1" /> No — describe a la persona, no lo que
+                  hace</label
+                >
+              </div>
+              <div class="row-actions">
+                <button type="button" class="primary">Crear la habilidad</button>
+                <button type="button">Guardar para después</button>
+                <button type="button">Descartar</button>
+              </div>
+            </article>
+
+            <article class="row">
+              <div class="row-top">
+                <span class="who">«soy cristiano y trabajo con la iglesia»</span>
+                <span class="tag">pendiente <code>pending</code></span>
+                <span class="when">hace 1 d</span>
+              </div>
+              <p class="count-note">
+                Escrita 1 vez · aquí la regla dice que no: no se puede tener sin la religión
+              </p>
+              <div class="row-actions">
+                <button type="button">Guardar para después</button>
+                <button type="button" class="primary">Descartar</button>
+              </div>
+            </article>
+
+            <article class="row">
+              <div class="row-top">
+                <span class="who">«mototaxi»</span>
+                <span class="tag">creada <code>authored</code></span>
+                <span class="when">hace 6 d</span>
+              </div>
+              <p class="count-note">
+                Ya existe como <em>transporte en moto</em> · la sugerencia queda apuntando a la
+                habilidad que la respondió
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <!-- SOLICITUDES ------------------------------------------------- -->
+        <section id="page-requests" hidden>
+          <div class="page-head">
+            <h1>Solicitudes</h1>
+            <span class="age late">1 abierta · vence en 4 días hábiles</span>
+          </div>
+          <p class="subhead">
+            Lo que llega por el correo publicado: alguien que no puede entrar a su cuenta, un
+            heredero, un apoderado. Quien sí puede entrar no aparece aquí — se responde solo en
+            <em>Tus datos</em>.
+          </p>
+
+          <div class="sheet-warn">
+            <strong>Prototype note.</strong> Everything here is ADR-0020 rendered. The one thing
+            this surface <em>adds</em> is the hand-create form that ADR requires —
+            <em>"an operator creates the row by hand"</em> — and never places. The reply itself is
+            composed and sent out of band: redacting prose is judgement no code can make.
+          </div>
+
+          <div class="rows">
+            <article class="row">
+              <div class="row-top">
+                <span class="who">Reclamo · supresión</span>
+                <span class="tag">reclamo <code>complaint</code></span>
+                <span class="tag">supresión <code>erasure</code></span>
+                <span class="clock tight">4 d hábiles</span>
+                <span class="when">llegó el 12 ago</span>
+              </div>
+              <p class="count-note">
+                Llegó al correo publicado · no puede entrar a la cuenta · identidad verificada fuera
+                de línea
+              </p>
+              <span class="legend"
+                >reclamo en trámite — se calcula, no se guarda; no se muestra en público</span
+              >
+              <div class="row-actions">
+                <button type="button" class="primary">Marcar como resuelta</button>
+              </div>
+            </article>
+
+            <article class="row">
+              <div class="row-top">
+                <span class="who">Consulta · acceso</span>
+                <span class="tag">consulta <code>inquiry</code></span>
+                <span class="tag">acceso <code>access</code></span>
+                <span class="clock none">sin fecha todavía</span>
+                <span class="when">llegó hoy</span>
+              </div>
+              <p class="count-note">
+                Falta saber quién es. El reloj no arranca hasta que la solicitud esté completa, y la
+                fecha se escribe una sola vez.
+              </p>
+              <div class="row-actions">
+                <button type="button" class="primary">Marcar como completa</button>
+              </div>
+            </article>
+          </div>
+
+          <div class="row" style="margin-top: 22px; max-width: 860px">
+            <div class="row-top">
+              <span class="who">Anotar una solicitud que llegó por correo</span>
+            </div>
+            <div class="row-actions" style="border-top: 0; padding-top: 0; margin-top: 8px">
+              <button type="button" class="primary">Consulta</button>
+              <button type="button" class="primary">Reclamo</button>
+            </div>
+          </div>
+        </section>
       </main>
     </div>
 
     <!-- Prototype chrome. English on purpose — this bar is not part of the
          product surface (ADR-0001 as amended by #30). -->
     <div class="chrome" role="group" aria-label="Prototype controls">
-      <span class="grp">
+      <span class="grp" id="photo-controls">
         <span class="k">view</span>
         <a href="?view=single" data-p="view" data-v="single">single</a>
         <a href="?view=sheet" data-p="view" data-v="sheet">sheet</a>
@@ -1078,7 +1514,7 @@
       // `sheet` is the queue and `single` is the detail page you reach from it —
       // chosen after seeing both. The sheet decides nothing; every approval and
       // every refusal still happens one face at a time on `single`.
-      const DEFAULTS = { view: "sheet", age: "fresh", repeat: "off" };
+      const DEFAULTS = { page: "photos", view: "sheet", age: "fresh", repeat: "off" };
 
       // State is a plain object, seeded from the URL on load. The URL is kept in
       // sync as a courtesy — so a variant can be linked or reloaded — but it is
@@ -1151,9 +1587,24 @@
       function render() {
         const s = S;
 
-        document.getElementById("view-single").hidden = s.view !== "single";
-        document.getElementById("view-sheet").hidden = s.view !== "sheet";
-        if (s.view === "sheet") buildSheet();
+        // Fotos is the only list with two views; the other three are one page
+        // each. `view` is therefore scoped to the photo page and the switcher
+        // hides itself elsewhere rather than offering a control that does
+        // nothing.
+        const onPhotos = s.page === "photos";
+        document.getElementById("view-single").hidden = !onPhotos || s.view !== "single";
+        document.getElementById("view-sheet").hidden = !onPhotos || s.view !== "sheet";
+        document.getElementById("page-reports").hidden = s.page !== "reports";
+        document.getElementById("page-suggestions").hidden = s.page !== "suggestions";
+        document.getElementById("page-requests").hidden = s.page !== "requests";
+        document.getElementById("photo-controls").hidden = !onPhotos;
+
+        for (const a of document.querySelectorAll(".nav a")) {
+          if (a.dataset.page === s.page) a.setAttribute("aria-current", "page");
+          else a.removeAttribute("aria-current");
+        }
+
+        if (onPhotos && s.view === "sheet") buildSheet();
 
         const late = s.age === "late";
         document.getElementById("late-note").hidden = !late;
@@ -1194,6 +1645,19 @@
         render();
         scrollTo({ top: 0 });
       });
+
+      // The sidebar is the product's navigation, not prototype chrome, so it is
+      // wired like the real thing: switching lists never resets the photo page's
+      // own state.
+      for (const a of document.querySelectorAll(".nav a")) {
+        a.addEventListener("click", (e) => {
+          e.preventDefault();
+          S = { ...S, page: a.dataset.page };
+          syncUrl();
+          render();
+          scrollTo({ top: 0 });
+        });
+      }
 
       syncUrl();
       render();

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -78,10 +78,23 @@ in one chart.
 
 ### Sidebar
 
-`--sidebar-*` exists, and today every token but `--sidebar` itself is an **alias of the page token it
-would otherwise duplicate**. There is no navigation surface yet; when one is designed, give these
-their own values deliberately and re-run the gate, which audits them separately from the page
-precisely so that day is visible.
+`--sidebar-*` carries **real values as of ADR-0031**, which built the operator surface — the first
+and, in v1, the only persistent navigation in the product. That was the day this block was parked
+against.
+
+The sidebar sits **one step off the page**, never a second palette: same hue, same ink, a deeper
+ground. Three tokens left the alias and each for a reason worth keeping:
+
+- `--sidebar` deepened, because a nav that only just leaves the page reads as a rendering artefact
+  rather than a region.
+- `--sidebar-accent` deepened, because the page value was chosen against white and is nearly
+  invisible on the sidebar's own ground — hover and the current item would separate by almost
+  nothing.
+- `--sidebar-border` deepened for the same reason: it divides the nav from the page, so it is
+  measured against the darker of the two.
+
+The ink and the brand stayed aliases deliberately — they do not change because the ground did. And
+`--sidebar-primary` marks the **current item**, never a call to action.
 
 ## Typography
 

--- a/packages/design-system/src/styles/globals.css
+++ b/packages/design-system/src/styles/globals.css
@@ -104,16 +104,28 @@
   --chart-4: oklch(0.48 0.16 295);
   --chart-5: oklch(0.68 0.16 355);
 
-  /* Sidebar. No sidebar exists, so every token here is an ALIAS of the page it would sit
-   * on rather than an invented second palette. When a real navigation surface is designed,
-   * give these their own values then — deliberately, and with the pairs below re-audited. */
-  --sidebar: oklch(0.985 0.004 248);
+  /* Sidebar. ADR-0031 gave these real values: the operator surface is the first — and in v1 the
+   * only — persistent navigation in the product, which is the day this block was parked against.
+   *
+   * The sidebar sits ONE STEP off the page rather than becoming a second palette: same hue, same
+   * ink, a deeper ground. Three tokens stop being aliases and each for a stated reason.
+   *   - `--sidebar` deepens 0.985 -> 0.975, because a nav that only just leaves the page reads as
+   *     a rendering artefact rather than a region.
+   *   - `--sidebar-accent` deepens 0.955 -> 0.94: the page value was chosen against white and is
+   *     nearly invisible on the sidebar's own ground, which would leave hover and the current item
+   *     distinguished by almost nothing.
+   *   - `--sidebar-border` deepens 0.915 -> 0.90 for the same reason — it divides the nav from the
+   *     page, so it is measured against the darker of the two.
+   * The rest stay aliases deliberately: the ink and the brand do not change because the ground did.
+   *
+   * `--sidebar-primary` marks the CURRENT item, never a call to action. */
+  --sidebar: oklch(0.975 0.008 248);
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--brand-700);
   --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: var(--accent);
+  --sidebar-accent: oklch(0.94 0.016 248);
   --sidebar-accent-foreground: var(--accent-foreground);
-  --sidebar-border: var(--border);
+  --sidebar-border: oklch(0.9 0.01 248);
   --sidebar-ring: var(--brand-700);
 
   --radius: 0.625rem;


### PR DESCRIPTION
Resolves #28.

**ADR-0031** — `docs/adr/0031-one-internal-surface-and-one-face-at-a-time.md`
**Prototype** — `docs/design/photo-review-prototype/`, open `index.html`, no install

## What it decides

- **Four lists, one surface.** ADR-0013 counted three and argued a solo developer maintaining three internal applications maintains none. That argument does not stop at three: ADR-0020 already assumed this surface for `data_requests` without naming it, and it is the one list where being missed is a regulatory event.
- **A Photo is judged one face at a time**, oldest-first, no priority order, no claim state. The contact sheet was built rather than dismissed and loses on batch-approve, on exposure, and on the access log's grain.
- **The operator picks a sentence, not a code** — the six ADR-0027 options render as the Spanish text the Person receives. A code picker reintroduces the operator-convenience vocabulary that ADR rejected, on the one screen where the decision is made.
- **The logged act is the signed-URL issuance.** List renders write nothing.
- **Neither `photo_reviews` nor the access log survives its subject** — both `with Person`, 12 months, on ADR-0021's own blocklist argument at full strength.
- **`@repo/catalog` stops being read-only at runtime**, and ADR-0012's art. 5 proxy rule moves into the write path as a recorded per-term answer.

## Amendments

ADR-0009 (2FA for operators only) · ADR-0013 (a Report may have no reporter) · ADR-0006 · ADR-0012 · ADR-0014 · ADR-0021 (two retention rows) · ADR-0029 (completed — the `--sidebar-*` block now carries values)

ADR-0015 is **extended, not amended**: its third and last notification candidate is decided negatively, so nothing is left to trigger a `notifications` table in v1.

`CONTEXT.md` gains **Operator**, which every ADR has used since ADR-0010 without defining. **Photo Review** and **Skill Suggestion** amended.

## Verification

`pnpm --filter @repo/design-system check-contrast` — 27/27 pairs, including the four sidebar pairs now measured against real values rather than aliases. `pnpm format` clean.