### PR TITLE
ADR-0033: a Need is composed on one screen, and Commitment says whether the work ends

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,14 +98,29 @@ _Avoid_: UserProfile, CV, Résumé, Hoja de vida
 
 **Need**:
 A kind of Publication: a specific piece of paid work a Person wants done, whether a one-off errand
-or an ongoing role. A Person may publish any number of them.
+or an ongoing role. A Person may publish many, up to a bounded number held published at once — a
+limit on standing footprint rather than on how often they publish, and generous enough that honest
+use never meets it.
 _Spanish (UI)_: necesidad
 _Avoid_: Job, Vacancy, Vacante, Oferta laboral
 
 **Commitment**:
-The shape of the work a `Need` describes — one-off or ongoing, with expected hours or dates. A
-property of a Need, not a separate kind of Need.
+Whether the work a Need describes **ends** — _una vez_, _por un tiempo_, or _sin fecha de fin_. A
+property of a Need, not a separate kind of Need, and drawn from a fixed vocabulary.
+
+It says nothing about hours, dates or how often the work repeats. That is deliberate: a Need quoting
+a schedule is a _vacante_ in everything but name, which is the object the platform's stated exposure
+turns on, and it is the same reason pay never appears on a Need either. How much work it is belongs
+to the Offer and to the Self-description.
+
+Like the Self-description it is **shown and never queried** — a worker filtering to _sin fecha de
+fin_ would be filtering out the fastest money available to them.
+
+An **Offer** carries a Commitment too, from the same vocabulary, **plus an optional date on which
+the work ends**. The Offer may be precise where the Need may not, because it is answered once by one
+person who has already been found, rather than read by anyone.
 _Spanish (UI)_: dedicación
