### PR TITLE
The public edge: ADR-0032, and the launch requirement that was not one (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,12 +166,25 @@ with the alarm it guards, which is why the operator email rides the outbox and t
 Decided in **ADR-0032**, not yet built, and **production-only** — staging has no Cloudflare zone, so
 none of this exists there. It all waits on ADR-0022's custom-domain launch gate.
 
-**Only static assets are cached. No HTML is cached at the edge, ever** — not the Walls, not a Public
-View, and never a `/search/work` results page, which would serve enumeration without the origin seeing
-it. That is why leaving takes effect **immediately** rather than ADR-0011's original "under a minute":
-there is no stale copy to outlive a Pause, an erasure or a `public_id` rotation. Reintroducing an HTML
-cache means reintroducing a purge and its missed-purge semantics, so it is a decision and not a tuning
-step.
+**Nothing that names, depicts or reveals a Person is cached at the edge** — the rule is about what a
+response contains, not what kind of file it is. In practice that means static assets, fonts and the
+**landing shell**, and nothing else: never a Wall, never a Public View, and never a `/search/work`
+results page, which would serve enumeration without the origin seeing it. That is why leaving takes
+effect **immediately** rather than ADR-0011's original "under a minute" — there is no stale copy to
+outlive a Pause, an erasure or a `public_id` rotation, and nothing edge-cached can ever need purging.
+
+**The landing page is two cache units, not one.** The shell (hero, ADR-0026's three mechanism facts,
+chrome) holds no personal data and gets a **long edge TTL**. The **Wall strip** holds real people and is
+**never** edge-cached. `stale-while-revalidate` is supported on Free and deliberately used nowhere: the
+shell does not need it (it changes only on deploy), and on the Wall it is the specific thing that must
+not happen, because with no purge there is no way to cut a stale copy short and what it would extend is
+the window in which a Paused, Suspended or Blocked Person is still on the front page.
+
+**If the Wall ever needs help, it is cached at the origin, not the edge** — Next 16 `"use cache"` with a
+short `cacheLife` and `revalidateTag()` on Pause, Suspension, Block, unpublish and erasure. The standing
+rule: **a cache the application can invalidate may hold a Person; a cache it cannot invalidate may
+not.** Next's cache is per-machine, so a blue-green overlap can miss a `revalidateTag` for the drain
+window.
 
 **Cloudflare Free gives exactly one rate-limiting rule**, keyed on IP, with a **10-second** counting
 period and only `Path` available in its expression. It goes on `/search/work` at **20 requests / 10 s**,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,49 @@ answers _why did it break_, Healthchecks.io answers _did it run at all_ — Sent
 never started — and UptimeRobot answers _is the site up_. A watchdog must never share a failure mode
 with the alarm it guards, which is why the operator email rides the outbox and the switch does not.
 
+### The public edge
+
+Decided in **ADR-0032**, not yet built, and **production-only** — staging has no Cloudflare zone, so
+none of this exists there. It all waits on ADR-0022's custom-domain launch gate.
+
+**Only static assets are cached. No HTML is cached at the edge, ever** — not the Walls, not a Public
+View, and never a `/search/work` results page, which would serve enumeration without the origin seeing
+it. That is why leaving takes effect **immediately** rather than ADR-0011's original "under a minute":
+there is no stale copy to outlive a Pause, an erasure or a `public_id` rotation. Reintroducing an HTML
+cache means reintroducing a purge and its missed-purge semantics, so it is a decision and not a tuning
+step.
+
+**Cloudflare Free gives exactly one rate-limiting rule**, keyed on IP, with a **10-second** counting
+period and only `Path` available in its expression. It goes on `/search/work` at **20 requests / 10 s**,
+action **Managed Challenge — never `block`**, because Colombian CGNAT makes the shared address normal
+and a challenge lets a real person through while a block refuses everyone behind it. **The edge rule
+bounds a burst and cannot bound volume**; what makes the public surface a sample rather than an index is
+its shape (ADR-0011, ADR-0014), not this rule.
+
+**Bot Fight Mode is deliberately off.** It cannot be excepted on any plan below Pro, so it would
+challenge ADR-0028's `/api/jobs/*` callback with no way out, and Cloudflare's own docs call it
+aggressive by design. It is the named escalation if scraping actually happens — and `/api/jobs/*` has to
+move first.
+
+**The origin refuses anything that did not come through Cloudflare**, on a shared secret header set by a
+transform rule and checked in `proxy.ts`, returning **404**. Without it a direct request to the
+`.fly.dev` host can pick its own `cf-connecting-ip` and the credential limiter stops existing. It is a
+transport gate, not an authorisation boundary — session checks still belong in each Server Function.
+
+**Rate-limit state lives in Postgres. Redis is not in the stack** — refused for the credential limiter,
+the search counter and sessions alike, and the reason is not cost (both are $0 at v1 volume). Better
+Auth uses `storage: "database"` with `window` **set explicitly**, because its own docs disagree about
+the default. `advanced.ipAddress.ipAddressHeaders` is `["cf-connecting-ip", "fly-client-ip"]`.
+
+Two counters are ours rather than Better Auth's: **a per-address failed-sign-in counter** in
+`@repo/auth` (10/hour → a self-clearing 15-minute refusal, keyed on an HMAC of the _submitted_ address
+so it leaks nothing about whether the account exists, and it **never blocks password reset**), and
+**`search_quotas`** in `@repo/matching` (200 searches per Person per day). The second one **may never
+record what was searched** — ADR-0014 refuses a search log, and the quota is how many, not what.
+
+**`/api/jobs/*` is not rate limited, by decision** — limiting a scheduled job risks silently disarming
+ADR-0020's deadline monitor.
+
 ### Testing
 
 Decided in **ADR-0017**, not yet built. Vitest 4, one `vitest.config.ts` per package, registered as a

--- a/docs/adr/0009-sign-in-credentials-and-account-recovery.md
+++ b/docs/adr/0009-sign-in-credentials-and-account-recovery.md
@@ -200,6 +200,18 @@ employment situation. The hardened path is set deliberately rather than inherite
 per-instance**, and **off in development**; there is no account lockout for password sign-in at all.
 In-memory means it silently stops working the moment a second Fly machine exists.
 
+> **Discharged by ADR-0032, and the accepted risk narrowed rather than inherited.** Storage becomes
+> `"database"` — one table, $0, and no longer a no-op under ADR-0022's blue-green deploy. More
+> importantly, ADR-0032 records that **IP-keyed limiting is not a defence against credential stuffing
+> at all**, because rotating addresses is the attack, so this ADR's "no lockout" left one account
+> guessable without bound. It adds a **per-address failed-sign-in counter**: ten failures in an hour
+> open a **fifteen-minute refusal window** that any successful sign-in clears and that expires on its
+> own. That is not the lockout refused below — **nobody has to be recovered**, which was this ADR's
+> actual objection, and it **never refuses password reset**, only sign-in. It is keyed on an HMAC of
+> the _submitted_ address (ADR-0021's `subject_key` derivation) so that it behaves identically whether
+> or not an account exists, rather than becoming the enumeration signal this ADR hardened signup
+> against.
+
 ## Cost
 
 Social login is **$0 per signup**. The password path is one verification email plus occasional

--- a/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
+++ b/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
@@ -173,12 +173,17 @@ Three surfaces, three honest answers:
 - **The public wall and profile pages** — short CDN TTL, purged on the way out, genuinely under a minute
   because the wall is one page rather than N.
 
-  > **Amended by ADR-0032 — immediate, because nothing is cached.** The reason given here reaches the
-  > Wall and was extended to profile pages without an argument. ADR-0032 caches **static assets only**
-  > and no HTML at all, which deletes the TTL, the purge and the missed-purge question together and
+  > **Amended by ADR-0032 — immediate, because nothing carrying a Person is cached.** The reason given
+  > here reaches the Wall and was extended to profile pages without an argument. ADR-0032 caches
+  > **nothing that names, depicts or reveals a Person** at the edge — static assets and the landing
+  > _shell_, never a Wall — which deletes the TTL, the purge and the missed-purge question together and
   > makes leaving take effect **immediately** on every public surface. The case that would have bitten
   > is `public_id` rotation: a cached `200` at a retired id is the opposite of _"dead-ending every copy
-  > in circulation"_ for the length of the TTL.
+  > in circulation"_ for the length of the TTL. The twelve faces this ADR puts on the landing page are
+  > what force that page to split — a cached shell and an uncached Wall strip — and `stale-while-revalidate`
+  > is refused on the strip specifically, because with no purge there is no way to cut a stale copy
+  > short, and what it would extend is the window in which a Paused or Suspended Person is still on the
+  > front page.
 
 - **Anything already crawled or scraped** — never, and the _política_ says so plainly instead of promising
   otherwise: we remove our copy and stop showing you, and we cannot retrieve what a third party already

--- a/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
+++ b/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
@@ -172,6 +172,14 @@ Three surfaces, three honest answers:
 - **Database and every authenticated view** — immediate.
 - **The public wall and profile pages** — short CDN TTL, purged on the way out, genuinely under a minute
   because the wall is one page rather than N.
+
+  > **Amended by ADR-0032 — immediate, because nothing is cached.** The reason given here reaches the
+  > Wall and was extended to profile pages without an argument. ADR-0032 caches **static assets only**
+  > and no HTML at all, which deletes the TTL, the purge and the missed-purge question together and
+  > makes leaving take effect **immediately** on every public surface. The case that would have bitten
+  > is `public_id` rotation: a cached `200` at a retired id is the opposite of _"dead-ending every copy
+  > in circulation"_ for the length of the TTL.
+
 - **Anything already crawled or scraped** — never, and the _política_ says so plainly instead of promising
   otherwise: we remove our copy and stop showing you, and we cannot retrieve what a third party already
   took. The wall being a sample is what makes that sentence survivable — a sample leaks a handful of
@@ -207,6 +215,15 @@ autorizada_ arts. 4(g)/17(d) target, and it is one row per review.
   rather than in the app — because the limiter ADR-0009 specified is _"in-memory per-instance, off in dev,
   a no-op behind a second Fly machine"_ and cannot defend a public surface. Without it, sample-not-index
   is a claim rather than a control.
+
+  > **Corrected by ADR-0032 — the limiter was never that control.** Cloudflare's free plan gives **one
+  > rule, keyed on IP, with a 10-second counting period and no other**, so it bounds a burst and cannot
+  > bound volume — and ADR-0014 established that **query volume is the axis** a scraper works on. What
+  > actually makes _sample-not-index_ true is the **shape** of the surface: bounded rotating Walls, no
+  > public skill search, no pagination, the 200-result cap, no facet counts, and the rotatable
+  > `public_id`. Those are this ADR's and ADR-0014's own work and they do not depend on Cloudflare. The
+  > edge rule is a burst bound in front of them, worth having and not worth overstating.
+
 - **#9 inherits** the requirement that _frozen_ is expressible in the Offer status vocabulary; whether an
   Offer also expires on its own clock is its call.
 

--- a/docs/adr/0013-safety-between-individuals.md
+++ b/docs/adr/0013-safety-between-individuals.md
@@ -212,6 +212,15 @@ why a cache is a legitimate home for it. #15 also inherits an unverified assumpt
 the Better Auth audit lists Redis/KV as an implied cost but **never priced it**, and its `"database"`
 backend costs one table and $0 against #18's real remainder of $4.46–$7.46/month.
 
+> **Priced and answered by ADR-0032: `"database"`, and Redis does not enter the stack.** Upstash Redis
+> Free is 256 MB and 500K commands/month, so **both options are $0 at v1 volume and cost decides
+> nothing**. Redis is refused on what it would relieve, not on price — and the paragraph above is
+> corrected in one respect: a cache is a legitimate home for auth-limiter state, but Postgres is a
+> cheaper one here, because the alternative brings a fifth vendor for a table we already have. This
+> ADR's distinction between auth limiting and safety counters survives intact; ADR-0032 adds a **third**
+> case it did not have — an unattributable public surface, defended at the edge — and keeps all three
+> separate.
+
 **Safety counters are not rate limiting at all.** "Has this Person sent more than N Offers this week,
 to more than M distinct people?" is a business rule evaluated over durable domain data — the `offers`
 rows are already the authoritative record. It is a `SELECT count(*)` with an index on

--- a/docs/adr/0014-search-as-two-bounded-surfaces.md
+++ b/docs/adr/0014-search-as-two-bounded-surfaces.md
@@ -141,6 +141,19 @@ key on.
 | Public Need search           | **Cloudflare edge**            | No account to attribute to. Already stacked, $0 (ADR-0005), and it is the anti-scraping requirement ADR-0011 handed to #15 — now with a second named surface |
 | Authenticated Profile search | **Durable per-Person counter** | Must be attributable and auditable to feed Suspension. ADR-0013's sense: a `SELECT count(*)`, never a cache                                                  |
 
+> **Filled in by ADR-0032, and one contradiction in this ADR resolved.** The edge rule is
+> `/search/work`, **20 requests per 10 seconds per IP**, action **Managed Challenge** — never `block`,
+> because Colombian CGNAT makes the shared address the normal case and Free's challenge-throttling
+> zeroes the counter for whoever passes. The per-Person counter is `search_quotas` in
+> `@repo/matching`: `(person_id, day, count)`, **200 searches per day**. It **feeds Suspension only by
+> being visible to an operator**, never automatically, which keeps ADR-0013's refusal of
+> accumulation-triggers-action intact.
+>
+> That counter and this ADR's `No per-search log` could not both stand as written. They are resolved
+> as **how many, never what**: the refusal is about _what was searched_, and a row holding a Person, a
+> day and an integer is a quota rather than a log. `search_quotas` is **schema-incapable of holding a
+> query** — the same move ADR-0013 made fixing pay direction in the schema.
+
 ## Postgres alone, and no second copy of anybody
 
 **A plain btree on `publication_skills (skill_id, publication_id)` is the index.** A join table with that
@@ -205,6 +218,9 @@ removes the thing a count would qualify.
 _finalidad_, and repeats reasoning ADR-0011 already accepted in declining a profile-view log. #13's
 abuse-investigation need stays in the fog where ADR-0011 left it.
 
+> **Read with ADR-0032**, which resolves this against the durable per-Person counter this ADR also
+> requires: the refusal is about **what** was searched, and the counter records only **how many**.
+
 **One anonymous counter is kept**: zero-result `(skill, location tier)` pairs, with **no Person link**.
 That is the second half of ADR-0012's _"only honest measure of how good 300 terms actually are"_,
 alongside the Skill Suggestion queue, and it points at nobody, satisfying #18's rule that analytics never
@@ -236,7 +252,11 @@ and often wanted; `matching` and search (issues #10, #20) need them."_
 (authenticated). _Work_ rather than _needs_ because the public one is what a person looking for income
 clicks. `/skills/atencion-al-cliente` remains ADR-0012's authored, indexable page.
 
-**Results pages are `noindex`.** A results page is a query, not content, and indexing
+**Results pages are `noindex`, and ADR-0032 adds that they are never edge-cached** — caching
+`/search/work` would serve enumeration from Cloudflare without the origin seeing it, which accelerates
+the one activity the rate limit exists to slow.
+
+A results page is a query, not content, and indexing
 `?skill=cocina-casera&dept=risaralda` would make our _difusión de vacantes_ maximally visible — the exact
 activity #23 could find no carve-out for. Licensed under ADR-0011's standing rule as a **distribution**
 control and never a privacy one, which is honest here because the underlying Needs are public by design.

--- a/docs/adr/0016-suggestions-as-a-search-you-did-not-type.md
+++ b/docs/adr/0016-suggestions-as-a-search-you-did-not-type.md
@@ -190,6 +190,15 @@ background job, no per-Person suggestion table.
 
 **Redis is refused, and cost is the weakest of three reasons.**
 
+> **Generalised by ADR-0032, and deliberately not into a ban.** ADR-0032 keeps Redis out of the stack
+> entirely — for the credential limiter, the search counter and, the case it examined hardest,
+> **sessions**. None of those reuse the argument below: a counter caches no list, and a session is not
+> a ranked set. They are refused because the load Redis would take off Postgres is **queries**, while
+> ADR-0028 named the unread risk as the **connection** ceiling that ADR-0006's singleton pool already
+> caps; and because it would put the highest-frequency read in the product on a meter, against
+> ADR-0004 choosing PlanetScale _"for budget certainty over lowest expected cost"_. Neither this ADR
+> nor that one is a general ban.
+
 1. **Staleness has a safety direction here.** A cached list can surface a Person who has since Paused, been
    Suspended, or Blocked the viewer. ADR-0011, ADR-0013 and ADR-0014 all treat absence as a safety
    property — ADR-0014 goes as far as making absence indistinguishable from _"nobody holds that skill"_

--- a/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
+++ b/docs/adr/0022-two-environments-one-artifact-one-human-gate.md
@@ -182,6 +182,15 @@ So **the custom domain is a launch gate, not a cosmetic step.** No zone, no edge
 anti-scraping control; no control, and ADR-0011's central argument is unbacked. Naming it here is
 cheaper than rediscovering it the week before launch.
 
+> **Sharpened by ADR-0032, with a stronger reason than the one recorded here.** The gate is not mainly
+> that the CDN and the limiter have nowhere to live — ADR-0032 corrects ADR-0011 on how much the
+> limiter was ever doing. It is that ADR-0032 makes the origin **refuse every request that did not
+> arrive through Cloudflare**, checked against a shared secret header set by a transform rule, because
+> otherwise a direct request to the `.fly.dev` hostname can choose its own rate-limit key and the
+> credential limiter ceases to exist. **The origin must begin refusing non-edge traffic on the same day
+> it begins holding personal data.** The production-only rule below extends to that header, so staging
+> cannot carry it — which makes this ADR's seeding rule the sole protection for staging a second time.
+
 The CDN is **production-only** when it arrives. Staging is a test environment kept at the lowest
 cost that works, and caching it would add a variable to the one place whose job is to have fewer of
 them.

--- a/docs/adr/0028-the-scheduler-runs-off-the-machine-and-holds-only-a-url.md
+++ b/docs/adr/0028-the-scheduler-runs-off-the-machine-and-holds-only-a-url.md
@@ -123,6 +123,15 @@ Costs, stated: the endpoint must do **bounded work per invocation and report whe
 a large R2 sweep cannot outlive an HTTP timeout; and it is a privileged endpoint, whose rate limiting
 belongs to #48 with the other two limiters.
 
+> **Decided by ADR-0032: no rate limiter, and the absence is the decision.** A legitimate caller is one
+> known client on a schedule, so the failure mode of limiting it is a **silently disarmed compliance
+> control** — the exact failure this ADR rejected GitHub Actions cron over — while the failure mode of
+> not limiting it is an attacker who already holds the shared secret, against whom a quota is a
+> consolation rather than a defence. The controls stay the constant-time compare, the bounded work per
+> invocation above, and ADR-0032's origin lockdown. One addition: **a bad secret returns 404, not
+> 401**, per ADR-0011's rule. ADR-0032 also keeps **Bot Fight Mode off** partly for this endpoint's
+> sake — it cannot be excepted on any plan below Pro, and it challenges exactly this kind of caller.
+
 ## The outbox row is the claim, so an interrupted job needs no timeout
 
 The drainer claims work with `FOR UPDATE SKIP LOCKED` **inside the sending transaction**, and there is
@@ -210,6 +219,14 @@ Free is 500K commands/month. And **ADR-0016's refusal does not reach this case**
 about a _cached list_ surfacing a Paused, Suspended or Blocked Person, and a channel carrying a row id
 caches nothing. Redis is not banned by this ADR; it was refused for a different use and is refused here
 for a third reason.
+
+> **Answered by ADR-0032: no, Redis does not enter the stack.** Item 3's deferral is discharged, and
+> the price was confirmed to be the non-argument this ADR suspected — both options are $0 at v1
+> volume. It is refused for the credential limiter, the search counter and, examined hardest,
+> **sessions**: `secondaryStorage` is the only way to remove the per-request database read ADR-0009
+> guaranteed by refusing `cookieCache.refreshCache`, and it relieves **queries** rather than the
+> **connection** ceiling item 3 of the direct-connection rejection above names as the unread risk —
+> which ADR-0006's singleton pool already caps at 5.
 
 ## The dead man's switch generalises. The escalation does not.
 

--- a/docs/adr/0032-the-edge-bounds-a-burst-and-the-shape-bounds-the-scrape.md
+++ b/docs/adr/0032-the-edge-bounds-a-burst-and-the-shape-bounds-the-scrape.md
@@ -1,7 +1,8 @@
 # The edge bounds a burst, and the shape bounds the scrape
 
-The production edge is **one Cloudflare rate-limiting rule on `/search/work`**, a **static-assets-only
-cache**, and **an origin that refuses every request not arriving through it**. Bot Fight Mode is off
+The production edge is **one Cloudflare rate-limiting rule on `/search/work`**, a cache that holds
+**nothing naming or depicting a Person** — static assets and the landing shell, never a Wall — and **an
+origin that refuses every request not arriving through it**. Bot Fight Mode is off
 and named as a lever. Everything else — the credential limiter, a new per-account failed-sign-in
 counter, and the authenticated search counter — lives at the origin in **Postgres**. **Redis does not
 enter the stack**, closing a question ADR-0013, ADR-0016 and ADR-0028 each deferred here.
@@ -66,18 +67,25 @@ in front of it, worth having and worth not overstating. **ADR-0011's sentence is
 because a future reader who believes the limiter is the control will make the wrong trade the first
 time it costs something.
 
-## Nothing but static assets is cached, and leaving becomes immediate
+## Nothing carrying a person is cached at the edge, and a person leaves immediately
 
 ADR-0011 specified the public surfaces as _"short CDN TTL, purged on the way out, genuinely under a
 minute **because the wall is one page rather than N**."_ The reason only reaches the Wall. A Public
 View is one URL per Person and a Need page is one per Need, and the justification was never extended
 to them — it was written once and applied to a list.
 
-**Only `/_next/static/*` and the like are cached at the edge. No HTML is cached anywhere in v1.**
+**The rule is about what a response contains, not what kind of file it is: nothing that names, depicts
+or reveals a Person is cached at the edge.** In practice that is `/_next/static/*`, the fonts, and the
+**landing shell** — and nothing else.
 
-This is the smaller decision and also the better one, which is why it is not a compromise. It deletes
-the TTL, the purge trigger, the purge API token, the missed-purge semantics and the cache-tag question
-in one move — and it **improves ADR-0011's promise rather than trading it away**. Leaving stops being
+The alternative was a flat _"no HTML at the edge"_, which is a simpler sentence and a worse rule: it
+would be obeyed for the wrong reason, and the first person to notice that a marketing paragraph is not
+personal data would relax it without knowing which half of it was load-bearing. Naming the property
+makes the rule explain itself.
+
+**It deletes the same machinery either way** — the TTL, the purge trigger, the purge API token, the
+missed-purge semantics and the cache-tag question all go, because nothing edge-cached can ever need
+purging. And it **improves ADR-0011's promise rather than trading it away**: leaving stops being
 _"genuinely under a minute"_ and becomes **immediate**, because there is no stale copy anywhere to
 outlive a Pause, a Suspension, an unpublish, an erasure or a `public_id` rotation.
 
@@ -85,10 +93,52 @@ That last one is the case worth naming, because it is the one that would have bi
 rotation a specific job — _"dead-ending every copy in circulation"_ — and a cached 200 at a retired
 `public_id` does the exact opposite of that for the length of the TTL.
 
-Two things follow. A results page is **never** cached: caching `/search/work` would serve enumeration
+**A results page is never cached** on a separate ground: caching `/search/work` would serve enumeration
 from the edge without the origin ever seeing it, which is an accelerator for the one activity the rule
-above exists to slow. And one long-lived Fly machine serving a bounded rotating sample to launch
-traffic needs no help; **caching is revisited when there is traffic to point at**, not before.
+below exists to slow.
+
+### The landing page is two things, and only one of them is cacheable
+
+ADR-0011 puts **twelve faces** on the landing page and `CONTEXT.md` defines a Wall as _"the bounded,
+rotating sample of **real** Capability Profiles and real Needs."_ So "cache the landing page" is not a
+single decision:
+
+| Half                                                                            | Contains             | Cached                                                       |
+| ------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------ |
+| **The shell** — hero, ADR-0026's three mechanism facts, the limits band, chrome | No personal data     | **Edge, long TTL**                                           |
+| **The Wall strip**                                                              | Real Persons, Photos | **Never at the edge**; origin `"use cache"` if it needs help |
+
+**The shell gets a long TTL and deliberately not `stale-while-revalidate`.** Cloudflare does support
+`stale-while-revalidate` on Free, and made it **fully asynchronous in February 2026** — the first
+request after expiry is served stale immediately rather than blocking — so this is a choice rather than
+a limitation. It is declined because SWR exists for content that goes stale on its own clock, and the
+shell changes only on deploy, which changes its asset URLs anyway. A stale window buys nothing and adds
+a state to reason about.
+
+**The Wall strip gets no edge cache, and `stale-while-revalidate` is the specific thing it must not
+have.** Edge staleness here is bounded by `s-maxage`; SWR extends the worst case to `s-maxage + swr`,
+and **with no purge there is no way to cut a stale copy short**. What would be extended is the window in
+which a **Paused, Suspended or Blocked Person is still on the front page** — the exact failure ADR-0016
+refused Redis over (_"a cache that lags on a Block is a safety bug"_) and the window ADR-0011 chose to
+bound at a minute.
+
+**The mechanism SWR is wanted for is available one layer down, with an invalidation path we own.**
+Next 16's Cache Components carry the same semantics — `"use cache"` with a `cacheLife` profile of
+`stale` / `revalidate` / `expire` — plus `revalidateTag()`, so a Pause, Suspension, Block, unpublish or
+erasure **drops the entry at the moment it happens** instead of being waited out. That keeps the
+database off the per-request path, which is the real objection to rendering the Wall live, while leaving
+ADR-0011's minute an **upper** bound rather than turning it into a floor. Stated as the general rule:
+
+> **A cache the application can invalidate may hold a Person. A cache it cannot invalidate may not.**
+> That is the whole difference between the origin and the edge here, and it is why the answer differs
+> for two halves of one page.
+
+One cost, recorded rather than discovered: Next's cache is **per-machine**, and ADR-0022's blue-green
+briefly runs two, so one machine can miss a `revalidateTag` during the drain window. Same shape as
+ADR-0016's in-process LRU problem, bounded to a deploy overlap on ADR-0005's single long-lived machine.
+
+**None of this is required at launch.** One machine serving a bounded rotating sample to launch traffic
+needs no help; the origin cache is the named answer for when it does, not a thing to build first.
 
 ## The one rule, and why a challenge beats a block here
 
@@ -349,9 +399,10 @@ purpose, and a short-lived IP counter is not the case that justifies making it.
   control"_ is corrected: the edge rule bounds burst, and the controls that make the claim true are the
   bounded rotating Walls, the absence of public skill search and pagination, the result cap and the
   rotatable `public_id` — all of which ADR-0011 and ADR-0014 already built. Its _"short CDN TTL, purged
-  on the way out, genuinely under a minute"_ becomes **immediate**, with no HTML cached; the promise
-  improves. Its standing rule on crawler directives is load-bearing in the origin-lockdown section, not
-  merely cited.
+  on the way out, genuinely under a minute"_ becomes **immediate**, because nothing edge-cached carries
+  a Person; the promise improves. Its twelve landing-page faces are what split that page into a cached
+  shell and an uncached Wall strip. Its standing rule on crawler directives is load-bearing in the
+  origin-lockdown section, not merely cited.
 - **ADR-0014 amended.** Its two-limiter table is filled in with mechanisms and numbers, and its internal
   contradiction — a durable per-Person counter against _"no per-search log"_ — is resolved on the record
   as **how many, never what**. Its `noindex` results page gains a rule: it is never edge-cached.

--- a/docs/adr/0032-the-edge-bounds-a-burst-and-the-shape-bounds-the-scrape.md
+++ b/docs/adr/0032-the-edge-bounds-a-burst-and-the-shape-bounds-the-scrape.md
@@ -1,0 +1,385 @@
+# The edge bounds a burst, and the shape bounds the scrape
+
+The production edge is **one Cloudflare rate-limiting rule on `/search/work`**, a **static-assets-only
+cache**, and **an origin that refuses every request not arriving through it**. Bot Fight Mode is off
+and named as a lever. Everything else — the credential limiter, a new per-account failed-sign-in
+counter, and the authenticated search counter — lives at the origin in **Postgres**. **Redis does not
+enter the stack**, closing a question ADR-0013, ADR-0016 and ADR-0028 each deferred here.
+
+The ticket asked for a TTL, a purge trigger, two limiters' keys and windows, and a Redis-versus-`"database"`
+price. Three of those five dissolved on contact with what the Free plan actually gives us, and the
+price turned out not to be the deciding argument on either side.
+
+What did not dissolve is a sentence in ADR-0011 that everything downstream has been resting on:
+_"without a rate limit, sample-not-index is a claim rather than a control."_ It is not true at $0, it
+was probably never true, and the control it names is not the control that has been doing the work.
+
+## What Cloudflare Free actually gives us
+
+Read off the plan tables rather than assumed, because every parent ADR that specified an edge mechanism
+specified it as _"Cloudflare edge, $0"_ and stopped there.
+
+| Capability                | Free plan                                                                    |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| Rate-limiting rules       | **1**                                                                        |
+| Counting characteristic   | **IP only** — no custom counting expression                                  |
+| Counting period           | **10 s** — no other value                                                    |
+| Mitigation timeout        | **10 s**                                                                     |
+| Fields in the expression  | **Path, Verified Bot** — nothing else                                        |
+| Challenge with a duration | Not available; challenge actions become **request throttling** (timeout `0`) |
+| Cache rules               | 10                                                                           |
+| WAF custom rules          | 5, all actions except Log                                                    |
+| Transform rules           | 10                                                                           |
+| Purge by URL              | 800 URLs/s                                                                   |
+| Purge by tag/prefix/host  | **5 requests per minute, per account**                                       |
+
+Two of these are worth stating as findings rather than parameters.
+
+**All purge methods reached all plans on 1 April 2025.** Every parent ADR was written while tag purge
+was Enterprise-only, so a design resting on cache tags was quietly available and nobody knew. It turns
+out not to matter, because of the next section — but the 5/minute account-wide ceiling on tag purge
+against 800/second for URL purge would have decided it anyway.
+
+**One rule means one threshold.** The rule can match several paths, but they then share a per-IP
+counter, and the right limit for public search and the right limit for a sign-in form are an order of
+magnitude apart. This is a single choice about which surface gets defended, not a configuration detail.
+
+## ADR-0011's launch requirement is not the control it says it is
+
+ADR-0014 established the axis: someone who wants the whole population _"does not page deep — they
+iterate ~300 Skills × 33 departments and take the top of each"_, so **query volume is the axis** and
+depth is not.
+
+A 10-second counting period bounds **burst** and nothing else. A scraper at one request per second
+never trips any threshold at or above ten, and finishes ADR-0014's full enumeration in under three
+hours. There is no window setting that fixes this, because 10 seconds is the only window Free has.
+
+So the edge limiter cannot be what makes _sample-not-index_ true, and the honest statement is that it
+never was. What has actually been doing that work is the **shape of the surface**, built across three
+ADRs before anyone reached for a limiter: bounded and rotating Walls with no pagination (ADR-0011),
+no public skill search, a 200-result cap that _"is only fair because of the rotation"_, no facet counts
+and no per-search log (ADR-0014), and unguessable, rotatable, never-reissued `public_id`s that 404
+rather than 403 (ADR-0011 via ADR-0003).
+
+That is a real set of controls and it does not depend on Cloudflare. The rate limiter is a burst bound
+in front of it, worth having and worth not overstating. **ADR-0011's sentence is amended to say so**,
+because a future reader who believes the limiter is the control will make the wrong trade the first
+time it costs something.
+
+## Nothing but static assets is cached, and leaving becomes immediate
+
+ADR-0011 specified the public surfaces as _"short CDN TTL, purged on the way out, genuinely under a
+minute **because the wall is one page rather than N**."_ The reason only reaches the Wall. A Public
+View is one URL per Person and a Need page is one per Need, and the justification was never extended
+to them — it was written once and applied to a list.
+
+**Only `/_next/static/*` and the like are cached at the edge. No HTML is cached anywhere in v1.**
+
+This is the smaller decision and also the better one, which is why it is not a compromise. It deletes
+the TTL, the purge trigger, the purge API token, the missed-purge semantics and the cache-tag question
+in one move — and it **improves ADR-0011's promise rather than trading it away**. Leaving stops being
+_"genuinely under a minute"_ and becomes **immediate**, because there is no stale copy anywhere to
+outlive a Pause, a Suspension, an unpublish, an erasure or a `public_id` rotation.
+
+That last one is the case worth naming, because it is the one that would have bitten. ADR-0011 gives
+rotation a specific job — _"dead-ending every copy in circulation"_ — and a cached 200 at a retired
+`public_id` does the exact opposite of that for the length of the TTL.
+
+Two things follow. A results page is **never** cached: caching `/search/work` would serve enumeration
+from the edge without the origin ever seeing it, which is an accelerator for the one activity the rule
+above exists to slow. And one long-lived Fly machine serving a bounded rotating sample to launch
+traffic needs no help; **caching is revisited when there is traffic to point at**, not before.
+
+## The one rule, and why a challenge beats a block here
+
+| Field  | Value                      |
+| ------ | -------------------------- |
+| Path   | `/search/work`             |
+| Limit  | 20 requests / 10 s, per IP |
+| Action | **Managed Challenge**      |
+
+`/search/work` rather than the Walls: a Wall is one page showing a rotating sample, so hammering it
+returns the same handful of cards, while `/search/work` is the query-shaped surface that multiplies.
+Typeahead costs nothing here — ADR-0014 ships Skills and Municipalities to the client as static JSON,
+so a search session is one request per submitted query.
+
+**The action is a Managed Challenge and never `block`, and Free's restriction is what makes that
+work.** On Free a challenge cannot carry a duration, so it degrades to request throttling: only
+requests over the limit are challenged, and **a client that passes has its counter set to zero**. A
+person in an internet café or behind a Colombian ISP's CGNAT — which is the normal case here, not the
+edge case — solves one challenge and continues. `block` would refuse everyone behind that address
+indiscriminately.
+
+Written down as a product rule rather than a dashboard value, because it will be re-derived otherwise:
+**on this platform the false positive is refusing the platform to the person it exists for.** The cost
+is stated too — a Managed Challenge needs JavaScript, so it is a barrier to a client that has none.
+
+**20 is not enshrined**, the same way ADR-0014 declined to enshrine its 200: it is a dashboard field
+that changes in seconds, and it moves when real traffic disagrees.
+
+## Bot Fight Mode is off, and it is the lever rather than the default
+
+Bot Fight Mode is the only real anti-automation product at $0, and it is refused at launch for two
+documented reasons and one about this audience.
+
+**It cannot be excepted.** It does not run on the Ruleset Engine, so _"you cannot bypass or skip Bot
+Fight Mode using WAF custom rules or Page Rules"_, and Cloudflare's own answer to _"I need an exception
+for my own API clients"_ is to upgrade to Super Bot Fight Mode on Pro. ADR-0028 put trigger.dev's
+`/api/jobs/*` callback on this origin: a non-browser client with no JavaScript, carrying five scheduled
+jobs of which one is ADR-0020's statutory deadline monitor. Enabling Bot Fight Mode challenges it with
+no way to make an exception — which is precisely the _silently disarmed compliance control_ failure
+ADR-0028 rejected GitHub Actions cron over.
+
+**It is aggressive by design.** Cloudflare's own troubleshooting page says so: _"Bot Fight Mode and
+Super Bot Fight Mode are aggressive by design, and false positives are expected."_ It cannot be tuned,
+scored, or run in a logging-only mode on Free.
+
+**And its challenge is CPU-intensive JavaScript**, mandatorily paired with JavaScript Detections. The
+cost of a false positive lands on a cheap Android phone on a bad connection in Risaralda, and the
+person gets no explanation — they get a spinner.
+
+So it is **off, and recorded as the named escalation**: one toggle, pulled when there is evidence of
+scraping rather than in anticipation of it, and pulled knowing that `/api/jobs/*` must move first. That
+is the same posture ADR-0013 already took on detection — _report-driven, not detective_, because zero
+users means nothing to tune against.
+
+## Redis does not enter the stack, and the budget is not why
+
+Three ADRs deferred this here, all three flagging cost as the open item — ADR-0013 noted the Better
+Auth audit _"lists Redis/KV as an implied cost but never priced it"_, and ADR-0028 restated that #48
+owns whether Redis enters the stack at all.
+
+**Priced, it is a non-argument.** Upstash Redis Free is 256 MB, 500K commands/month and one database;
+Pay-as-you-go is $0.20 per 100K with a settable budget cap. Better Auth's `storage: "database"` costs
+one table. At v1 volume both are $0, so cost decides nothing and the question has to be decided on
+something real.
+
+The strongest case for Redis was not the limiter at all. It was **sessions**: ADR-0009 refused
+`cookieCache.refreshCache` because _"a session we cannot revoke within the 5-minute cache window is not
+one we can honestly promise to revoke"_, which **guarantees a database read on every authenticated
+request**, and Better Auth's `secondaryStorage` is the only way to remove that read without weakening
+revocation. It is refused, on what it would actually relieve:
+
+1. **It relieves the wrong resource.** ADR-0028 named the risk as PS-5's unread **connection** ceiling,
+   with _"the only defence is not causing it"_ and no PlanetScale webhook for exhaustion — and
+   ADR-0006's singleton `pg.Pool` already caps connections at 5. Session lookups add **queries**, not
+   connections, and a primary-key read is the cheapest thing Postgres does. It is not latency either:
+   Fly `iad` and PlanetScale `us-east-1` are the same region.
+2. **It puts the highest-frequency read in the product on a meter.** 500K commands/month is roughly one
+   `GET` per server request, or **about 500 daily-active users** before it is metered. ADR-0004 chose
+   PlanetScale explicitly _"for budget certainty over lowest expected cost"_, and ADR-0005 rejected
+   Workers partly because _"Cloudflare bills seven metered products… where a slow React render costs
+   money rather than latency"_. Sessions in Redis reverses both decisions on the busiest path in the
+   product.
+3. **It makes a fifth vendor a hard dependency for being signed in at all.** Today that list is Fly and
+   PlanetScale.
+4. **Session rows hold `ipAddress` and `userAgent`**, so it moves personal data outside ADR-0021's
+   one-transaction erasure and needs ADR-0010's photo ordering — commit, then delete, then a
+   reconciliation sweep — as a second such adapter.
+
+**One objection was checked and withdrawn.** `secondaryStorage` looked like a lightly-travelled code
+path: seventeen Better Auth issues name it, spanning November 2024 to May 2026. **Every one of them is
+closed**, so "it is buggy" is not available as an argument and is not made here. Two are worth knowing
+anyway because of where they sit — `state_mismatch` with Redis enabled, and
+`account.storeStateStrategy` defaulting wrongly under `secondaryStorage` — both on OAuth `state`, which
+is where ADR-0009's Pending Signup design lives. If this is ever revisited, that is the seam to test
+first, and the version to write is `secondaryStorage` **with `storeSessionInDatabase: true`**, never
+without: keeping the durable row is what preserves the erasure transaction and ADR-0017's reflective
+invariant.
+
+The general principle the refusal rests on, stated once so it does not have to be rediscovered:
+
+> **A limiter at the origin is a limiter an attacker gets to make us pay for.** Every request it counts
+> already cost a Fly CPU cycle and a database write. The edge limiter is the only one an attacker
+> cannot bill us for, because it drops the request before it arrives. That is why the unauthenticated
+> surface is defended at the edge and the origin limiters sit behind an account.
+
+Redis is not banned by this ADR; it is refused for the uses that exist, and it would have to earn a
+different argument than cost to arrive later.
+
+## ADR-0014 against itself: what was searched, versus how many times
+
+ADR-0014 specifies a **_"durable per-Person counter… attributable and auditable… never a cache"_** for
+authenticated Profile search, and four sections later refuses **_"No per-search log. Who searched for
+what is the searcher's own personal data, serves no consented finalidad."_** Both cannot stand as
+written, and no ADR noticed.
+
+They are resolved by the distinction the second sentence already contains: the refusal is about **what
+was searched**. A counter holding `(person_id, window, count)` and **no query** records only **how
+many**, which is a quota and not a log.
+
+`search_quotas` therefore holds a Person, a day and an integer, and is **schema-incapable of holding a
+query** — the same move ADR-0013 made fixing pay direction in the schema so an Offer cannot express
+_"the worker pays"_. **200 searches per Person per day**, in **`@repo/matching`** where ADR-0014 put
+search, so it is read and written inside a function taking `Db | Tx` and is therefore an ADR-0017
+integration seam, testable on PGlite today.
+
+Two things stated rather than implied. ADR-0013 refused a Redis counter because it would be _"a second
+source of truth that can drift"_ against durable domain data; here there **is** no durable domain data
+to count, because ADR-0014 refused the log — so this table is the **only** source of truth, and
+ADR-0013's argument arrives in a form it never faced and points the same way. And ADR-0014 said the
+counter must be able to _"feed Suspension"_: it does so **only by being visible to an operator who is
+already looking**, never automatically. ADR-0013's refusal of accumulation-triggers-action is not
+weakened by a number an operator can read.
+
+At 200/day, ADR-0014's full enumeration run takes about **fifty days** on an account that is
+suspendable throughout. That is the whole argument for putting Capability Profile search behind an
+account, finally expressed as a number.
+
+## The counter ADR-0009 left unbuilt
+
+ADR-0009 recorded that _"there is no account lockout for password sign-in at all"_ and accepted it,
+because lockout is dangerous for an audience it had just refused a recovery desk. It then deferred the
+IP limiter here.
+
+**IP-keyed limiting is not a defence against credential stuffing.** An attacker rotating addresses
+defeats it completely, and rotating addresses is the attack. So one account can currently be guessed at
+without bound, and the IP limiter's honest job is stopping a naive attacker and absorbing accidents.
+
+This ADR adds the missing half, and it is affordable because Q10 already put durable counters in
+Postgres. **A per-email failed-sign-in counter**: ten failures inside an hour opens a **fifteen-minute
+refusal window**, cleared by any successful sign-in and expiring on its own.
+
+Three properties make it not the lockout ADR-0009 refused:
+
+- **Nobody has to be recovered.** ADR-0009's objection was specifically to a manual identity check —
+  _"we cannot tell the honest person from an attacker"_ — and a window that clears itself never sends
+  anyone to one.
+- **It refuses sign-in and never refuses recovery.** Password reset is untouched. A window that also
+  blocked `/forget-password` would be a lockout wearing a different word.
+- **It is keyed on an HMAC of the submitted email**, reusing ADR-0021's `subject_key` derivation, so
+  the table holds no address in plaintext — and, more importantly, it behaves **identically for an
+  address that has an account and one that does not**. Keying on `users.id` would have made the
+  presence of a refusal window a signal that the account exists, which is the enumeration ADR-0009
+  hardened signup against, arriving through the sign-in form instead.
+
+It lives in **`@repo/auth`** (ADR-0006 tier 1), reachable from ADR-0017's module-function seam. It is
+one more consumer of the HMAC key ADR-0021 says can never be rotated — noted because the map's fog on
+backup and recovery is tracking exactly that secret.
+
+## `/api/jobs/*` gets no limiter, and that is the decision
+
+ADR-0028 handed this over asking that it be decided rather than inherited. **The decision is no rate
+limiter**, and it is a decision because the default was to add one.
+
+A legitimate caller is one known client on a schedule. The failure mode of limiting it is a **silently
+disarmed compliance control**, which is the specific failure ADR-0028 spent the ticket avoiding. The
+failure mode of not limiting it is an attacker who **already holds the shared secret** — at which point
+a quota is a consolation, not a defence.
+
+The controls are the constant-time secret compare, the origin lockdown below, and ADR-0028's own rule
+that the endpoint does bounded work per invocation and reports whether more remains. One addition: **a
+bad secret returns 404, not 401.** ADR-0011 set that pattern for absent profiles and this repo has now
+used it three times; a 401 confirms that the path is real and that a correct secret exists.
+
+## Until the origin refuses non-edge traffic, none of the above exists
+
+Everything decided here is optional for anyone who requests the `.fly.dev` hostname directly: the
+rate-limiting rule, the challenge, the WAF, the cache. Worse than optional in one case — Better Auth
+determines the client address from a header, so a request that bypasses Cloudflare can **choose its own
+rate-limit key**, which does not weaken the credential limiter so much as delete it.
+
+**The origin requires a shared secret header, set by a Cloudflare Transform Rule, and returns 404 to
+anything without it.** Free allows ten transform rules; this needs one. The check lives in Next 16's
+`proxy.ts`.
+
+Two honest qualifications. ADR-0005 recorded that Next's own documentation calls Proxy _"a last
+resort"_ and says _"always verify authentication and authorization inside each Server Function rather
+than relying on Proxy alone"_ — that guidance stands and is not contradicted here, because this is a
+**transport gate and not an authorisation boundary**. Data is protected by the session checks inside
+each Server Function, exactly as ADR-0005 says; the lockdown protects the _edge controls_, and its
+failure mode is losing them rather than losing the data. Second, the header is a static secret, so it
+is a control against arbitrary internet traffic and not against someone who has read our Cloudflare
+configuration.
+
+The rejected alternative is worth naming because it is the tempting one. **Accepting direct origin
+access on the grounds that the `.fly.dev` hostname is not published** is security by an unpublished
+name, which is the same species of claim as ADR-0011's standing rule that _"`robots.txt` and `noindex`
+are never privacy controls… anything reachable without a session is permanently public and assumed
+scraped."_ This repo refused that reasoning once; refusing it consistently costs one transform rule.
+
+Cloudflare Tunnel would remove the public origin outright and was rejected for adding a `cloudflared`
+process to ADR-0005's single machine, for a gate a header already closes.
+
+**This is what makes ADR-0022's custom domain a launch gate**, and gives it a sharper reason than the
+one it recorded: not merely that the CDN and the limiter have nowhere to live, but that **the origin
+must begin refusing non-edge traffic on the same day it begins holding personal data.**
+
+## Staging has no edge, and that is safe only because it is empty
+
+ADR-0022 makes the CDN production-only. This extends to all of it: staging has no zone, no rate-limit
+rule, no challenge and **no lockdown header** — enabling one would make staging reject every request it
+receives, since nothing is in front of it.
+
+Staging is therefore protected by exactly one thing, and it is the thing ADR-0022 already identified as
+the control rather than the hygiene: **production personal data never leaves production**, so staging
+has none. That rule was promoted once already; this ADR is the second decision resting on it.
+
+One consequence for the client-address configuration: `cf-connecting-ip` does not exist in staging, so
+the header list is `["cf-connecting-ip", "fly-client-ip"]` and staging keys its limiters on the second.
+In production that ordering is trustworthy **only because of the lockdown** — the two are load-bearing
+on each other, and neither is safe to remove alone.
+
+## The numbers, in one place
+
+| Control                   | Where             | Key                     | Window | Limit | On breach                        |
+| ------------------------- | ----------------- | ----------------------- | ------ | ----- | -------------------------------- |
+| Public Need search        | Cloudflare edge   | IP                      | 10 s   | 20    | Managed Challenge (throttling)   |
+| Sign-in, per address      | `@repo/auth`      | HMAC of submitted email | 1 h    | 10    | 15-minute refusal, self-clearing |
+| Better Auth global        | `rateLimit` table | IP (/64 for IPv6)       | 60 s   | 100   | 429 with `X-Retry-After`         |
+| `/forget-password`        | `rateLimit` table | IP                      | 1 h    | 5     | 429                              |
+| `/sign-up/email`          | `rateLimit` table | IP                      | 1 h    | 10    | 429                              |
+| Capability Profile search | `@repo/matching`  | `person_id`             | 1 day  | 200   | Refusal in Spanish, nothing else |
+| `/api/jobs/*`             | —                 | —                       | —      | —     | Not limited, by decision         |
+
+**Better Auth's `window` is set explicitly rather than inherited**, because its own documentation
+disagrees with itself: the concepts page states a 60-second default and the options reference states 10. Pinning it costs one line and removes the question.
+
+`storage: "database"` with the generated `rateLimit(id, key, count, lastRequest)` schema, unmodified.
+Two things about that table are recorded rather than fixed: Better Auth ships **no cleanup** for it, so
+it joins ADR-0028's reflective purge in `@repo/db`; and it holds an IP with **no foreign key to
+`persons`**, so ADR-0017's reflective erasure invariant cannot enumerate it — the same hole ADR-0021
+found in `verifications` and could not close. Widening that invariant to enumerate every table was
+considered here and **deliberately not taken**: it is a change to a guard that exists for a different
+purpose, and a short-lived IP counter is not the case that justifies making it.
+
+## Consequences
+
+- **ADR-0011 amended in two places.** _"Without a rate limit, sample-not-index is a claim rather than a
+  control"_ is corrected: the edge rule bounds burst, and the controls that make the claim true are the
+  bounded rotating Walls, the absence of public skill search and pagination, the result cap and the
+  rotatable `public_id` — all of which ADR-0011 and ADR-0014 already built. Its _"short CDN TTL, purged
+  on the way out, genuinely under a minute"_ becomes **immediate**, with no HTML cached; the promise
+  improves. Its standing rule on crawler directives is load-bearing in the origin-lockdown section, not
+  merely cited.
+- **ADR-0014 amended.** Its two-limiter table is filled in with mechanisms and numbers, and its internal
+  contradiction — a durable per-Person counter against _"no per-search log"_ — is resolved on the record
+  as **how many, never what**. Its `noindex` results page gains a rule: it is never edge-cached.
+- **ADR-0009's deferred flag is discharged**, and its accepted risk is narrowed rather than merely
+  inherited: `storage: "database"` fixes the per-instance no-op it warned about under blue-green, and the
+  per-address counter closes the distributed-guessing gap that IP limiting never covered. Its refusal of
+  a recovery desk is untouched, because nothing here creates one.
+- **ADR-0013's deferred question is answered.** Redis is refused for the auth limiter too, on grounds it
+  did not have; its distinction between auth limiting and safety counters survives intact, and safety
+  counters remain a `SELECT count(*)` over `offers`.
+- **ADR-0016's Redis refusal is generalised, carefully.** It refused a cached _list_ on safety grounds;
+  this refuses Redis for counters and sessions on cost-shape and dependency grounds. Neither is a general
+  ban and this ADR says so, so that a future case is argued rather than assumed closed.
+- **ADR-0028's handover is discharged.** `/api/jobs/*` is decided as **not limited**, with the reason; its
+  reflective purge in `@repo/db` gains the `rateLimit` table; and its statement that _"#48 owns whether
+  Redis enters the stack at all"_ is answered no.
+- **ADR-0022's launch gate is sharpened.** The custom domain is a launch gate not only because the CDN and
+  limiter have nowhere to live, but because the origin must refuse non-edge traffic from the day it holds
+  personal data. Its production-only CDN rule extends to the lockdown header, and its seeding rule becomes
+  the sole protection for staging for a second time.
+- **ADR-0017 gains no invariant here**, deliberately. Every rule in this ADR is a configuration value or a
+  quota, and neither is the kind of decision an Invariant Test guards.
+- **`CLAUDE.md`** gains a **Public edge** section: what is cached, the one rule, the lockdown header, and
+  the rule that no HTML is edge-cached.
+- **`docs/runbook.md`** gains the zone provisioning steps — cache rule, rate-limiting rule, transform rule
+  and origin secret, Bot Fight Mode explicitly left off — and they belong to the launch gate, not to a
+  routine deploy.
+- **No `CONTEXT.md` change.** An edge, a cache and a limiter are engineering vocabulary, which ADR-0017
+  settled belongs in `CLAUDE.md` rather than the product glossary.
+- **Whoever implements search inherits** two counters, one at each seam, and the rule that the
+  authenticated one may never learn what was searched.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -256,9 +256,39 @@ no payment method; no Fly app exists. Work top to bottom — later steps need th
     available.
 14. **Secrets**: `TRIGGER_SECRET_KEY` per project into GitHub environment secrets (for
     `trigger.dev deploy`), and a shared **`JOBS_CALLBACK_SECRET`** into both Fly apps _and_ both
-    trigger.dev projects. The callback secret is the only thing protecting `/api/jobs/*` until #48
-    lands its rate limit.
-15. **Arm `deploy.yml`** — one edit, named in the file.
-16. **Run the restore drill** (procedures 6 and 2 against a throwaway branch) and record the result
+    trigger.dev projects. **ADR-0032 decided that `/api/jobs/*` gets no rate limit**, so the callback
+    secret plus the origin lockdown in step 19 are the whole control — rotate the secret if it is ever
+    exposed rather than expecting a quota to absorb the damage.
+15. **Cloudflare — the zone.** Buy the domain and add it to a **Free** zone, proxied. Everything from
+    here to step 20 is **production only**; staging keeps its `*.fly.dev` hostname and gets none of
+    it. This is ADR-0022's launch gate, and ADR-0032 gives it its sharper reason: the origin has to
+    start refusing non-edge traffic on the day it starts holding personal data.
+16. **Cloudflare — cache rule.** One rule making **static assets** eligible for cache. **No HTML rule,
+    and no `Eligible for cache` on any HTML path** — ADR-0032 caches no HTML at all, and adding one
+    later means adding a purge and its missed-purge semantics with it.
+17. **Cloudflare — the one rate-limiting rule.** Free allows exactly one:
+
+    | Field  | Value                      |
+    | ------ | -------------------------- |
+    | Path   | `/search/work`             |
+    | Limit  | 20 requests / 10 s, per IP |
+    | Action | **Managed Challenge**      |
+
+    Not `block` — on Free a challenge becomes request throttling and passing it zeroes the counter,
+    which is what lets a real person behind CGNAT through.
+
+18. **Cloudflare — leave Bot Fight Mode OFF.** It cannot be excepted below Pro and would challenge
+    trigger.dev's `/api/jobs/*` callback with no way to exclude it, silently disarming ADR-0020's
+    deadline monitor. It is the escalation lever if scraping actually happens; `/api/jobs/*` moves
+    first.
+19. **Cloudflare — origin lockdown.** One **request header transform rule** setting a static secret
+    header on every request into the origin (Free allows ten rules). Set the same value as a Fly
+    secret on the production app only; `proxy.ts` returns **404** to any request lacking it. Staging
+    must **not** have the check enabled — nothing is in front of it, so it would reject everything.
+20. **Verify the lockdown by trying to bypass it.** `curl https://encuentra.fly.dev/` must 404 while
+    the proxied hostname serves normally. Until that is true, `cf-connecting-ip` is attacker-chosen
+    and the credential limiter does not exist.
+21. **Arm `deploy.yml`** — one edit, named in the file.
+22. **Run the restore drill** (procedures 6 and 2 against a throwaway branch) and record the result
     here. ADR-0024 treats this as a launch requirement, because the recovery commands above are
     written from documentation rather than from having done it once.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -263,9 +263,12 @@ no payment method; no Fly app exists. Work top to bottom — later steps need th
     here to step 20 is **production only**; staging keeps its `*.fly.dev` hostname and gets none of
     it. This is ADR-0022's launch gate, and ADR-0032 gives it its sharper reason: the origin has to
     start refusing non-edge traffic on the day it starts holding personal data.
-16. **Cloudflare — cache rule.** One rule making **static assets** eligible for cache. **No HTML rule,
-    and no `Eligible for cache` on any HTML path** — ADR-0032 caches no HTML at all, and adding one
-    later means adding a purge and its missed-purge semantics with it.
+16. **Cloudflare — cache rules.** One rule making **static assets** eligible for cache, and at most one
+    more for the **landing shell** if it is served on its own path. **Nothing that names, depicts or
+    reveals a Person may be made cache-eligible** — not a Wall, not a Public View, not `/search/work`.
+    Set no `stale-while-revalidate` anywhere: Cloudflare honours it on Free, and ADR-0032 declines it
+    on both halves for different reasons. Anything cache-eligible here must be safe to serve **stale
+    forever**, because there is no purge in this design.
 17. **Cloudflare — the one rate-limiting rule.** Free allows exactly one:
 
     | Field  | Value                      |


### PR DESCRIPTION
Resolves #48.

**ADR-0032 — the edge bounds a burst, and the shape bounds the scrape.**

The ticket asked for a Wall cache TTL, a purge trigger, two limiters' keys and windows, and a Redis-versus-`"database"` price. Three of those dissolved on contact with what Cloudflare Free actually gives us, and the price turned out to decide nothing either way.

### What Cloudflare Free actually gives us

Read off the plan tables rather than assumed, because every parent ADR specified an edge mechanism as *"Cloudflare edge, $0"* and stopped there:

- **One** rate-limiting rule, **IP only**, **10-second** counting period, only `Path` and `Verified Bot` in the expression.
- Challenge actions cannot carry a duration — they become request throttling, and **passing zeroes the counter**.
- All purge methods reached all plans on 2025-04-01 (tag purge is no longer Enterprise-only) — but tag/prefix purge is **5 req/min per account** against 800 URLs/s for URL purge.
- Bot Fight Mode **cannot be excepted** by any rule below Pro.

### The findings that changed the design

**ADR-0011's launch requirement is not the control it says it is.** ADR-0014 established that query volume is the axis a scraper works on; a 10-second window bounds burst and there is no other window on Free. So *"without a rate limit, sample-not-index is a claim rather than a control"* is corrected: the controls are the bounded rotating Walls, the absence of public skill search and pagination, the 200-result cap and the rotatable `public_id` — all already built, none dependent on Cloudflare.

**ADR-0014 contradicted itself and nobody had noticed.** It requires a *"durable per-Person counter… never a cache"* for Profile search and four sections later refuses *"No per-search log."* Resolved as **how many, never what** — `search_quotas` holds a Person, a day and an integer, and is schema-incapable of holding a query.

**IP-keyed limiting is not a defence against credential stuffing**, because rotating addresses is the attack — so ADR-0009's accepted "no lockout" left one account guessable without bound. Added: a per-address failed-sign-in window that clears itself, keyed on an HMAC of the *submitted* address so it leaks nothing about whether the account exists, and which never blocks password reset.

**Sessions were the strongest case for Redis and it fails on what it relieves.** `secondaryStorage` is the only way to remove the per-request database read ADR-0009 guaranteed — but it relieves *queries*, while ADR-0028 named the unread risk as the *connection* ceiling that ADR-0006's singleton pool already caps at 5, and it would put the busiest read in the product on a meter (~500 DAU on Upstash Free) against ADR-0004 choosing PlanetScale *"for budget certainty over lowest expected cost."* One objection was checked and **withdrawn**: all seventeen Better Auth `secondaryStorage` issues are closed, so "it is buggy" is not argued.

**The landing page is two cache units, not one.** ADR-0011 puts **twelve faces** on it and `CONTEXT.md` defines a Wall as a bounded sample of *real* people, so "cache the landing page" was never one decision. The **shell** — hero, ADR-0026's three mechanism facts, chrome — holds no personal data and gets a long edge TTL; the **Wall strip** is never edge-cached. That is why the rule is phrased as a property of the response rather than a flat *"no HTML at the edge"*, which would have been obeyed for the wrong reason.

`stale-while-revalidate` **is** supported on Free and went [fully asynchronous in Feb 2026](https://developers.cloudflare.com/changelog/post/2026-02-26-async-stale-while-revalidate/), so declining it is a choice rather than a limitation. Declined on the shell because it changes only on deploy; **refused on the Wall** because with no purge there is no way to cut a stale copy short, and what it would extend is the window in which a Paused, Suspended or Blocked Person is still on the front page — ADR-0016's *"a cache that lags on a Block is a safety bug."* The mechanism it was wanted for is available one layer down with an invalidation path we own (Next 16 `"use cache"` + `cacheLife` + `revalidateTag`), which yields the standing rule: **a cache the application can invalidate may hold a Person; a cache it cannot invalidate may not.**

### Decided

| | |
| --- | --- |
| Cache | **Nothing that names, depicts or reveals a Person.** Static assets + the landing shell; never a Wall — leaving becomes *immediate*, not "under a minute" |
| Edge rule | `/search/work`, 20 req / 10 s per IP, **Managed Challenge — never `block`** (CGNAT is the normal case here) |
| Bot Fight Mode | **Off**, named as the escalation lever |
| Redis | **Not in the stack** — closes the question ADR-0013, ADR-0016 and ADR-0028 each deferred |
| Credential limiter | Better Auth `storage: "database"`, `window` pinned explicitly because its own docs disagree about the default |
| Sign-in, per address | 10 failures/hour → self-clearing 15-minute refusal, in `@repo/auth` |
| Profile search | `search_quotas`, 200/day, in `@repo/matching` — operator-visible, never automatic |
| `/api/jobs/*` | **Not limited, by decision** — limiting it risks silently disarming ADR-0020's deadline monitor |
| Origin | Refuses anything not arriving through Cloudflare (transform-rule header, 404 in `proxy.ts`) |

### Files

- `docs/adr/0032-…` — the decision. Numbered 0032 because 0031 landed on `dev` mid-session.
- **ADR-0011** amended twice (the TTL sentence, the launch requirement), **ADR-0014** three times, **ADR-0009**, **ADR-0013**, **ADR-0016**, **ADR-0022**, **ADR-0028** once each.
- `CLAUDE.md` gains a **Public edge** section; `docs/runbook.md` gains provisioning steps 15–20, including *verify the lockdown by trying to bypass it*.
- **No `CONTEXT.md` change** — engineering vocabulary belongs in `CLAUDE.md` per ADR-0017.

### Notes

- Nothing is built; this is a decision, per the map's plan-only rule.
- Still gated on ADR-0022's custom domain, which this PR gives a sharper reason: **the origin must begin refusing non-edge traffic on the day it begins holding personal data.**
- One item deliberately not taken: widening ADR-0017's reflective erasure invariant to enumerate every table would have closed the `verifications` hole ADR-0021 found, but a short-lived IP counter is not the case that justifies changing a guard built for a different purpose.
