### PR TITLE
chore(ci): dependabot watches four ecosystems, and every action is a SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,222 @@
+# Dependabot — version updates, and the shape of the security updates that ride alongside them.
+#
+# Read from the **default branch only**, which here is `dev` (ADR-0022's trunk). Editing this file
+# on a feature branch changes nothing until it merges; there is no per-branch config and no second
+# file — GitHub supports exactly one `.github/dependabot.yml` per repository.
+#
+# Two things are configured elsewhere, in repository settings, because no YAML can turn them on:
+# **Dependabot alerts** and **security updates**. Both are enabled. This file does not create them;
+# it only decides how their pull requests are grouped, labelled and scheduled. The division matters
+# when debugging: no alerts at all is a settings problem, alerts with no pull request is this file.
+#
+# `cooldown` below is the supply-chain control and the reason several of these blocks exist. A
+# compromised release is caught and yanked in hours to days, so a version that has been public for
+# a few days is a meaningfully different risk from one published this morning. **Cooldown applies
+# to version updates only** — a security update jumps the queue by design, which is exactly the
+# behaviour wanted: age the routine bumps, never the CVE fixes.
+
+version: 2
+
+updates:
+  # ── npm (pnpm) ─────────────────────────────────────────────────────────────────────────────────
+  # One entry, at the root, for the whole workspace. `pnpm-lock.yaml` and `pnpm-workspace.yaml` live
+  # there and Dependabot resolves `apps/*` and `packages/*` from them — adding `/apps/*` and
+  # `/packages/*` here would point the updater at directories holding a `package.json` and no
+  # lockfile, which it cannot resolve and reports as a failed job.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      # The project is in Pereira and its clock decisions are Colombian everywhere else
+      # (ADR-0008). A Monday-morning batch that lands Monday morning *here* is the point.
+      timezone: America/Bogota
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    # Conventional Commits, matching the history: `chore(deps): …` and `chore(deps-dev): …`.
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    cooldown:
+      default-days: 5
+      semver-patch-days: 3
+      semver-minor-days: 5
+      # A major is a reading job regardless, so the extra wait costs nothing and removes any
+      # chance of being the first repository to run a compromised `x.0.0`.
+      semver-major-days: 14
+    ignore:
+      # `@types/node` majors track the **Node runtime**, not npm's newest. `.nvmrc` says 24 and
+      # `engines` says `>=24.0.0`, so `@types/node@26` would type a runtime this repo does not run
+      # and cannot run — it would compile happily against APIs the Docker image has never heard of.
+      # Raise this ceiling in the same commit that raises `.nvmrc`, never before it.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+    groups:
+      # First match wins, so the ordering here is the policy.
+
+      # One pull request for every CVE fix in a batch, ahead of everything else. Without this,
+      # eight open alerts is eight pull requests.
+      security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+      # ADR-0018: `oxlint-tsgolint` tracks TypeScript **release-for-release**, and `typescript` is
+      # pinned exact for that reason. Split across two pull requests, whichever merges first leaves
+      # the type-aware lane broken until the second one lands. They move together or not at all —
+      # majors included, which is why this group sets no `update-types`.
+      typescript-toolchain:
+        patterns:
+          - typescript
+          - oxlint-tsgolint
+
+      # Same argument, weaker version: `eslint-plugin-turbo` is published from the turbo repo at
+      # the same version, and the two drifting is what produced the current 2.7.1 / 2.10.x gap.
+      turborepo:
+        patterns:
+          - turbo
+          - eslint-plugin-turbo
+
+      # React, its DOM renderer, their `@types/*` and the framework that pins peer ranges over all
+      # four. Bumping `react` without `react-dom` is an install error, and without `@types/react` a
+      # type error; the framework decides which combinations are legal at all.
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+          - next
+          - eslint-config-next
+
+      # ADR-0017's test lane, published in lockstep from one repository.
+      vitest:
+        patterns:
+          - vitest
+          - "@vitest/*"
+          - "@electric-sql/pglite"
+          - "@electric-sql/pglite-socket"
+
+      # drizzle-orm and drizzle-kit share a snapshot format. A `db:generate` run by one against
+      # migrations written by the other is `pnpm db:check`'s drift failure, at best.
+      drizzle:
+        patterns:
+          - drizzle-orm
+          - drizzle-kit
+          - "@types/pg"
+          - pg
+
+      # Everything else, split by dependency type and **minor/patch only** — a major that reaches
+      # here gets its own pull request and its own read, which is the whole reason not to write
+      # `patterns: ["*"]` and be done with it.
+      production-dependencies:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+        # oxfmt is pinned exact because it is pre-1.0 and rewrites the entire repository on a
+        # patch release (ADR-0019). That diff has to arrive alone, or it buries whatever else
+        # shared the pull request.
+        exclude-patterns:
+          - oxfmt
+
+  # ── Docker: the runtime image ──────────────────────────────────────────────────────────────────
+  # `Dockerfile` pins `node:24.19.0-slim` **by digest as well as tag**, which is what makes "one
+  # artifact, promoted" true down to the base OS. Dependabot understands that pin and rewrites both
+  # halves together; a digest-only pin is the case it cannot version, and this repo does not have
+  # one.
+  #
+  # This is the entry that answers a base-image CVE, so its cooldown is short on purpose. A Debian
+  # security patch that has been public for five days is not safer than one published yesterday —
+  # it is five days of exposure.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Bogota
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: chore
+      include: scope
+    cooldown:
+      default-days: 2
+    ignore:
+      # Node majors are `.nvmrc`'s decision, not this file's — and moving one here would put the
+      # image and `engines` on different major lines with nothing to catch it, since `next build`
+      # runs inside this image and would simply succeed.
+      - dependency-name: node
+        update-types: ["version-update:semver-major"]
+
+  # ── Docker Compose: the local database ─────────────────────────────────────────────────────────
+  # `postgres:18.6-trixie` is pinned to **the exact patch PlanetScale runs** (ADR-0004). A pull
+  # request here is therefore a prompt to go and check what PlanetScale is on, not a bump to merge
+  # on green: matching the managed host is the property being maintained, and CI cannot see it.
+  #
+  # Monthly, because nothing in this file can make PlanetScale move faster than it does.
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: monthly
+      time: "07:00"
+      timezone: America/Bogota
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: chore
+      include: scope
+    ignore:
+      # **PlanetScale has no in-place major-version upgrade** — moving majors means creating a new
+      # database and migrating into it (ADR-0004). A `postgres:19` pull request would not be a
+      # dependency update; it would be a migration project wearing one, and merging it would make
+      # local and production disagree about the engine.
+      - dependency-name: postgres
+        update-types: ["version-update:semver-major"]
+
+  # ── GitHub Actions ─────────────────────────────────────────────────────────────────────────────
+  # Every `uses:` in this repository is pinned to a **commit SHA**, not a tag. A tag is a mutable
+  # pointer the action's owner can move after review — which is how `tj-actions/changed-files` was
+  # turned into a secret exfiltrator across thousands of repositories without a single consumer
+  # changing a line. A SHA cannot be moved.
+  #
+  # Pinning is what makes this entry load-bearing rather than tidy: a SHA pin **does not float**,
+  # so an unattended repository silently stops receiving security fixes for its own CI. Dependabot
+  # is the thing that keeps a pin current, and rewrites the `# vN` comment beside it in step.
+  #
+  # These jobs hold `FLY_*` tokens and `*_DATABASE_URL`. The blast radius of a compromised action
+  # here is production.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Bogota
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore
+      include: scope
+    cooldown:
+      default-days: 3
+    ignore:
+      # `superfly/flyctl-actions/setup-flyctl` is pinned to a SHA of **master**, which is what Fly
+      # documents and the only ref they keep current; their newest release tag is older than it.
+      # Left alone, Dependabot would read the pin as un-versioned and "update" it backwards onto
+      # `1.5`. Bumping this is a manual re-read of the master SHA.
+      - dependency-name: superfly/flyctl-actions
+    groups:
+      # Minor and patch in one pull request — the diff is a line per action and reads in a glance.
+      # A major arrives alone, because an action major is a behaviour change (a new runner, a
+      # renamed input) and it should be possible to revert one without reverting five.
+      actions:
+        patterns: ["*"]
+        update-types: [minor, patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,27 @@ env:
   # without inspecting a deploy log, and what makes an expand and its contract two pull requests.
   DB_CHECK_BASE: origin/${{ github.base_ref || 'dev' }}
 
+# Every `uses:` below is pinned to a **commit SHA**, with the version it was at in the comment
+# beside it. A tag is a mutable pointer the action's owner can move after anyone reviewed it, which
+# is how `tj-actions/changed-files` became a secret exfiltrator in thousands of repositories without
+# a single consumer changing a line. A SHA cannot be moved.
+#
+# The cost of a SHA pin is that it does not float, so it goes stale in silence. `.github/dependabot.yml`
+# is what pays that cost — it rewrites the SHA and the comment together, weekly.
+
 jobs:
   gate:
     name: Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # `--affected` walks history to find the merge base.
           fetch-depth: 0
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -50,7 +58,7 @@ jobs:
       # Turborepo's own cache, kept on GitHub rather than Vercel Remote Cache: CI runners are always
       # cold so caching pays, and this map has priced vendor count carefully everywhere else
       # (ADR-0022).
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -83,6 +91,32 @@ jobs:
         if: github.event_name != 'pull_request'
         run: pnpm exec turbo run lint check-types test db:check check-contrast
 
+  # Fails a pull request that *introduces* a dependency with a known advisory — before it is in the
+  # lockfile on `dev`, rather than after, which is the only thing Dependabot alerts can offer.
+  #
+  # It reads the diff of the dependency graph, so it says nothing about advisories already present:
+  # those are the alerts' job. That is what makes it safe to fail on `moderate` here without the
+  # gate going permanently red on debt.
+  #
+  # It runs on Dependabot's own pull requests too, and that is the point — a bump whose new
+  # transitive closure carries a CVE is a real and unglamorous way to import one.
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          # No `comment-summary-in-pr`. Posting one needs `pull-requests: write`, and GitHub hands
+          # Dependabot's own pull requests a read-only token no matter what a workflow asks for —
+          # so the comment would fail on exactly the pull requests this job exists to check. The
+          # findings are in the job summary, which needs no permission at all.
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
@@ -94,11 +128,11 @@ jobs:
       # a broken pipeline; the fix, when it is needed, is a `workflow_run` job.
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -116,4 +150,11 @@ jobs:
       # ADR-0017 declines one explicitly, and **never gates on the number** — the seams are
       # restricted by decision, so the figure can only be raised by testing what this repo decided
       # not to test.
-      - uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2
+      #
+      # Skipped for Dependabot. GitHub issues `github.actor == 'dependabot[bot]'` runs a read-only
+      # `GITHUB_TOKEN` regardless of the `permissions:` block above — the elevated scope is not
+      # denied, it is silently not granted — so this step would 403 on every dependency bump and
+      # paint the Coverage job red for a reason that has nothing to do with coverage. The `coverage`
+      # run itself still happens above, which is the part that could actually catch a regression.
+      - if: github.actor != 'dependabot[bot]'
+        uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -132,9 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm


### PR DESCRIPTION
Sets up Dependabot with a DevSecOps posture, and closes the two gaps that would have made its output noise instead of signal.

## Settings changed outside this diff

Dependabot **alerts** and **security updates** were disabled on the repository — no YAML can turn those on, so they were flipped via the API. First scan surfaced **8 open advisories** (7 high/medium in transitive dev dependencies, plus `esbuild`'s dev-server request leak). This PR does not fix them; it decides what the pull requests that fix them look like. That division is worth knowing when debugging: *no alerts at all* is a settings problem, *alerts with no pull request* is this file.

## `.github/dependabot.yml`

Four ecosystems:

| Ecosystem | Target | Cadence | Notes |
|---|---|---|---|
| `npm` | `/` | weekly | One entry — pnpm resolves `apps/*` and `packages/*` from the root lockfile. Pointing the updater at those directories produces failed jobs, not more coverage. |
| `docker` | `Dockerfile` | weekly | `node:24.19.0-slim`, tag **and** digest rewritten together. Short 2-day cooldown: a base-image CVE patch that has aged five days is five days of exposure, not five days of safety. |
| `docker-compose` | `docker-compose.yml` | monthly | `postgres:18.6-trixie`. A PR here is a prompt to check what PlanetScale is on, not a bump to merge on green. |
| `github-actions` | `.github/workflows/` | weekly | The reason the SHA pins below stay current. |

**Grouping encodes this repo's actual coupling**, not a template:

- `typescript` + `oxlint-tsgolint` — ADR-0018 pins them release-for-release. Split across two PRs, whichever merges first leaves the type-aware lane broken until the other lands.
- `turbo` + `eslint-plugin-turbo` — published from one repo at one version. Letting them drift independently is exactly how they reached 2.10.10 and 2.7.1.
- `drizzle-orm` + `drizzle-kit` — shared snapshot format; a mismatch is a `pnpm db:check` drift failure.
- `react` / `react-dom` / their `@types` / `next` — peer ranges make illegal combinations installable but broken.
- `oxfmt` **excluded from every group**: a pre-1.0 patch rewrites the whole repository (ADR-0019), and that diff has to arrive alone or it buries whatever shared the PR.
- All security updates batch into **one** PR. Eight alerts would otherwise be eight PRs.
- Majors never join a minor/patch group — each gets its own PR and its own read.

**Two `ignore` rules that are decisions, not preferences:**

- `@types/node` majors — these track the **Node runtime**, not npm's newest. `.nvmrc` says 24; `@types/node@26` would type a runtime the Docker image has never run, and would compile happily.
- `postgres` majors — **PlanetScale has no in-place major upgrade** (ADR-0004). Moving majors means creating a new database and migrating into it. Such a PR is a migration project wearing a dependency bump.
- `superfly/flyctl-actions` — pinned to a SHA of `master`, which is what Fly documents and the only ref they keep current; their newest release tag is *older*. Left alone, Dependabot would "update" it backwards onto `1.5`.

**`cooldown`** ages routine updates 3–14 days by semver rank, so this is never the first repository to install a freshly compromised release. Security updates bypass it by design — age the routine bumps, never the CVE fixes.

## Every action is pinned by commit SHA

`deploy.yml` already did this for third-party actions; the first-party `actions/*` ones were on floating `@v4`. A tag is a mutable pointer the action's owner can move *after* anyone reviewed it — which is how `tj-actions/changed-files` was turned into a secret exfiltrator across thousands of repositories without a single consumer changing a line. These jobs hold `FLY_*` tokens and `*_DATABASE_URL`; the blast radius is production.

Pinned at their **current** versions, so this PR is behaviour-neutral. The version bumps are PR 2. The cost of a SHA pin is that it does not float and decays in silence — the Dependabot entry above is what pays it.

## New `dependency-review` job

Fails a PR that *introduces* a dependency with a known advisory, rather than reporting it once it is already on `dev`. It reads the **diff** of the dependency graph, so the 8 existing alerts do not make it red — that is what makes `fail-on-severity: moderate` safe here. It runs on Dependabot's own PRs too, which is the point: a bump whose new transitive closure carries a CVE is a real and unglamorous way to import one.

No `comment-summary-in-pr` — see below.

## The fix without which all of this would have looked broken

GitHub issues Dependabot PRs a **read-only `GITHUB_TOKEN` regardless of a workflow's `permissions:` block** — the elevated scope is not denied, it is silently not granted. The coverage job asks for `pull-requests: write` to post its sticky comment, so that step would have **403'd on every single dependency bump**, painting Coverage red for a reason that has nothing to do with coverage.

It is now skipped for `dependabot[bot]`. The `coverage` run itself still happens, which is the part that could catch a regression.

## Verification

- `.github/dependabot.yml` validated against the SchemaStore Dependabot 2.0 schema (`check-jsonschema --builtin-schema vendor.dependabot`) — and the validator negative-tested with a bogus key to confirm it actually rejects unknown properties rather than passing everything.
- Both workflows validated against `vendor.github-workflows`.
- Full gate green locally: `pnpm format:check`, `pnpm boundaries`, `turbo run lint check-types test db:check check-contrast` (9/9 tasks, 50 tests).
- Every `uses:` confirmed SHA-pinned: `grep -rn "uses:" .github/workflows/ | grep -v "@[0-9a-f]\{40\}"` returns nothing.

## Not in this PR

- **`minimumReleaseAge`** (install-time supply-chain cooldown) needs pnpm ≥ 10.16 — verified by grepping both tarballs; `pnpm@9.0.0` has no such setting. The repo is on `pnpm@9.0.0`, which is the unrevisited `create-turbo` scaffold default. It moves with the pnpm bump in PR 2.
- The 8 open advisories, and every version bump. PR 2.