+_Avoid_: Schedule, Horario, Duration (the Need's says whether it ends, not how long it runs)
 
 **Work Setting**:
 Where the work would happen — in the hirer's home, in the worker's own home, on business premises,

--- a/docs/adr/0006-modular-monolith-as-ten-packages.md
+++ b/docs/adr/0006-modular-monolith-as-ten-packages.md
@@ -15,7 +15,7 @@ module that owns it. There is no event bus: anything spanning modules upward is 
 | `@repo/catalog`       | 1    | The `skills` taxonomy and `municipalities` (DANE DIVIPOLA) — seeded, read-only at runtime                                                                                | db                                        |
 | `@repo/people`        | 2    | `persons`, contact details, and the nullable `user_id` seam of ADR-0002                                                                                                  | db, auth                                  |
 | `@repo/consent`       | 3    | `consents` rows, the `Purpose` enum, aviso/política versions; answers `hasConsented()`. **Also `data_requests`, the business-day clock and the holiday list (ADR-0020)** | db, people                                |
-| `@repo/publications`  | 4    | `publications`, `capability_profiles`, `needs`, `publication_skills`, `commitments`, and the `status` column                                                             | db, people, catalog, consent              |
+| `@repo/publications`  | 4    | `publications`, `capability_profiles`, `needs`, `publication_skills`, ~~`commitments`~~ (ADR-0033), and the `status` column                                              | db, people, catalog, consent              |
 | `@repo/notifications` | 4    | Email delivery and templates; enforces the consent gate itself                                                                                                           | db, consent                               |
 | `@repo/offers`        | 5    | `offers` and its status machine, ~~the contact-exchange log~~ `offer_send_attempts` (ADR-0015)                                                                           | db, publications, people, consent         |
 | `@repo/safety`        | 6    | `reports`, `blocks`, moderation decisions                                                                                                                                | db, people, publications, offers          |
@@ -29,6 +29,12 @@ or a higher tier, which is the acyclicity guarantee.
 > timestamp obliged to always equal another. The module gains `offer_send_attempts` instead — an
 > append-only record of sends refused by a rate limit, which ADR-0013 requires and which is
 > deliberately not an `offers` row.
+
+> **Corrected by ADR-0033 — there is no `commitments` table.** This list was derived when tiers were
+> assigned and nothing about `Commitment` was known. It is one value per Need, so the table has no
+> rows to hold: it is a column on `needs`, and a second on `offers` because ADR-0015 copies rather
+> than points. The correction is not cosmetic — a table shaped for many Commitments per Need invites
+> the hours-and-dates schedule ADR-0033 refused, arriving through the schema instead of the UI.
 
 Two shapes were rejected as modules. **"Profiles" and "needs" are not separate modules**: ADR-0001's
 domain model makes `Publication` the root that owns the person, municipality, remote flag, skills and

--- a/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
+++ b/docs/adr/0011-public-profiles-are-a-sample-not-a-directory.md
@@ -159,6 +159,13 @@ The state belongs to the **Person**, not the Publication. Someone with one Capab
 Needs should not unpublish four things one at a time, and unpublishing does not stop the thing they
 actually want stopped, which is Offers already sent to them.
 
+> **Extended by ADR-0033 — a per-Need unpublish control exists, and it is not Pause.** The sentence
+> above is an argument for Pause existing, never an argument against a Need-level control, and the two
+> answer different questions: _I am not available at all_ versus _this particular job is filled_.
+> `publications.status` already carried `unpublished` (ADR-0008); ADR-0033 puts the control on the
+> compose-and-edit screen. Pause is untouched, and remains the only one of the two that freezes
+> pending Offers.
+
 Offers freeze rather than decline because declining on someone's behalf destroys information and puts
 words in their mouth. On return they surface as a **reviewable list, not as live Offers** — what arrived,
 how long ago, answer or dismiss. A month-old Offer answered _sí_ is a worse first interaction than none.

--- a/docs/adr/0013-safety-between-individuals.md
+++ b/docs/adr/0013-safety-between-individuals.md
@@ -229,6 +229,14 @@ Three counters, all durable, all refusing with honest copy rather than dropping 
 
 **Blocks are never limited.** A safety action does not get a quota.
 
+> **Extended by ADR-0033 — the published-Need cap is not a fourth counter.** Nothing here bounds how
+> many Needs a Person may have published at once, and ADR-0033 adds a generous bound on exactly that.
+> It is recorded as **not** belonging in this table: all three counters above are per unit of time
+> because all three guard a blast pattern, whereas a **standing footprint** is
+> `count(*) where status = 'published'` evaluated at the moment of publishing, with no window and no
+> durable count. This is the rule above applied a fourth time — auth limiting and safety counters
+> _"share a name and share nothing else"_, and so does this.
+
 ## What the offer flow must record
 
 Requirements handed to #9, so that the patterns deferred above are answerable later:

--- a/docs/adr/0014-search-as-two-bounded-surfaces.md
+++ b/docs/adr/0014-search-as-two-bounded-surfaces.md
@@ -264,6 +264,16 @@ photo consent doing one job in one place.
 > the link to the Public View wait for a session instead. The query, the bands and the explanation
 > sentence are unchanged for every Need.
 
+> **ADR-0033 collects the `Commitment` this card prints, and refuses it as a query axis.** Listed
+> here from the start and collected by nothing, it rendered blank on every card; it is now three
+> values saying whether the work ends. It joins the Self-description as **shown, never queried** —
+> a closed vocabulary on a public card looks exactly like a filter axis, and is not one: a worker
+> filtering to `ongoing` filters out the one-off work that is the fastest money available to someone
+> who lost their income last month, and a hirer filtering on it narrows the side ADR-0016 found
+> empty. **`What a query is` is therefore untouched**, which matters beyond consistency — ADR-0030
+> relied on that query being uniform for every Need, and a new axis is a new way to read a value off
+> a result set.
+
 This overlaps **#12** and is recorded as a constraint #12 inherits, not as a presentation decision made
 here.
 

--- a/docs/adr/0015-the-offer-as-an-immutable-snapshot.md
+++ b/docs/adr/0015-the-offer-as-an-immutable-snapshot.md
@@ -49,15 +49,31 @@ sending a new one.
 
 ### The fields
 
-| Field            | Required | Notes                                            |
-| ---------------- | -------- | ------------------------------------------------ |
-| What the work is | yes      | prose                                            |
-| Work Setting     | yes      | fixed vocabulary — see below                     |
-| Municipality     | yes      |                                                  |
-| Commitment       | yes      | one-off or ongoing, with expected hours or dates |
-| Start date       | no       | _"as soon as possible"_ is an honest answer      |
-| Pay amount       | yes      | a single figure, COP                             |
-| Pay basis        | yes      | per hour / day / week / month / job              |
+| Field            | Required | Notes                                                |
+| ---------------- | -------- | ---------------------------------------------------- |
+| What the work is | yes      | prose                                                |
+| Work Setting     | yes      | fixed vocabulary — see below                         |
+| Municipality     | yes      |                                                      |
+| Commitment       | yes      | fixed vocabulary — ADR-0033                          |
+| End date         | no       | added by ADR-0033; what makes `temporary` answerable |
+| Start date       | no       | _"as soon as possible"_ is an honest answer          |
+| Pay amount       | yes      | a single figure, COP                                 |
+| Pay basis        | yes      | per hour / day / week / month / job                  |
+
+> **Amended by ADR-0033 — `Commitment` has a vocabulary, and the Offer gains an end date.** This row
+> read _"one-off or ongoing, with expected hours or dates"_, which was a sketch rather than a
+> vocabulary and which nothing collected on either object. It is now three values — `one_off`,
+> `temporary`, `ongoing` — shared with the Need.
+>
+> The hours and dates half does **not** come back as columns. Most of the precision this table wanted
+> was already here: **`Pay basis` encodes the shape of the work** (per hour / day / week / month /
+> job) and `Start date` existed. The one thing genuinely absent was when the work **ends**, so that is
+> the single field added. There is deliberately **no hours column** — a second field about the same
+> quantity as `Pay basis` is a second source of truth inside one immutable record.
+>
+> The Offer may be precise where the Need may not, and the difference is exposure rather than taste:
+> this is a private snapshot answered once by someone already found, and a Need is a card on a surface
+> with no session gate.
 
 **Work Setting moves.** `CONTEXT.md` made it a property of a Need, and ADR-0013 relies on it to
 select the safety guidance shown at a Contact Exchange — but an Offer addressed to a Capability

--- a/docs/adr/0025-the-first-run-asks-which-door-you-came-through.md
+++ b/docs/adr/0025-the-first-run-asks-which-door-you-came-through.md
@@ -189,7 +189,18 @@ the person leaves holding an action they can take today without waiting for anyo
 | Self-description  | **not asked in the first run**      | **asked** — _Cuenta qué hay que hacer_  |
 | Photo             | offered                             | not offered                             |
 | Work Setting      | n/a                                 | asked on _dónde_ (ADR-0030)             |
+| Commitment        | n/a                                 | asked on _descripción_ (ADR-0033)       |
 | Publishes on      | _dónde_                             | _descripción_                           |
+
+> **ADR-0033 adds the `Commitment` control to _descripción_.** It is the field ADR-0014 and ADR-0026
+> print on the public Need card and nothing collected, so every card rendered it blank. It lands on
+> _descripción_ rather than _dónde_ because _how much work is this_ is the same question as _what is
+> the work_, while _dónde_ is the place screen ADR-0030 already filled. **The Need arm is still four
+> screens.**
+>
+> It is a radio group over three values and carries no hours and no dates — that half of
+> `CONTEXT.md`'s old sketch is refused by ADR-0033 on this ADR's own argument, since a Need quoting a
+> schedule is the _vacante_ this screen's copy rule already keeps it from becoming.
 
 **The Self-description split is the whole of it, and it falls out of an existing decision rather than
 out of taste.** `CONTEXT.md` makes it _"never searched, never filtered, and never an input to
@@ -252,6 +263,12 @@ guessing wrong in the second sentence someone reads is a worse failure than a sl
   author's name instead, and this flow gains the Work Setting control and two conditional sentences.
 - **#12 inherits** the fork's two cards as the first surface anyone sees signed-in, and the rule that
   a profile without a Photo never renders second-class.
+- **Everything after the first Publication is ADR-0033's**, which composes and edits on **one screen**
+  rather than re-running this flow — including the _first_ Need published by someone who came through
+  the worker door, since the pacing here is bought for newness to the **product** and they no longer
+  have it. Two things from this ADR travel there rather than staying: the _"El pago y las condiciones
+  no van aquí"_ line, and the three Photo constraints, which were already stated as properties of any
+  screen that offers a Photo.
 - **#16 inherits nothing testable.** Every decision here is a screen, a string or an ordering, and
   ADR-0017 puts all of it outside the two seams — see below.
 

--- a/docs/adr/0030-a-public-need-names-the-place-not-the-person.md
+++ b/docs/adr/0030-a-public-need-names-the-place-not-the-person.md
@@ -199,6 +199,12 @@ reasons and no sixth screen, which ADR-0025 was right to count as a cost:
 no ADR collects it either. Named so that it is discovered on purpose rather than by a blank card, and
 left to whoever owns Need composition beyond the first run — which is also unowned.
 
+> **Both halves closed by ADR-0033.** `Commitment` is three values saying whether the work ends —
+> collected on ADR-0025's _descripción_ screen, and carrying no hours and no dates for the same
+> Res. 000129 art. 5 reason this ADR's neighbour keeps pay off a Need. Need composition beyond the
+> first run is **one screen**, which also owns editing, and the `hirer_home` flip it creates needs no
+> machinery because this ADR already put that branch in the read-time projection.
+
 ## Authored Municipality pages are prose and a link, and list no Publications
 
 ADR-0014 asserts that _"the authored skill and municipality pages stay indexable and remain the surface
@@ -249,5 +255,6 @@ licensed it.
   depends on the second being right; **Work Setting** gains the third job; **Public View** is untouched.
 - **Whoever builds the Need card inherits** one branch and the rule that the branch lives in the
   projection.
-- **Need composition beyond the first run has no owner**, and now has two fields waiting for one —
-  Work Setting and Commitment.
+- ~~**Need composition beyond the first run has no owner**, and now has two fields waiting for one —
+  Work Setting and Commitment.~~ **Owned by ADR-0033**, which collects `Commitment`, composes and
+  edits a Need on one screen, and inherits this ADR's two conditional `hirer_home` sentences onto it.

--- a/docs/adr/0033-a-need-is-composed-on-one-screen.md
+++ b/docs/adr/0033-a-need-is-composed-on-one-screen.md
@@ -1,0 +1,285 @@
+# A Need is composed on one screen, and `Commitment` says whether the work ends
+
+Two fields print on the public Need card and are collected by **nothing**. `Work Setting` was half
+fixed by ADR-0030, which put its control on ADR-0025's _dónde_ screen because its own disclosure rule
+could not run without it — and said plainly that it had covered the first run only. `Commitment` was
+not fixed at all: `CONTEXT.md` sketches it as _"one-off or ongoing, with expected hours or dates"_,
+which is a description rather than a vocabulary, and ADR-0015 makes it **required on an Offer** under
+the same sketch.
+
+Behind both sits a surface nobody has described. ADR-0025 publishes exactly one Publication and owns
+nothing after it, while ADR-0002 lets a Person publish **0..n** Needs. The second Need has been
+composed nowhere since the domain model was written.
+
+This ADR closes the vocabulary, the surface and editing together, because each of the three was
+answering a question the other two had already half decided.
+
+## `Commitment` is a duration class, and the hours are missing on purpose
+
+Three values, and they are the whole of it on a Need:
+
+| Value       | UI                 |
+| ----------- | ------------------ |
+| `one_off`   | _una vez_          |
+| `temporary` | _por un tiempo_    |
+| `ongoing`   | _sin fecha de fin_ |
+
+**The sketch's second half — _"with expected hours or dates"_ — is removed rather than implemented.**
+ADR-0025 threw pay and conditions off the Need on an argument that reaches this field exactly:
+
+> a Need quoting a rate and a schedule is a _vacante_ in everything but name
+
+which is the object UAESPE **Res. 000129 art. 5** reaches, and the exposure ADR-0011 accepted
+knowingly and narrowly. Pay left through the front door; hours and dates would walk back in through
+this one. A `Commitment` carrying _"20 horas semanales, del 3 de marzo al 30 de junio"_ is a schedule,
+and a public card carrying a schedule is the thing the whole of ADR-0025's copy rule exists to keep the
+Need from becoming.
+
+What survives is the question a worker is actually asking, which is not _how many hours_ but **does
+this end**. A day's work and a permanent post are different decisions about whether to answer, and
+they are different in a way that survives having no numbers attached.
+
+**Frequency is deliberately not collected.** _Every Saturday_ versus _full-time_ is hours by another
+name, arriving as a second enum instead of a number. Where it matters it belongs to the Offer, which
+is where ADR-0025 already sent _"el pago y las condiciones"_, and to the Self-description, which is
+what a worker reads before deciding whether to answer at all.
+
+**Two values were rejected** — collapsing _por un tiempo_ into _sin fecha de fin_ loses the
+distinction that matters most to someone deciding whether to give up other work for this.
+**Four were rejected** because the fourth is always a schedule wearing a category's clothes.
+
+## The Offer's `Commitment` is the same word doing a second job
+
+ADR-0015 requires it and means the precise reading — an Offer is answerable exactly once, and you
+cannot honestly say yes to a vague thing. That is a real difference from the Need, and it is a
+difference in **exposure**: the Offer is a private, immutable snapshot between two people who have
+already found each other, and the Need is a card on a surface with no session gate.
+
+So the Offer carries the same three values **plus an optional end date, and nothing else**.
+
+On re-reading ADR-0015's field table, most of the precision its sketch asked for **already exists
+there**: `Pay basis` is per hour / day / week / month / job, which encodes the shape of the work, and
+`Start date` is already a column. The only thing genuinely absent is when the work **ends**, which is
+what makes `temporary` answerable rather than decorative. **No hours column** — `Pay basis` already
+carries that, and a second field about the same quantity is a second source of truth that can
+disagree with the first inside one immutable record.
+
+**One word now covers two shapes, and `CONTEXT.md` says so explicitly.** That is stated rather than
+left to be noticed, because this is the second time it has happened: ADR-0015 discovered that
+`Work Setting` had quietly moved from the Need to the Offer, and only noticed because the snapshot
+rule met the safety rule in one place. A vocabulary that means slightly different things on two
+objects is fine; a vocabulary that does so silently is what produced that repair.
+
+## `Commitment` is shown and never queried
+
+It is a closed vocabulary on a public card, which makes it look exactly like a filter axis. It is not
+one, on three grounds, and the first is the one that decides it:
+
+**A worker filtering to `ongoing` filters out the fastest money available to them.** The audience is
+people who lost their income within the last few weeks. One-off work pays this month; a filter that
+hides it is a control that hurts the person operating it, offered by a product whose whole argument is
+that it does not know better than the person using it.
+
+**A hirer filtering on it narrows the side ADR-0016 already found empty.** The worker-facing corpus is
+the scarce one; adding an axis that shrinks a result set is a feature aimed at the abundant side.
+
+**And ADR-0014's query stays literally unchanged**, which matters more than consistency for its own
+sake — ADR-0030 leaned on that query being **uniform for every Need** when it argued that a card
+withholding the Municipality was a fig leaf, because the band membership disclosed it anyway. A new
+filter axis is a new way to read a value off the result set, and it would need that argument re-run.
+
+The rule is therefore the Self-description's rule, applied to a field that happens to be an enum:
+**shown, never queried, never an input to matching.**
+
+## The second Need is composed on one screen
+
+One screen, every field on it, one **_Publicar_** button.
+
+ADR-0025's four-screen pacing is bought for a **stranger** — someone who has never seen the product,
+one question at a time, a breadcrumb so they know it ends. There is no stranger here. A Person
+publishing a second Need has already met the picker, the _dónde_ screen and the ending that tells them
+what publishing does and does not do.
+
+**The cheaper choice is also the kinder one**, and for the constraint this map keeps naming: a person
+rationing mobile data loads one page instead of four, and has no partial progress to lose between
+them. ADR-0025 built _"Guardar y seguir después"_ precisely because the flow could be abandoned
+halfway; a single screen has less halfway to be abandoned in.
+
+**This covers the first Need through the other door too.** ADR-0025's fork tells a worker _"la otra
+queda para cuando quieras"_, so a Person who came through the _Busco trabajo_ door and later publishes
+their first Need is composing a Need for the first time while not being new to the product. Newness to
+the **product** is what the flow buys, and they do not have it.
+
+What arrives on the screen unchanged:
+
+- **ADR-0023's picker**, capped at **5** for a Need (ADR-0016), with its meter, its cap treatment and
+  its Skill Suggestion.
+- **The Municipality, the remote flag and the Work Setting**, as ADR-0030 grouped them.
+- **`Commitment`**, as a radio group.
+- **The Self-description**, which is the field a worker reads before answering.
+
+And the copy, which is the part that must not be lost:
+
+- ADR-0025's **_"El pago y las condiciones no van aquí: los pones en la oferta que le mandas a
+  alguien."_**
+- ADR-0030's two `hirer_home` conditional lines — the one about the author's name on the public card,
+  and the one about not typing an address into the prose.
+
+**Teaching copy is not pacing.** The distinction is load-bearing: when the scaffolding of a guided
+flow is removed, the sentences carrying a regulatory edge are exactly the ones most easily removed
+along with it, because they look like onboarding. They are not. They ride as inline notes on the
+fields they belong to.
+
+## Editing is the same screen prefilled, and it is safe because the Offer copies
+
+One component, two entry points. A Need is an **advertisement**, not an agreement, and editing one is
+ordinary — which is worth saying out loud only because ADR-0015 makes the neighbouring object
+immutable for reasons that do not transfer.
+
+**Editing is safe precisely because of the decision that made the Offer immutable.** ADR-0015 has the
+Offer **copy** its terms rather than point at them, on the ground that _"editing a Need cannot rewrite
+what someone already accepted"_. That property was argued for the Offer's benefit; it is what makes an
+editable Need harmless, and nothing further is needed to protect an accepted Offer from an edit.
+
+**The `hirer_home` flip needs no machinery.** Changing the Work Setting to or from `hirer_home` flips
+whether the public card names the author — but ADR-0030 already requires that branch to live in the
+**read-time projection** (_"the branch lives in the projection"_), and its Invariant Test assumes it.
+So the card simply renders differently on the next read. The screen shows the same conditional
+sentence at the moment the setting changes that the compose screen shows when it is first chosen; the
+consequence is disclosed where the choice is made, which is ADR-0025's pattern and ADR-0030's
+requirement.
+
+**Unpublish and republish live here.** `publications.status` already carries
+`draft | published | unpublished` (ADR-0008), and a per-Need control is the thing ADR-0011's Pause
+explicitly is **not** — it warned that Needs _"should not unpublish four things one at a time"_, which
+is an argument for a Person-level Pause existing, never an argument against a Need-level control.
+They answer different questions: _I am not available at all_ versus _this particular job is filled_.
+
+**No delete.** ADR-0008 hard-deletes and defaults FKs to `RESTRICT`, so a Need with Offers against it
+cannot be deleted without either a cascade that destroys an Offer's provenance or an error the person
+cannot act on. Unpublish is the honest mechanism, it is already built, and a second one buys nothing.
+
+## The Capability Profile gets the same screen
+
+The same hole exists one object over: the Capability Profile is composed in the first run and edited
+**nowhere**. Closing it costs a paragraph, and leaving it open is the identical bug.
+
+Same one-screen pattern, prefilled, picker capped at **20** rather than 5 (ADR-0012). It differs in
+one way that matters: it carries the **Photo** control, so **ADR-0025's three structural constraints
+arrive whole** — never the last control before the button that saves, two controls of equal visual
+weight, and the stated cost of skipping being nothing. ADR-0025 declared those properties of _any_
+screen that offers the Photo rather than of its flow, so this inherits them and reopens none of them.
+
+D.1377 art. 6's ban on conditioning is broken by a running order as easily as by a rule, and on a
+single screen "running order" means visual order. The constraint is not weaker here for being on one
+screen; it is only expressed in a different axis.
+
+## A cap on published Needs is a footprint, not a rate
+
+`CONTEXT.md` says 0..n and means it literally. **Nothing anywhere bounds it.** ADR-0013's three
+durable counters guard Offers sent per day, distinct recipients per rolling week, and Reports per
+reporter per day — every one of them **per unit of time**, because every one of them guards a blast
+pattern. Publishing is unguarded, and a Need is public prose on a surface with no session gate.
+
+The bound is on **published Needs held at once**, and it is generous — well above any honest use.
+Unpublish one to publish another.
+
+**It must not be wired into ADR-0013's counter mechanism**, and that is the substance of this section
+rather than the number. A standing footprint and a rate are different shapes: a rate needs a window
+and a durable count over `created_at`, a footprint is `count(*) where status = 'published'` evaluated
+at the moment of publishing. Sharing a mechanism between them would give the safety counters a member
+that is not a safety counter, and ADR-0013 was explicit that its counters exist so the patterns it
+deferred stay answerable by SQL later.
+
+ADR-0013 already set the rule this follows: auth limiting and safety counters **_"share a name and
+share nothing else"_**. ADR-0032 extends that to a third case — an unattributable public surface at
+the edge — and keeps all three apart. This is a **fourth** thing again, and the only one of the four
+that is not a rate at all.
+
+**The number is not enshrined here, and unlike ADR-0012's skill cap it is symmetric.** That is worth
+defending rather than asserting, because ADR-0012's asymmetry argument looks like it should transfer
+and does not: there, lowering the cap means **telling people who have already published to delete
+skills**, because the cap is checked wherever a Publication is written. Here the check runs at
+**publish time only** — `count(*) where status = 'published'` against the cap, at the moment of
+publishing. A Person holding more than a newly-lowered cap is a legal state that demands nothing of
+them; they simply cannot add another until they unpublish one. Lowering costs a config value and no
+conversation, so ADR-0014's precedent of deliberately not fixing such a number applies and ADR-0012's
+does not.
+
+## `commitments` is a column, not a table
+
+ADR-0006 lists a plural `commitments` table in `@repo/publications`. With one value per Need there are
+no rows for it to hold: `Commitment` is `text({ enum })` plus a `check()` per ADR-0008's
+no-`pgEnum` rule, on `needs` and again on `offers` — the second copy because ADR-0015 copies rather
+than points.
+
+ADR-0006's list was derived at tier-assignment time, before anything about `Commitment` was known, and
+it is corrected rather than honoured. **A table nobody removes is a table somebody eventually fills**,
+and the shape it would invite — many Commitments per Need — is the schedule this ADR just refused,
+arriving through the schema instead of through the UI.
+
+## Consequences
+
+- **ADR-0006 corrected.** `commitments` leaves `@repo/publications`' table list; the column lives on
+  `needs`, and a second on `offers`. No tier changes and no dependency edge moves.
+- **ADR-0015 amended.** Its `Commitment` row gains a definition instead of a sketch, and the Offer
+  gains an **optional end date**. Its immutability, its copy-not-point rule and its field table are
+  otherwise untouched — and the copy-not-point rule is what makes an editable Need safe.
+- **ADR-0025 amended.** The Need arm's _descripción_ screen gains the `Commitment` control. **The
+  Need arm is still four screens** — the count ADR-0030 also preserved. Its Photo constraints are
+  inherited by the Capability Profile screen below, as it required.
+- **ADR-0014 and ADR-0026 discharged.** The public Need card's `Commitment` is now collected, so it no
+  longer renders blank — which ADR-0026's no-placeholder reasoning would otherwise have reached.
+  ADR-0014's query definition, bands and explanation sentence are **unchanged**.
+- **ADR-0030's open note is discharged.** _"`Commitment` is the same gap and is not closed here …
+  left to whoever owns Need composition beyond the first run — which is also unowned"_ — both halves
+  are owned by this ADR.
+- **ADR-0011 extended.** A per-Need unpublish control exists and is not Pause; Pause stays the
+  Person-level state it defined.
+- **ADR-0013 extended, and deliberately not amended.** The published-Need cap is named as **not** one
+  of its counters, so nobody wires one mechanism for both — the same separation it insisted on
+  between safety counters and the auth limiter.
+- **ADR-0017 gains one testable thing and no more.** The cap is enforced in a use case, which is a
+  seam; everything else here is a screen, a string or an ordering, which ADR-0017 tests in neither
+  seam. ADR-0030's projection Invariant Test already covers the `hirer_home` branch and needs no
+  companion.
+- **`CONTEXT.md`** — **Commitment** rewritten with its three values and the explicit note that the
+  Offer's copy carries an end date the Need's does not; **Need** gains that the number a Person may
+  have published at once is bounded.
+
+## What has no automated guard
+
+The one screen's copy — ADR-0025's _pago y condiciones_ line and ADR-0030's two `hirer_home`
+sentences — and the visual ordering that keeps the Photo control off the save button on the Capability
+Profile screen. Both are properties of a React component tree, which ADR-0017 puts outside its two
+seams.
+
+This adds the compose-and-edit surfaces to the list the map already carries: the consent-evidence
+path, ADR-0023's picker, ADR-0025's first run and ADR-0031's operator surface. The item with a
+regulatory edge is the same one ADR-0025 named — a refactor that moves one element publishes people
+through a control the law says may not condition anything — and it now exists in two places rather
+than one.
+
+## Rejected
+
+**Hours and dates on the Need.** The sketch in `CONTEXT.md` said so, and it is a schedule; ADR-0025
+kept pay and conditions off the Need for exactly the reason that reaches it.
+
+**A frequency value beside the duration class.** _Every Saturday_ is hours expressed as a category.
+
+**`Commitment` as a search filter.** Argued above: it hurts the person operating it, narrows the
+scarce side, and reopens the uniformity ADR-0030 relied on.
+
+**Re-running the first-run flow for the second Need.** Pacing bought for a stranger, charged to
+someone who is not one, and paid in page loads by a person rationing data.
+
+**A separate edit flow.** Two surfaces asking the same questions drift, and the teaching copy would
+survive on only one of them.
+
+**Deleting a Need.** `RESTRICT` plus an Offer's provenance; unpublish already exists and is honest.
+
+**Wiring the cap into ADR-0013's counters.** A footprint is not a rate, and the counters exist to keep
+a deferred question answerable in SQL.
+
+**Coarsening the Offer's `Commitment` to match the Need's.** Symmetry for its own sake, against
+ADR-0015's requirement that an Offer be answerable once. The exposure differs, so the field may.


### PR DESCRIPTION
Resolves #63 — the last unclaimed architectural decision on the [map](https://github.com/m0t0r/workforpereira/issues/1).

Two fields print on the public Need card and were collected by **nothing**. ADR-0030 fixed half of `Work Setting` and said plainly it had covered the first run only; `Commitment` was a sketch in `CONTEXT.md` that ADR-0015 *also* made required on an Offer. Behind both sat a surface nobody had described — ADR-0025 publishes exactly one Publication, while ADR-0002 allows 0..n Needs.

## What it decides

- **`Commitment` is three values saying whether the work ends** — `one_off` / `temporary` / `ongoing`. The sketch's *"with expected hours or dates"* half is **refused rather than implemented**: a Need quoting a schedule is the *vacante* under UAESPE Res. 000129 art. 5 that ADR-0025 kept pay off a Need to avoid. Frequency is not collected either — *every Saturday* is hours wearing a category's clothes.
- **The Offer carries the same three plus an optional end date, and nothing else.** Most of the precision ADR-0015's sketch wanted already existed there: `Pay basis` encodes the shape of the work and `Start date` was already a column. Only *when it ends* was missing. No hours column — that would be a second source of truth against `Pay basis` inside an immutable record.
- **Shown, never queried.** A worker filtering to `ongoing` filters out the one-off work that is the fastest money available to someone who lost their income last month; a hirer filtering on it narrows the side ADR-0016 found empty. ADR-0014's query is therefore untouched, which matters because ADR-0030 leaned on it being uniform for every Need.
- **One screen composes and edits a Need** — and the Capability Profile too, closing the identical hole one object over. Pacing is bought for a stranger, and a Person publishing their second Need is not one. Editing is safe *because* ADR-0015 has the Offer **copy** its terms rather than point at them.
- **Unpublish/republish is a per-Need control and is not Pause.** No delete: `RESTRICT` plus an Offer's provenance.
- **A generous cap on published Needs** — a standing footprint, `count(*) where status = 'published'` at publish time, and deliberately **not** a fourth ADR-0013 counter. All three of those are per-unit-time because all three guard a blast pattern.

## Corrections to existing ADRs

- **ADR-0006** — there is no `commitments` table. It was derived at tier-assignment time before anything about `Commitment` was known; one value per Need means no rows to hold, and a table shaped for many invites the schedule this ADR just refused, arriving through the schema.
- **ADR-0015** — `Commitment` gains a vocabulary; the Offer gains an end date.
- **ADR-0025** — *descripción* gains the `Commitment` control. The Need arm is **still four screens**.
- **ADR-0030** — both of its open notes discharged (`Commitment`, and Need composition beyond the first run).
- **ADR-0011** (per-Need unpublish is not Pause), **ADR-0013** (the cap is not a counter), **ADR-0014** (the card's field is now collected, and refused as a query axis).
- **`CONTEXT.md`** — `Commitment` rewritten; `Need` gains the bound.

## Notes

ADR number coordinated with the concurrent #48 session, which holds 0032.

Nothing here is implemented — this map is plan-only. The one testable thing it adds is the cap, which lands in a use case (an ADR-0017 seam); everything else is a screen, a string or an ordering, and is added to the list of surfaces guarded by prose alone.